### PR TITLE
cephcluster: add storageaccounttype for azuredisk provisioner

### DIFF
--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -365,7 +365,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 				},
 				Provisioner: string(AzureDisk),
 				Parameters: map[string]string{
-					"type": "managed-premium",
+					"storageaccounttype": "Premium_LRS",
 				},
 			},
 			deviceSets: []api.StorageDeviceSet{


### PR DESCRIPTION
add storageaccounttype for azuredisk provisioner and remove type for azuredisk as azure StorageClass does not have type parameter. fix the test according the changes.

Signed-off-by: crombus <pkundra@redhat.com>