### PR TITLE
Add ability to force reconcile, regardless of platform

### DIFF
--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -21,12 +21,14 @@ func (obj *ocsCephObjectStores) ensureCreated(r *StorageClusterReconciler, insta
 	reconcileStrategy := ReconcileStrategy(instance.Spec.ManagedResources.CephObjectStores.ReconcileStrategy)
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return nil
-	}
-
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
-	if err != nil {
-		return err
-	}
+	} else if reconcileStrategy == ReconcileStrategyForce {
+                avoid = False
+        } else {
+	        avoid, err := r.PlatformsShouldAvoidObjectStore()
+	        if err != nil {
+                        return err
+	        }
+        }
 
 	if avoid {
 		platform, err := r.platform.GetPlatform(r.Client)

--- a/controllers/storagecluster/cephobjectstoreusers.go
+++ b/controllers/storagecluster/cephobjectstoreusers.go
@@ -44,10 +44,13 @@ func (obj *ocsCephObjectStoreUsers) ensureCreated(r *StorageClusterReconciler, i
 	reconcileStrategy := ReconcileStrategy(instance.Spec.ManagedResources.CephObjectStoreUsers.ReconcileStrategy)
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return nil
-	}
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
-	if err != nil {
-		return err
+	} else if  reconcileStrategy == ReconcileStrategyForce {
+                avoid = False
+        } else {
+	        avoid, err := r.PlatformsShouldAvoidObjectStore()
+	        if err != nil {
+                        return err
+                }
 	}
 
 	if avoid {

--- a/controllers/storagecluster/cephobjectstoreusers.go
+++ b/controllers/storagecluster/cephobjectstoreusers.go
@@ -44,13 +44,11 @@ func (obj *ocsCephObjectStoreUsers) ensureCreated(r *StorageClusterReconciler, i
 	reconcileStrategy := ReconcileStrategy(instance.Spec.ManagedResources.CephObjectStoreUsers.ReconcileStrategy)
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return nil
-	} else if  reconcileStrategy == ReconcileStrategyForce {
-                avoid = False
-        } else {
-	        avoid, err := r.PlatformsShouldAvoidObjectStore()
-	        if err != nil {
-                        return err
-                }
+	}
+
+	avoid, err := r.PlatformsShouldAvoidObjectStore()
+	if err != nil {
+		return err
 	}
 
 	if avoid {
@@ -58,8 +56,12 @@ func (obj *ocsCephObjectStoreUsers) ensureCreated(r *StorageClusterReconciler, i
 		if err != nil {
 			return err
 		}
-		r.Log.Info(fmt.Sprintf("not creating a CephObjectStoreUsers because the platform is '%s'", platform))
-		return nil
+		if reconcileStrategy == ReconcileStrategyForce {
+			r.Log.Info("force creating a CephObjectStore")
+		} else {
+			r.Log.Info(fmt.Sprintf("not creating a CephObjectStoreUsers because the platform is '%s'", platform))
+			return nil
+		}
 	}
 
 	cephObjectStoreUsers, err := r.newCephObjectStoreUserInstances(instance)

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -61,6 +61,8 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	ReconcileStrategyIgnore ReconcileStrategy = "ignore"
 	// ReconcileStrategyManage means always reconcile
 	ReconcileStrategyManage ReconcileStrategy = "manage"
+	// ReconcileStrategyForce means always reconcile, regardless of platform
+	ReconcileStrategyForce ReconcileStrategy = "force"
 	// ReconcileStrategyStandalone also means never reconcile (NooBaa)
 	ReconcileStrategyStandalone ReconcileStrategy = "standalone"
 


### PR DESCRIPTION
Add the ability to force reconcile cephobjectstores and cephobjecstoreusers
regardless of platform. Useful for testing, workshops, demos. Resolves #960 