### PR TITLE
Update builder Dockerfile for OpenShift CI usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,14 @@ operator-sdk:
 
 ocs-operator-openshift-ci-build: build
 
-build: build-go
+build: deps-update generate build-go
 
-build-go: deps-update generate
+# Do not update/generate deps to ensures a consistent build with the current vendored deps.
+build-go:
 	@echo "Building the ocs-operator binary"
 	hack/go-build.sh
 
-build-container:
+build-container: deps-update generate
 	@echo "Building the ocs-operator binary (containerized)"
 	hack/build-container.sh
 

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,11 +1,24 @@
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+# FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+# ubi8/go-toolset only supports up to Go v1.15 (20 Aug 2021)
+FROM golang:1.16 as builder
 
-COPY . /ocs-operator
-WORKDIR /ocs-operator
+WORKDIR /go/src/github.com/openshift/ocs-operator
+COPY . .
+USER root
 RUN make build-go
+
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-COPY --from=builder /ocs-operator/build/_output/bin/ocs-operator /usr/local/bin/ocs-operator
-COPY --from=builder /ocs-operator/build/_output/bin/metrics-exporter /usr/local/bin/metrics-exporter
-COPY --from=builder /ocs-operator/build/_output/*rules*.yaml /ocs-prometheus-rules/
+ENV OPBIN=/usr/local/bin/ocs-operator
+ENV MEBIN=/usr/local/bin/metrics-exporter
+ENV PROMRULES=/ocs-prometheus-rules
+
+COPY --from=builder /go/src/github.com/openshift/ocs-operator/build/_output/bin/ocs-operator "${OPBIN}"
+COPY --from=builder /go/src/github.com/openshift/ocs-operator/build/_output/bin/metrics-exporter "${MEBIN}"
+COPY --from=builder /go/src/github.com/openshift/ocs-operator/metrics/deploy/*rules*.yaml "${PROMRULES}"
+
+RUN chmod +x "${OPBIN}"
+RUN chmod +x "${MEBIN}"
+
+ENTRYPOINT ["/usr/local/bin/ocs-operator"]

--- a/hack/build-container.sh
+++ b/hack/build-container.sh
@@ -5,5 +5,4 @@ set -e
 source hack/common.sh
 source hack/docker-common.sh
 
-cp $PROMETHEUS_RULES_PATH/*rules*.yaml $OUTDIR
 ${IMAGE_BUILD_CMD} build -f build/Dockerfile.build -t "${OPERATOR_FULL_IMAGE_NAME}" .


### PR DESCRIPTION
Update build/Dockerfile.build to still allow local building and also
allow for direct usage by OpenShift CI.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>