### PR TITLE
Automate prometheususer creation for ob metrics collector

### DIFF
--- a/controllers/storagecluster/cephobjectstoreusers.go
+++ b/controllers/storagecluster/cephobjectstoreusers.go
@@ -15,6 +15,8 @@ import (
 
 type ocsCephObjectStoreUsers struct{}
 
+const prometheusUserName = "prometheus-user"
+
 // newCephObjectStoreUserInstances returns the cephObjectStoreUser instances that should be created
 // on first run.
 func (r *StorageClusterReconciler) newCephObjectStoreUserInstances(initData *ocsv1.StorageCluster) ([]*cephv1.CephObjectStoreUser, error) {
@@ -27,6 +29,20 @@ func (r *StorageClusterReconciler) newCephObjectStoreUserInstances(initData *ocs
 			Spec: cephv1.ObjectStoreUserSpec{
 				DisplayName: initData.Name,
 				Store:       generateNameForCephObjectStore(initData),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prometheusUserName,
+				Namespace: initData.Namespace,
+			},
+			Spec: cephv1.ObjectStoreUserSpec{
+				DisplayName: prometheusUserName,
+				Store:       generateNameForCephObjectStore(initData),
+				// This user needs to read quota info from other users where actual quota is on set at the backend
+				Capabilities: &cephv1.ObjectUserCapSpec{
+					User: "read",
+				},
 			},
 		},
 	}

--- a/controllers/storagecluster/uninstall_reconciler_test.go
+++ b/controllers/storagecluster/uninstall_reconciler_test.go
@@ -570,18 +570,30 @@ func assertTestDeleteCephBlockPools(
 	}
 }
 
-func getFakeCephObjectStoreUser() *cephv1.CephObjectStoreUser {
+func getFakeCephObjectStoreUser() []cephv1.CephObjectStoreUser {
 
 	sc := createDefaultStorageCluster()
 
-	return &cephv1.CephObjectStoreUser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      generateNameForCephObjectStoreUser(sc),
-			Namespace: sc.Namespace,
+	return []cephv1.CephObjectStoreUser{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      generateNameForCephObjectStoreUser(sc),
+				Namespace: sc.Namespace,
+			},
+			Spec: cephv1.ObjectStoreUserSpec{
+				DisplayName: sc.Name,
+				Store:       generateNameForCephObjectStore(sc),
+			},
 		},
-		Spec: cephv1.ObjectStoreUserSpec{
-			DisplayName: sc.Name,
-			Store:       generateNameForCephObjectStore(sc),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prometheusUserName,
+				Namespace: sc.Namespace,
+			},
+			Spec: cephv1.ObjectStoreUserSpec{
+				DisplayName: sc.Name,
+				Store:       generateNameForCephObjectStore(sc),
+			},
 		},
 	}
 }
@@ -607,9 +619,8 @@ func TestDeleteCephObjectStoreUsers(t *testing.T) {
 
 		for _, obj := range testList {
 			fakeCephObjectStoreUser := getFakeCephObjectStoreUser()
-			runtimeObjs := []client.Object{fakeCephObjectStoreUser}
+			runtimeObjs := []client.Object{&fakeCephObjectStoreUser[0], &fakeCephObjectStoreUser[1]}
 			_, reconciler, sc, _ := initStorageClusterResourceCreateUpdateTestWithPlatform(t, cp, runtimeObjs, nil)
-
 			assertTestDeleteCephObjectStoreUsers(t, reconciler, sc, obj.CephObjectStoreUsersExist)
 		}
 	}


### PR DESCRIPTION
As a prerequisite for object bucket metrics collector, it is expected to have a user named `prometheus-user` in the object store with certain permissions . Otherwise, it won't able to fetch the stat info from backend. This PR automates that creation