### PR TITLE
Fixing a minor bug regarding RGW TLS support enabling

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -195,7 +195,8 @@ func (r *StorageClusterReconciler) newExternalCephObjectStoreInstances(
 	}
 	var tlsEnabled bool = false
 	_, err := r.retrieveSecret(cephRgwTLSSecretKey, initData)
-	if err != nil {
+	// if we could retrieve a TLS secret, then enable TLS
+	if err == nil {
 		tlsEnabled = true
 	}
 	gatewaySpec, err := newExternalGatewaySpec(rgwEndpoint, r.Log, tlsEnabled)


### PR DESCRIPTION
When the TLS secret is retrieved successfully, that is retrieving 'err' is nil,
then only enable the 'SecurePort' and 'SSLCertRef' in CephObjectStore Gateway.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>