### PR TITLE
Bug 2005970: [release-4.8] add check for PodAntiAffinity not nil

### DIFF
--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -61,14 +61,16 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookv1.Placement {
 	topologyKey := getFailureDomain(sc)
 	topologyKey, _ = topologyMap.GetKeyValues(topologyKey)
 	if component == "mon" || component == "mds" || (component == "rgw" && getCephObjectStoreGatewayInstances(sc) > 1) {
-		if placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
-			for i := range placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-				placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[i].PodAffinityTerm.TopologyKey = topologyKey
+		if placement.PodAntiAffinity != nil {
+			if placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+				for i := range placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+					placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[i].PodAffinityTerm.TopologyKey = topologyKey
+				}
 			}
-		}
-		if placement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-			for i := range placement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
-				placement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[i].TopologyKey = topologyKey
+			if placement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+				for i := range placement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+					placement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[i].TopologyKey = topologyKey
+				}
 			}
 		}
 	}

--- a/controllers/storagecluster/placement_test.go
+++ b/controllers/storagecluster/placement_test.go
@@ -58,6 +58,12 @@ var workerPlacements = map[rookv1.KeyType]rookv1.Placement{
 	"all": {
 		NodeAffinity: &workerNodeAffinity,
 	},
+	"mds": {
+		NodeAffinity: &workerNodeAffinity,
+	},
+	"mon": {
+		NodeAffinity: &workerNodeAffinity,
+	},
 }
 
 var emptyLabelSelector = metav1.LabelSelector{
@@ -65,9 +71,47 @@ var emptyLabelSelector = metav1.LabelSelector{
 }
 var emptyPlacements = map[rookv1.KeyType]rookv1.Placement{
 	"all": {},
+	"mds": {},
+	"mon": {},
 }
 
-var customPlacement = rookv1.Placement{
+var customMDSPlacement = rookv1.Placement{
+	PodAntiAffinity: &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"rook-ceph-mds"},
+						},
+					},
+				},
+				TopologyKey: "topology.rook.io/rack",
+			},
+		},
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+			{
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"rook-ceph-mds"},
+							},
+						},
+					},
+					TopologyKey: "topology.rook.io/rack",
+				},
+				Weight: 100,
+			},
+		},
+	},
+}
+
+var customMONPlacement = rookv1.Placement{
 	PodAntiAffinity: &corev1.PodAntiAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 			{
@@ -103,6 +147,16 @@ var customPlacement = rookv1.Placement{
 	},
 }
 
+func getOcsToleration() corev1.Toleration {
+	toleration := corev1.Toleration{
+		Key:      "node.ocs.openshift.io/storage",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	return toleration
+}
+
 func TestGetPlacement(t *testing.T) {
 	cases := []struct {
 		label              string
@@ -126,6 +180,11 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity:    defaults.DefaultNodeAffinity,
 					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
 				},
+				"mds": {
+					NodeAffinity:    defaults.DefaultNodeAffinity,
+					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
+					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
+				},
 			},
 		},
 		{
@@ -138,8 +197,10 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity: defaults.DefaultNodeAffinity,
 				},
 				"mon": {
-					NodeAffinity:    defaults.DefaultNodeAffinity,
-					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
+					NodeAffinity: defaults.DefaultNodeAffinity,
+				},
+				"mds": {
+					NodeAffinity: defaults.DefaultNodeAffinity,
 				},
 			},
 		},
@@ -157,6 +218,11 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity:    &workerNodeAffinity,
 					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
 				},
+				"mds": {
+					NodeAffinity:    &workerNodeAffinity,
+					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
+					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
+				},
 			},
 		},
 		{
@@ -169,8 +235,10 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity: &workerNodeAffinity,
 				},
 				"mon": {
-					NodeAffinity:    &workerNodeAffinity,
-					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
+					NodeAffinity: &workerNodeAffinity,
+				},
+				"mds": {
+					NodeAffinity: &workerNodeAffinity,
 				},
 			},
 		},
@@ -200,19 +268,27 @@ func TestGetPlacement(t *testing.T) {
 							NodeSelectorTerms: []corev1.NodeSelectorTerm{
 								{
 									MatchExpressions: []corev1.NodeSelectorRequirement{
-										// TODO: For this test, this is an expected result that
-										// will yield an undesirable CephCluster config. Since
-										// NodeAffinity will be defined in the CephCluster, the
-										// "all" NodeAffinity will not apply, meaning mons will
-										// only run on master nodes. We should figure out a way
-										// to prevent this, if possible.
+										workerSelectorRequirement,
 										masterSelectorRequirement,
 									},
 								},
 							},
 						},
 					},
-					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
+				},
+				"mds": {
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										workerSelectorRequirement,
+										masterSelectorRequirement,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -228,13 +304,18 @@ func TestGetPlacement(t *testing.T) {
 				"mon": {
 					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
 				},
+				"mds": {
+					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
+					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
+				},
 			},
 		},
 		{
 			label:          "Case 7: Custom placement is applied without failure",
-			storageCluster: mockStorageCluster,
+			storageCluster: mockStorageCluster.DeepCopy(),
 			placements: rookv1.PlacementSpec{
-				"mon": customPlacement,
+				"mds": customMDSPlacement,
+				"mon": customMONPlacement,
 			},
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
@@ -243,15 +324,20 @@ func TestGetPlacement(t *testing.T) {
 				},
 				"mon": {
 					NodeAffinity:    defaults.DefaultNodeAffinity,
-					PodAntiAffinity: customPlacement.PodAntiAffinity,
+					PodAntiAffinity: customMONPlacement.PodAntiAffinity,
+				},
+				"mds": {
+					NodeAffinity:    defaults.DefaultNodeAffinity,
+					PodAntiAffinity: customMDSPlacement.PodAntiAffinity,
 				},
 			},
 		},
 		{
 			label:          "Case 8: Custom placement is modified by labelSelector",
-			storageCluster: mockStorageCluster,
+			storageCluster: mockStorageCluster.DeepCopy(),
 			placements: rookv1.PlacementSpec{
-				"mon": customPlacement,
+				"mds": customMDSPlacement,
+				"mon": customMONPlacement,
 			},
 			labelSelector: &workerLabelSelector,
 			expectedPlacements: rookv1.PlacementSpec{
@@ -261,7 +347,11 @@ func TestGetPlacement(t *testing.T) {
 				},
 				"mon": {
 					NodeAffinity:    &workerNodeAffinity,
-					PodAntiAffinity: customPlacement.PodAntiAffinity,
+					PodAntiAffinity: customMONPlacement.PodAntiAffinity,
+				},
+				"mds": {
+					NodeAffinity:    &workerNodeAffinity,
+					PodAntiAffinity: customMDSPlacement.PodAntiAffinity,
 				},
 			},
 		},
@@ -274,6 +364,27 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity: defaults.DefaultNodeAffinity,
 					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
 				},
+				"mds": {
+					NodeAffinity: defaults.DefaultNodeAffinity,
+					Tolerations:  defaults.DaemonPlacements["mds"].Tolerations,
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "app",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"rook-ceph-mds"},
+										},
+									},
+								},
+								TopologyKey: zoneTopologyLabel,
+							},
+						},
+					},
+				},
+
 				"mon": {
 					NodeAffinity: defaults.DefaultNodeAffinity,
 					PodAntiAffinity: &corev1.PodAntiAffinity{
@@ -318,6 +429,60 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity:    defaults.DefaultNodeAffinity,
 					PodAntiAffinity: &corev1.PodAntiAffinity{},
 				},
+				"mds": {
+					NodeAffinity:    defaults.DefaultNodeAffinity,
+					Tolerations:     defaults.DaemonPlacements["all"].Tolerations,
+					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
+				},
+			},
+		},
+		{
+			label:          "Case 11: When PodAntiAffinity is empty and topologyMap is provided ",
+			storageCluster: mockStorageCluster.DeepCopy(),
+			placements: rookv1.PlacementSpec{
+				"all": {
+					Tolerations: []corev1.Toleration{
+						getOcsToleration(),
+					},
+				},
+				"mon": {
+					Tolerations: []corev1.Toleration{
+						getOcsToleration(),
+					},
+				},
+				"mds": {
+					Tolerations: []corev1.Toleration{
+						getOcsToleration(),
+					},
+				},
+			},
+			topologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
+					zoneTopologyLabel: []string{
+						"zone1",
+						"zone2",
+						"zone3",
+					},
+				},
+			},
+			labelSelector: nil,
+			expectedPlacements: rookv1.PlacementSpec{
+				"all": {
+					NodeAffinity: defaults.DefaultNodeAffinity,
+					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
+				},
+				"mon": {
+					NodeAffinity: defaults.DefaultNodeAffinity,
+					Tolerations: []corev1.Toleration{
+						getOcsToleration(),
+					},
+					PodAntiAffinity: nil,
+				},
+				"mds": {
+					NodeAffinity:    defaults.DefaultNodeAffinity,
+					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
+					PodAntiAffinity: nil,
+				},
 			},
 		},
 	}
@@ -336,6 +501,10 @@ func TestGetPlacement(t *testing.T) {
 
 		expectedPlacement = c.expectedPlacements["mon"]
 		actualPlacement = getPlacement(sc, "mon")
+		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
+
+		expectedPlacement = c.expectedPlacements["mds"]
+		actualPlacement = getPlacement(sc, "mds")
 		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
 	}
 }

--- a/functests/common.go
+++ b/functests/common.go
@@ -23,7 +23,7 @@ func debug(msg string, args ...interface{}) {
 //RunMustGather runs the OCS must-gather container image
 func RunMustGather() error {
 	gopath := os.Getenv("GOPATH")
-	cmd := exec.Command("/bin/bash", gopath+"/src/github.com/openshift/ocs-operator/hack/dump-debug-info.sh")
+	cmd := exec.Command("/bin/bash", gopath+"/src/github.com/red-hat-storage/ocs-operator/hack/dump-debug-info.sh")
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
add check for PodAntiAffinity not nil before checking
underlying resources otherwise it will cause nil pointer
err. Also updating unit test to test this nil pointer
condition.

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit 2c9b8417d729ce089dcb65ff83de741a5c8a0402)