### PR TITLE
Reduce the mon_data_avail_warn to 15%

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -33,6 +33,7 @@ mon_osd_backfillfull_ratio = .8
 mon_osd_nearfull_ratio = .75
 mon_max_pg_per_osd = 600
 mon_pg_warn_max_object_skew = 0
+mon_data_avail_warn = 15
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.5
 `


### PR DESCRIPTION
Reduce the mon_data_avail_warn to 15% to be on same threshold with OCP's garbage collector for images.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1964055

Signed-off-by: Ashish Singh <assingh@redhat.com>