### PR TITLE
BUG 1938647: use SecurityContextConstraints API from Ceph-CSI

### DIFF
--- a/controllers/ocsinitialization/sccs.go
+++ b/controllers/ocsinitialization/sccs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	cephcsi "github.com/ceph/ceph-csi/api/deploy/ocp"
 	secv1 "github.com/openshift/api/security/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -103,43 +104,12 @@ func newRookCephSCC(namespace string) *secv1.SecurityContextConstraints {
 }
 
 func newRookCephCSISCC(namespace string) *secv1.SecurityContextConstraints {
-	scc := blankSCC()
+	rookValues := cephcsi.SecurityContextConstraintsValues{
+		Namespace: namespace,
+		Deployer:  "rook",
+	}
 
-	scc.Name = "rook-ceph-csi"
-	scc.AllowPrivilegedContainer = true
-	scc.AllowHostNetwork = true
-	scc.AllowHostDirVolumePlugin = true
-	scc.AllowedCapabilities = []corev1.Capability{
-		secv1.AllowAllCapabilities,
-	}
-	scc.AllowHostPorts = true
-	scc.AllowHostPID = true
-	scc.AllowHostIPC = true
-	scc.ReadOnlyRootFilesystem = false
-	scc.RequiredDropCapabilities = []corev1.Capability{}
-	scc.DefaultAddCapabilities = []corev1.Capability{}
-	scc.RunAsUser = secv1.RunAsUserStrategyOptions{
-		Type: secv1.RunAsUserStrategyRunAsAny,
-	}
-	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
-		Type: secv1.SELinuxStrategyRunAsAny,
-	}
-	scc.FSGroup = secv1.FSGroupStrategyOptions{
-		Type: secv1.FSGroupStrategyRunAsAny,
-	}
-	scc.SupplementalGroups = secv1.SupplementalGroupsStrategyOptions{
-		Type: secv1.SupplementalGroupsStrategyRunAsAny,
-	}
-	scc.Volumes = []secv1.FSType{
-		secv1.FSTypeAll,
-	}
-	scc.Users = []string{
-		fmt.Sprintf("system:serviceaccount:%s:rook-csi-rbd-plugin-sa", namespace),
-		fmt.Sprintf("system:serviceaccount:%s:rook-csi-rbd-provisioner-sa", namespace),
-		fmt.Sprintf("system:serviceaccount:%s:rook-csi-rbd-attacher-sa", namespace),
-		fmt.Sprintf("system:serviceaccount:%s:rook-csi-cephfs-plugin-sa", namespace),
-		fmt.Sprintf("system:serviceaccount:%s:rook-csi-cephfs-provisioner-sa", namespace),
-	}
+	scc, _ := cephcsi.NewSecurityContextConstraints(rookValues)
 
 	return scc
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/RHsyseng/operator-utils v1.4.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
+	github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70
 	github.com/ceph/go-ceph v0.11.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
+github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70 h1:QOGXUOQKNB8+8+7lzqr0B2kGHCINE1gWNNtjPGNXmJU=
+github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70/go.mod h1:H15KD1Pe+9+a/zk5IEC+bMZ2A39hwAvqbkt1ncuuQBk=
 github.com/ceph/go-ceph v0.9.1-0.20210607162346-8179bd4437f9/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
 github.com/ceph/go-ceph v0.10.1-0.20210729101705-11f319727ffb/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
 github.com/ceph/go-ceph v0.11.0 h1:A1pphV40LL8GQKDPpU4XqCa7gkmozsst7rhCC730/nk=

--- a/vendor/github.com/ceph/ceph-csi/api/LICENSE
+++ b/vendor/github.com/ceph/ceph-csi/api/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/doc.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ocp contains functions to obtain standard and recommended
+// deployment artifacts for OpenShift. These artifacts can be used by
+// automation tools that want to deploy Ceph-CSI.
+package ocp

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocp
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+	secv1 "github.com/openshift/api/security/v1"
+)
+
+//go:embed scc.yaml
+var securityContextConstraints string
+
+// SecurityContextConstraintsValues contains values that need replacing in the
+// template.
+type SecurityContextConstraintsValues struct {
+	// Namespace contains the OpenShift Namespace where the SCC will be
+	// used.
+	Namespace string
+	// Deployer refers to the Operator that creates the SCC and
+	// ServiceAccounts. This is an optional option.
+	Deployer string
+}
+
+// SecurityContextConstraintsDefaults can be used for generating deployment
+// artifacts with defails values.
+var SecurityContextConstraintsDefaults = SecurityContextConstraintsValues{
+	Namespace: "ceph-csi",
+	Deployer:  "",
+}
+
+// NewSecurityContextConstraints creates a new SecurityContextConstraints
+// object by replacing variables in the template by the values set in the
+// SecurityContextConstraintsValues.
+//
+// The deployer parameter (when not an empty string) is used as a prefix for
+// the name of the SCC and the linked ServiceAccounts.
+func NewSecurityContextConstraints(values SecurityContextConstraintsValues) (*secv1.SecurityContextConstraints, error) {
+	data, err := NewSecurityContextConstraintsYAML(values)
+	if err != nil {
+		return nil, err
+	}
+
+	scc := &secv1.SecurityContextConstraints{}
+	err = yaml.Unmarshal([]byte(data), scc)
+	if err != nil {
+		return nil, fmt.Errorf("failed convert YAML to %T: %w", scc, err)
+	}
+
+	return scc, nil
+}
+
+// internalSecurityContextConstraintsValues extends
+// SecurityContextConstraintsValues with some private attributes that may get
+// set based on other values.
+type internalSecurityContextConstraintsValues struct {
+	SecurityContextConstraintsValues
+
+	// Prefix is based on SecurityContextConstraintsValues.Deployer.
+	Prefix string
+}
+
+// NewSecurityContextConstraintsYAML returns a YAML string where the variables
+// in the template have been replaced by the values set in the
+// SecurityContextConstraintsValues.
+func NewSecurityContextConstraintsYAML(values SecurityContextConstraintsValues) (string, error) {
+	var buf bytes.Buffer
+
+	// internalValues is a copy of values, but will get extended with
+	// API-internal values
+	internalValues := internalSecurityContextConstraintsValues{
+		SecurityContextConstraintsValues: values,
+	}
+
+	if internalValues.Deployer != "" {
+		internalValues.Prefix = internalValues.Deployer + "-"
+	}
+
+	tmpl, err := template.New("SCC").Parse(securityContextConstraints)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+	err = tmpl.Execute(&buf, internalValues)
+	if err != nil {
+		return "", fmt.Errorf("failed to replace values in template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
@@ -1,0 +1,43 @@
+---
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: "{{ .Prefix }}ceph-csi"
+# To allow running privilegedContainers
+allowPrivilegedContainer: true
+# CSI daemonset pod needs hostnetworking
+allowHostNetwork: true
+# This need to be set to true as we use HostPath
+allowHostDirVolumePlugin: true
+priority:
+# SYS_ADMIN is needed for rbd to execture rbd map command
+allowedCapabilities: ["SYS_ADMIN"]
+# Needed as we run liveness container on daemonset pods
+allowHostPorts: true
+# Needed as we are setting this in RBD plugin pod
+allowHostPID: true
+# Required for encryption
+allowHostIPC: true
+# Set to false as we write to RootFilesystem inside csi containers
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+# The type of volumes which are mounted to csi pods
+volumes:
+  - configMap
+  - projected
+  - emptyDir
+  - hostPath
+users:
+  # A user needs to be added for each service account.
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-rbd-plugin-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-rbd-provisioner-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-plugin-sa"
+  # yamllint disable-line rule:line-length
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-provisioner-sa"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,6 +36,9 @@ github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
 ## explicit
 github.com/blang/semver/v4
+# github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70
+## explicit
+github.com/ceph/ceph-csi/api/deploy/ocp
 # github.com/ceph/go-ceph v0.11.0
 ## explicit
 github.com/ceph/go-ceph/rgw/admin


### PR DESCRIPTION
Remove the duplication of the SCC for the CephCSI component, use the
new Ceph-CSI API to get the SCC instead.

Signed-off-by: Niels de Vos <ndevos@redhat.com>