### PR TITLE
build: support AWS/Graviton (aarch64)

### DIFF
--- a/hack/ensure-operator-sdk.sh
+++ b/hack/ensure-operator-sdk.sh
@@ -6,10 +6,13 @@ source hack/common.sh
 source hack/operator-sdk-common.sh
 
 if [ ! -x "${OPERATOR_SDK}" ]; then
-	echo "Downloading operator-sdk ${OPERATOR_SDK_VERSION}-${OPERATOR_SDK_PLATFORM}"
-	mkdir -p ${OUTDIR_TOOLS}
-	curl -JL "${OPERATOR_SDK_URL}/${OPERATOR_SDK_VERSION}/${OPERATOR_SDK_BIN}" -o "${OPERATOR_SDK}"
+	echo "Downloading operator-sdk: ${OPERATOR_SDK_DL_URL_FULL} --> ${OPERATOR_SDK}"
+	mkdir -p "${OUTDIR_TOOLS}"
+	curl -JL "${OPERATOR_SDK_DL_URL_FULL}" -o "${OPERATOR_SDK}"
 	chmod +x "${OPERATOR_SDK}"
 else
 	echo "Using operator-sdk cached at ${OPERATOR_SDK}"
 fi
+
+# Ensure operator-sdk can run properly on local machine
+"${OPERATOR_SDK}" version > /dev/null 2>&1 || echo "Bad operator-sdk binary: ${OPERATOR_SDK}"

--- a/hack/ensure-opm.sh
+++ b/hack/ensure-opm.sh
@@ -5,18 +5,42 @@ set -e
 source hack/common.sh
 
 OPM_VERSION="v1.12.3"
-OPM_PLATFORM="linux-amd64-opm"
-if [ "$OS_TYPE" == "Darwin" ]; then
-	OPM_PLATFORM=darwin-amd64-opm
-fi
+case "$(uname -m)" in
+	x86_64)
+		OPM_ARCH="amd64"
+		;;
+	aarch64)
+		OPM_ARCH="arm64"
+		;;
+	*)
+		OPM_ARCH="$(uname -m)"
+		;;
+esac
+OPM_OS=$(echo -n "${OS_TYPE}" | awk '{print tolower($0)}')
+OPM_PLATFORM="${OPM_OS}-${OPM_ARCH}-opm"
 OPM_URL="https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/${OPM_PLATFORM}"
 OPM_BIN="opm-${OPM_VERSION}"
 OPM="${OUTDIR_TOOLS}/${OPM_BIN}"
-if [ ! -x "${OPM}" ]; then
-	echo "Downloading opm ${OPM_VERSION} for ${OS_TYPE}"
-	mkdir -p ${OUTDIR_TOOLS}
-	curl -JL ${OPM_URL} -o ${OPM}
-	chmod +x ${OPM}
-else
+OPERATOR_REGISTRY_TMPDIR="${OUTDIR_TOOLS}/operator-registry"
+
+if [ -x "${OPM}" ]; then
+	# Case 1: already has opm binray
 	echo "Using opm cached at ${OPM}"
+elif [ "${OPM_ARCH}" != "amd64" ]; then
+	# Case 2: image does not exist, need to build from source
+	echo "Building opm from source under ${OPERATOR_REGISTRY_TMPDIR} for ${OPM_OS}-${OPM_ARCH}"
+	mkdir -p "${OPERATOR_REGISTRY_TMPDIR}"
+	pushd "${OPERATOR_REGISTRY_TMPDIR}"
+	git clone https://github.com/operator-framework/operator-registry .
+	git checkout "${OPM_VERSION}"
+	make
+	popd
+	cp "${OPERATOR_REGISTRY_TMPDIR}/bin/opm" "${OPM}"
+	rm -rf "${OPERATOR_REGISTRY_TMPDIR}"
+else
+	# Case 3: use public image
+	echo "Downloading opm ${OPM_VERSION} for ${OS_TYPE}"
+	mkdir -p "${OUTDIR_TOOLS}"
+	curl -JL "${OPM_URL}" -o "${OPM}"
+	chmod +x "${OPM}"
 fi

--- a/hack/operator-sdk-common.sh
+++ b/hack/operator-sdk-common.sh
@@ -3,11 +3,19 @@
 # shellcheck disable=SC2034
 # don't fail on unused variables - this is for sourcing
 
+
+# Align with installation instructions from:
+# https://sdk.operatorframework.io/docs/installation/
+OPERATOR_SDK_ARCH=$(uname -m)
+OPERATOR_SDK_OS=$(uname | awk '{print tolower($0)}')
+# This hack was changed in newer operator-sdk versions
+if [ "$OPERATOR_SDK_OS" == "linux" ]; then
+       OPERATOR_SDK_OS="linux-gnu"
+elif [ "$OPERATOR_SDK_OS" == "darwin" ]; then
+       OPERATOR_SDK_OS="apple-darwin"
+fi
+
 OPERATOR_SDK_URL="${OPERATOR_SDK_URL:-https://github.com/operator-framework/operator-sdk/releases/download}"
 OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-v1.2.0}"
-OPERATOR_SDK_PLATFORM="x86_64-linux-gnu"
-if [ "$OS_TYPE" == "Darwin" ]; then
-	OPERATOR_SDK_PLATFORM="x86_64-apple-darwin"
-fi
-OPERATOR_SDK_BIN="operator-sdk-${OPERATOR_SDK_VERSION}-${OPERATOR_SDK_PLATFORM}"
+OPERATOR_SDK_DL_URL_FULL="${OPERATOR_SDK_URL}/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-${OPERATOR_SDK_ARCH}-${OPERATOR_SDK_OS}"
 OPERATOR_SDK="${OUTDIR_TOOLS}/operator-sdk-${OPERATOR_SDK_VERSION}"


### PR DESCRIPTION
Build OCS on AWS/Graviton processor (ARM, aarch64). Need to update usage
of external tools:

1) Download proper operator-sdk for local arch, make sure that the
   downloaded image is indeed exacutable on local host.
2) For aarch64 need to build opm on local machine as no image is
   provided.

Align definition of OS & ARCH with installation instruction at:
  https://sdk.operatorframework.io/docs/installation/

Signed-off-by: Shachar Sharon <ssharon@redhat.com>