### PR TITLE
storagecluster: create StorageQuota before CephCluster

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -339,6 +339,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			// preserve list order
 			objs = []resourceManager{
 				&ocsTopologyMap{},
+				&ocsStorageQuota{},
 				&ocsCephConfig{},
 				&ocsCephCluster{},
 				&ocsCephBlockPools{},
@@ -348,7 +349,6 @@ func (r *StorageClusterReconciler) reconcilePhases(
 				&ocsCephRGWRoutes{},
 				&ocsStorageClass{},
 				&ocsNoobaaSystem{},
-				&ocsStorageQuota{},
 				&ocsSnapshotClass{},
 				&ocsJobTemplates{},
 				&ocsCephRbdMirrors{},
@@ -365,6 +365,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 		// preserve list order
 		objs = []resourceManager{
 			&ocsExternalResources{},
+			&ocsStorageQuota{},
 			&ocsCephCluster{},
 			&ocsSnapshotClass{},
 			&ocsNoobaaSystem{},


### PR DESCRIPTION
Must call ocsStorageQuota.ensureCreated before doing so for
ocsCephCluster or we may get into wrong state where user may consume
PVCs without the protection of ClusterResourceQuota. In addition, from
the user perspective it looks as if no ClusterResourceQuota is created
for long time.

Refs BZ2006030

Signed-off-by: Shachar Sharon <ssharon@redhat.com>