### PR TITLE
add managedBy label only for mcg-standalone

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -111,7 +111,10 @@ func getNooBaaMonitoringLabels(sc ocsv1.StorageCluster) map[string]string {
 	if sc.Spec.Monitoring != nil && sc.Spec.Monitoring.Labels != nil {
 		labels = sc.Spec.Monitoring.Labels
 	}
-	labels["noobaa.io/managedBy"] = sc.Name
+	if sc.Spec.MultiCloudGateway != nil &&
+		ReconcileStrategy(sc.Spec.MultiCloudGateway.ReconcileStrategy) == ReconcileStrategyStandalone {
+		labels["noobaa.io/managedBy"] = sc.Name
+	}
 	return labels
 }
 


### PR DESCRIPTION
Adding `managedBy` label only when mcg is standalone. This is to prevent collision when mcg is deployed along with Ceph.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>