### PR TITLE
Enable taint-nodes from the operator CSV

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1093,7 +1093,7 @@ metadata:
       "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints",
       "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}'
     features.ocs.openshift.io/enabled: '["kms", "arbiter", "flexible-scaling", "multus",
-      "pool-management", "namespace-store", "mcg-standalone"]'
+      "pool-management", "namespace-store", "mcg-standalone", "taint-nodes"]'
     olm.skipRange: '>=0.0.1 <4.9.0'
     operatorframework.io/initialization-resource: "\n    {\n        \"apiVersion\":
       \"ocs.openshift.io/v1\",\n        \"kind\": \"StorageCluster\",\n        \"metadata\":

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -626,7 +626,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
 	// Feature gating for Console. The array values are unique identifiers provided by the console.
 	// This can be used to enable/disable console support for any supported feature
 	// Example: "features.ocs.openshift.io/enabled": `["external", "foo1", "foo2", ...]`
-	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "pool-management", "namespace-store", "mcg-standalone"]`
+	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "pool-management", "namespace-store", "mcg-standalone", "taint-nodes"]`
 	// Used by UI to validate user uploaded metdata
 	// Metadata is used to connect to an external cluster
 	ocsCSV.Annotations["external.features.ocs.openshift.io/validation"] = `{"secrets":["rook-ceph-operator-creds", "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints", "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}`


### PR DESCRIPTION
Added UI for dedicated nodes with taints in 4.10 (https://github.com/openshift/console/pull/10323)
This PR is to enable that UI.

Signed-off-by: sanjalkatiyar <sanjaldhir@gmail.com>