### PR TITLE
helper pod runs with non-root privileges

### DIFF
--- a/must-gather/templates/pod.template
+++ b/must-gather/templates/pod.template
@@ -32,6 +32,7 @@ spec:
     name: must-gather-helper
     securityContext:
       privileged: true
+      runAsUser: 1000
     volumeMounts:
       - mountPath: /dev
         name: dev


### PR DESCRIPTION
This commit changes the root privileges of helper
pod from root to user.

BZ: #1991462

Signed-off-by: yati1998 <ypadia@redhat.com>