### PR TITLE
storagecluster: allow any storageclass for storagequota

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -637,10 +637,6 @@ func validateOverprovisionControlSpec(sc *ocsv1.StorageCluster, reqLogger logr.L
 		if opc.StorageClassName == "" {
 			return fmt.Errorf("missing storageclassname")
 		}
-		if opc.StorageClassName != sc.Name+"-"+cephFsStorageClassName &&
-			opc.StorageClassName != sc.Name+"-"+cephRbdStorageClassName {
-			return fmt.Errorf("unsupported storageclassname: %s", opc.StorageClassName)
-		}
 		if opc.QuotaName == "" {
 			return fmt.Errorf("missing quotaname")
 		}


### PR DESCRIPTION
Allow user-defined custom storgaeclass names in Overprovision
definition, so users can define quota for future storageclasses, which
are not available during deployment time.

Refs BZ-2024545

Signed-off-by: Shachar Sharon <ssharon@redhat.com>