### PR TITLE
misc fixes for rook-ceph toolbox

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -58,7 +58,7 @@ func newToolsDeployment(namespace string, rookImage string) *appsv1.Deployment {
 	name := rookCephToolDeploymentName
 	var replicaOne int32 = 1
 
-	privilegedContainer := true
+	privilegedContainer := false
 	runAsNonRoot := true
 	var runAsUser, runAsGroup int64 = 2016, 2016
 	return &appsv1.Deployment{

--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -60,7 +60,7 @@ func newToolsDeployment(namespace string, rookImage string) *appsv1.Deployment {
 
 	privilegedContainer := true
 	runAsNonRoot := true
-	var runAsUser int64 = 1000
+	var runAsUser, runAsGroup int64 = 2016, 2016
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -115,6 +115,7 @@ func newToolsDeployment(namespace string, rookImage string) *appsv1.Deployment {
 								Privileged:   &privilegedContainer,
 								RunAsNonRoot: &runAsNonRoot,
 								RunAsUser:    &runAsUser,
+								RunAsGroup:   &runAsGroup,
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "ceph-config", MountPath: "/etc/ceph"},

--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -85,8 +85,12 @@ func newToolsDeployment(namespace string, rookImage string) *appsv1.Deployment {
 						{
 							Name:    name,
 							Image:   rookImage,
-							Command: []string{"/tini"},
-							Args:    []string{"-g", "--", "/usr/local/bin/toolbox.sh"},
+							Command: []string{"/bin/bash"},
+							Args: []string{
+								"-m",
+								"-c",
+								"/usr/local/bin/toolbox.sh",
+							},
 							Env: []corev1.EnvVar{
 								{
 									Name: "ROOK_CEPH_USERNAME",


### PR DESCRIPTION
Stop using tini on the toolbox job
Rook-Ceph has stopped using tini in the current devel code which will be
release with Rook 1.8 which will be the basis of the 4.10 branch.
So removing the tini entrypoint command to replace it with a simple bash
shell.

Run the toolbox with the rook user
Rook-Ceph now uses its own user to operate. The Operator runs as "rook"
and not "root" anymore so this should be reflected in the toolbox as
well.

Stop running the toolbox as privileged
The toolbox does not need to run privileged so let's remove this
capability.

Signed-off-by: Sébastien Han <seb@redhat.com>