### PR TITLE
add a tty to the toolbox

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -201,6 +201,7 @@ func newExtendClusterJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephC
 									ReadOnly:  true,
 								},
 							},
+							TTY:     true,
 							Command: cephCommands,
 						},
 					},


### PR DESCRIPTION
Bash's job control needs a TTY to control a terminal, without it the
container fails to run. So adding a TTY to it.

Signed-off-by: Sébastien Han <seb@redhat.com>