### PR TITLE
Add encrypted RBD storage class during deployment

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -284,8 +284,14 @@ type MonitoringSpec struct {
 // EncryptionSpec defines if encryption should be enabled for the Storage Cluster
 // It is optional and defaults to false.
 type EncryptionSpec struct {
+	// deprecated from OCS 4.10 onwards, acting as a dummy,
+	// UI will keep sending this flag for backward compatibility (OCP 4.10 + OCS 4.9)
 	// +optional
-	Enable               bool                     `json:"enable,omitempty"`
+	Enable bool `json:"enable,omitempty"`
+	// +optional
+	ClusterWide bool `json:"clusterWide,omitempty"`
+	// +optional
+	StorageClass         bool                     `json:"storageClass,omitempty"`
 	KeyManagementService KeyManagementServiceSpec `json:"kms,omitempty"`
 }
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -285,7 +285,12 @@ spec:
                 description: EncryptionSpec defines if encryption should be enabled
                   for the Storage Cluster It is optional and defaults to false.
                 properties:
+                  clusterWide:
+                    type: boolean
                   enable:
+                    description: deprecated from OCS 4.10 onwards, acting as a dummy,
+                      UI will keep sending this flag for backward compatibility (OCP
+                      4.10 + OCS 4.9)
                     type: boolean
                   kms:
                     description: KeyManagementServiceSpec provides a way to enable
@@ -294,6 +299,8 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  storageClass:
+                    type: boolean
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -455,6 +455,7 @@ func createDummyKMSConfigMap(kmsProvider, kmsAddr string) *corev1.ConfigMap {
 	cm.Name = KMSConfigMapName
 	cm.Data = make(map[string]string)
 	cm.Data["KMS_PROVIDER"] = kmsProvider
+	cm.Data["KMS_SERVICE_NAME"] = "my-connection"
 	cm.Data[kmsProviderAddressKeyMap[kmsProvider]] = kmsAddr
 	cm.Data["VAULT_BACKEND_PATH"] = "ocs"
 	cm.Data["VAULT_NAMESPACE"] = "my-ocs-namespace"

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -266,7 +266,7 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 	}
 
 	sc2 := &api.StorageCluster{}
-	sc2.Spec.Encryption.Enable = false
+	sc2.Spec.Encryption.ClusterWide = false
 	sc2.Spec.StorageDeviceSets = mockDeviceSets
 	sc2.Status.NodeTopologies = &api.NodeTopologyMap{
 		Labels: map[string]api.TopologyLabelValues{
@@ -279,7 +279,7 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 	}
 
 	sc3 := &api.StorageCluster{}
-	sc3.Spec.Encryption.Enable = true
+	sc3.Spec.Encryption.ClusterWide = true
 	sc3.Spec.StorageDeviceSets = mockDeviceSets
 	sc3.Status.NodeTopologies = &api.NodeTopologyMap{
 		Labels: map[string]api.TopologyLabelValues{
@@ -349,7 +349,7 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 			assert.DeepEqual(t, defaults.DaemonResources["osd"], scds.Resources)
 			assert.DeepEqual(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
 			assert.Equal(t, true, scds.Portable)
-			assert.Equal(t, c.sc.Spec.Encryption.Enable, scds.Encrypted)
+			assert.Equal(t, c.sc.Spec.Encryption.ClusterWide, scds.Encrypted)
 
 			if c.topologyKey == "rack" {
 				assert.DeepEqual(t, getPlacement(c.sc, "osd"), scds.Placement)
@@ -415,7 +415,7 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 			assert.DeepEqual(t, defaults.DaemonResources["osd"], scds.Resources)
 			assert.DeepEqual(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
 			assert.Equal(t, true, scds.Portable)
-			assert.Equal(t, c.sc.Spec.Encryption.Enable, scds.Encrypted)
+			assert.Equal(t, c.sc.Spec.Encryption.ClusterWide, scds.Encrypted)
 			if scds.Portable && c.topologyKey == "rack" {
 				assert.Equal(t, scds.Placement.TopologySpreadConstraints[0].WhenUnsatisfiable, corev1.UnsatisfiableConstraintAction("DoNotSchedule"))
 				assert.Equal(t, len(scds.Placement.TopologySpreadConstraints), 2)
@@ -497,6 +497,7 @@ func assertCephClusterKMSConfiguration(t *testing.T, kmsArgs struct {
 	}
 	// create a cephcluster CR and enable the KMS
 	cr := createDefaultStorageCluster()
+	cr.Spec.Encryption.ClusterWide = true
 	cr.Spec.Encryption.KeyManagementService.Enable = true
 
 	// don't start dummy servers for invalid tests
@@ -608,7 +609,7 @@ func TestStorageClassDeviceSetCreationForArbiter(t *testing.T) {
 			assert.DeepEqual(t, defaults.DaemonResources["osd"], scds.Resources)
 			assert.DeepEqual(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
 			assert.Equal(t, true, scds.Portable)
-			assert.Equal(t, c.sc.Spec.Encryption.Enable, scds.Encrypted)
+			assert.Equal(t, c.sc.Spec.Encryption.ClusterWide, scds.Encrypted)
 			assert.DeepEqual(t, getPlacement(c.sc, "osd-tsc"), scds.Placement)
 			topologyKey := scds.PreparePlacement.TopologySpreadConstraints[0].TopologyKey
 			assert.Equal(t, c.topologyKey, topologyKey)

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -43,6 +43,10 @@ func generateNameForCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-ceph-rbd", initData.Name)
 }
 
+func generateNameForEncryptedCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
+	return fmt.Sprintf("%s-ceph-rbd-encrypted", initData.Name)
+}
+
 // generateNameForSnapshotClass function generates 'SnapshotClass' name.
 // 'snapshotType' can be: 'rbdSnapshotter' or 'cephfsSnapshotter'
 func generateNameForSnapshotClass(initData *ocsv1.StorageCluster, snapshotType SnapshotterType) string {

--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -180,9 +180,10 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	}
 
 	// Add KMS details to Noobaa spec, only if
-	// cluster-wide encryption is enabled (ie; sc.Spec.Encryption.Enable is True)
+	// cluster-wide encryption is enabled
+	// ie, sc.Spec.Encryption.ClusterWide/sc.Spec.Encryption.Enable is True
 	// and KMS ConfigMap is available
-	if sc.Spec.Encryption.Enable {
+	if sc.Spec.Encryption.Enable || sc.Spec.Encryption.ClusterWide {
 		if kmsConfig, err := getKMSConfigMap(KMSConfigMapName, sc, r.Client); err != nil {
 			return err
 		} else if kmsConfig != nil {

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -283,7 +283,12 @@ spec:
                 description: EncryptionSpec defines if encryption should be enabled
                   for the Storage Cluster It is optional and defaults to false.
                 properties:
+                  clusterWide:
+                    type: boolean
                   enable:
+                    description: deprecated from OCS 4.10 onwards, acting as a dummy,
+                      UI will keep sending this flag for backward compatibility (OCP
+                      4.10 + OCS 4.9)
                     type: boolean
                   kms:
                     description: KeyManagementServiceSpec provides a way to enable
@@ -292,6 +297,8 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  storageClass:
+                    type: boolean
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -285,7 +285,12 @@ spec:
                 description: EncryptionSpec defines if encryption should be enabled
                   for the Storage Cluster It is optional and defaults to false.
                 properties:
+                  clusterWide:
+                    type: boolean
                   enable:
+                    description: deprecated from OCS 4.10 onwards, acting as a dummy,
+                      UI will keep sending this flag for backward compatibility (OCP
+                      4.10 + OCS 4.9)
                     type: boolean
                   kms:
                     description: KeyManagementServiceSpec provides a way to enable
@@ -294,6 +299,8 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  storageClass:
+                    type: boolean
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When


### PR DESCRIPTION
Add a new encrypted RBD storage class during cluster deployment, if the customer asked for PV encryption.

URL: https://issues.redhat.com/browse/RHSTOR-2269