### PR TITLE
pass kms vault options for ceph object store spec

### DIFF
--- a/controllers/storagecluster/cephobjectstores_test.go
+++ b/controllers/storagecluster/cephobjectstores_test.go
@@ -36,7 +36,7 @@ func TestCephObjectStores(t *testing.T) {
 	}
 }
 func assertCephObjectStores(t *testing.T, reconciler StorageClusterReconciler, cr *api.StorageCluster, request reconcile.Request) {
-	expectedCos, err := reconciler.newCephObjectStoreInstances(cr)
+	expectedCos, err := reconciler.newCephObjectStoreInstances(cr, nil)
 	assert.NoError(t, err)
 
 	actualCos := &cephv1.CephObjectStore{
@@ -66,6 +66,6 @@ func assertCephObjectStores(t *testing.T, reconciler StorageClusterReconciler, c
 	assert.Equal(t, len(expectedCos[0].OwnerReferences), 1)
 
 	cr.Spec.ManagedResources.CephObjectStores.GatewayInstances = 2
-	expectedCos, _ = reconciler.newCephObjectStoreInstances(cr)
+	expectedCos, _ = reconciler.newCephObjectStoreInstances(cr, nil)
 	assert.Equal(t, expectedCos[0].Spec.Gateway.Instances, int32(2))
 }

--- a/controllers/storagecluster/uninstall_reconciler_test.go
+++ b/controllers/storagecluster/uninstall_reconciler_test.go
@@ -724,7 +724,7 @@ func assertTestDeleteCephObjectStores(
 		assert.NoError(t, err)
 	}
 
-	cephStores, err := reconciler.newCephObjectStoreInstances(sc)
+	cephStores, err := reconciler.newCephObjectStoreInstances(sc, nil)
 	assert.NoError(t, err)
 
 	for _, cephStore := range cephStores {


### PR DESCRIPTION
Currently kms config options are passed to ceph cluster spec, but for
RGW this need to pass seperately and need to set secret engine as
`transit` than `kv`.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>