### PR TITLE
Adding vault service account and ibm key protect based KMS encryption support

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -406,15 +406,26 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 
 	// if kmsConfig is not 'nil', add the KMS details to CephCluster spec
 	if kmsConfigMap != nil {
-		// Set default KMS_PROVIDER and VAULT_SECRET_ENGINE values, refer https://issues.redhat.com/browse/RHSTOR-1963
+		// Set default KMS_PROVIDER. Possible values are: vault, ibmkeyprotect.
 		if _, ok := kmsConfigMap.Data["KMS_PROVIDER"]; !ok {
-			kmsConfigMap.Data["KMS_PROVIDER"] = "vault"
+			kmsConfigMap.Data["KMS_PROVIDER"] = VaultKMSProvider
 		}
-		if _, ok := kmsConfigMap.Data["VAULT_SECRET_ENGINE"]; !ok {
-			kmsConfigMap.Data["VAULT_SECRET_ENGINE"] = "kv"
+		// vault as a KMS service provider
+		if kmsConfigMap.Data["KMS_PROVIDER"] == VaultKMSProvider {
+			// Set default VAULT_SECRET_ENGINE values
+			if _, ok := kmsConfigMap.Data["VAULT_SECRET_ENGINE"]; !ok {
+				kmsConfigMap.Data["VAULT_SECRET_ENGINE"] = "kv"
+			}
+			// Set default VAULT_AUTH_METHOD. Possible values are: token, kubernetes.
+			if _, ok := kmsConfigMap.Data["VAULT_AUTH_METHOD"]; !ok {
+				kmsConfigMap.Data["VAULT_AUTH_METHOD"] = VaultTokenAuthMethod
+			}
+			// Set TokenSecretName only for vault token based auth method
+			if kmsConfigMap.Data["VAULT_AUTH_METHOD"] == VaultTokenAuthMethod {
+				cephCluster.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName
+			}
 		}
 		cephCluster.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfigMap.Data
-		cephCluster.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName
 	}
 	return cephCluster
 }

--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -25,6 +25,12 @@ const (
 	KMSProviderKey = "KMS_PROVIDER"
 	// VaultKMSProvider a constant to represent 'vault' KMS provider
 	VaultKMSProvider = "vault"
+	// VaultTokenAuthMethod is the key to represent vault token based authentication
+	VaultTokenAuthMethod = "token"
+	// VaultSAAuthMethod is the key to represent vault k8s service account based authentication
+	VaultSAAuthMethod = "kubernetes"
+	// IbmKeyProtectKMSProvider a constant to represent IBM hpcs KMS provider
+	IbmKeyProtectKMSProvider = "ibmkeyprotect"
 )
 
 var (

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -282,7 +282,7 @@ func (r *StorageClusterReconciler) newStorageClassConfigurations(initData *ocsv1
 		ret = append(ret, newCephOBCStorageClassConfiguration(initData))
 	}
 	// encrypted Ceph Block Pool storageclass will be returned only if
-	// storage-class wide encryption + kms is enabled and KMS ConfigMap is available
+	// storage-class encryption + kms is enabled and KMS ConfigMap is available
 	if initData.Spec.Encryption.StorageClass && initData.Spec.Encryption.KeyManagementService.Enable {
 		kmsConfig, err := getKMSConfigMap(KMSConfigMapName, initData, r.Client)
 		if err == nil && kmsConfig != nil {

--- a/controllers/storagecluster/storageclasses_test.go
+++ b/controllers/storagecluster/storageclasses_test.go
@@ -40,7 +40,7 @@ func testStorageClasses(t *testing.T, pvEncryption bool, customSpec *api.Storage
 		cp := &Platform{platform: eachPlatform}
 		runtimeObjs := []client.Object{}
 		if pvEncryption {
-			runtimeObjs = append(runtimeObjs, createDummyKMSConfigMap(dummyKmsProvider, dummyKmsAddress))
+			runtimeObjs = append(runtimeObjs, createDummyKMSConfigMap(dummyKmsProvider, dummyKmsAddress, ""))
 		}
 		t, reconciler, cr, request := initStorageClusterResourceCreateUpdateTestWithPlatform(
 			t, cp, runtimeObjs, customSpec)

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1095,7 +1095,8 @@ metadata:
       "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}'
     features.ocs.openshift.io/disabled: '["ss-list"]'
     features.ocs.openshift.io/enabled: '["kms", "arbiter", "flexible-scaling", "multus",
-      "pool-management", "namespace-store", "mcg-standalone", "taint-nodes"]'
+      "pool-management", "namespace-store", "mcg-standalone", "taint-nodes", "vault-sa-kms",
+      "hpcs-kms"]'
     olm.skipRange: '>=0.0.1 <4.9.0'
     operatorframework.io/initialization-resource: "\n    {\n        \"apiVersion\":
       \"ocs.openshift.io/v1\",\n        \"kind\": \"StorageCluster\",\n        \"metadata\":

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -630,7 +630,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
 	// Feature gating for Console. The array values are unique identifiers provided by the console.
 	// This can be used to enable/disable console support for any supported feature
 	// Example: "features.ocs.openshift.io/enabled": `["external", "foo1", "foo2", ...]`
-	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "pool-management", "namespace-store", "mcg-standalone", "taint-nodes"]`
+	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "pool-management", "namespace-store", "mcg-standalone", "taint-nodes", "vault-sa-kms", "hpcs-kms"]`
 	// Feature disablement flag for Console. The array values are unique identifiers provided by the console.
 	// To be used to disable UI components. This is used to track migration of features.
 	// Example: "features.ocs.openshift.io/disabled": `["external", "foo1", "foo2", ...]`


### PR DESCRIPTION
Introducing new KMS features in 4.10:

1. Vault Kubernetes service account-based authentication: 
- The Kubernetes auth method can be used to authenticate with Vault using a Kubernetes Service Account Token.
Steps to enable Kubernetes to service account based auth is:
1. To configure vault:
        https://github.com/rook/rook/blob/master/tests/scripts/deploy-validate-vault.sh#L173
```
ConfigMap: ocs-kms-connection-details
   data:
        KMS_PROVIDER: vault
        KMS_SERVICE_NAME: // name for this config
        VAULT_AUTH_KUBERNETES_ROLE: //required
        VAULT_AUTH_METHOD: kubernetes
        VAULT_CLIENT_CERT: //optional
        VAULT_NAMESPACE: //optional
        VAULT_CACERT: //optional
        VAULT_TLS_SERVER_NAME: //optional
        VAULT_CLIENT_KEY: //optional
        VAULT_BACKEND_PATH: //optional
        VAULT_ADDR: //required
```         
   
 2. IBM HPCS: https://www.ibm.com/cloud/blog/announcements/keep-your-private-keys-safe-on-red-hat-openshift-on-ibm-cloud-with-hyper-protect-crypto-services.


```
ConfigMap: ocs-kms-connection-details
   data:
       KMS_PROVIDER: "ibmkeyprotect",
       KMS_SERVICE_NAME: //name for this config
       IBM_SERVICE_INSTANCE_ID: //required
       IBM_KMS_KEY: //required (Secret Name)
       IBM_BASE_URL: //optional
       IBM_TOKEN_URL: //optional
```  

3. Enable encryption

```
StorageCluster CR:
spec:
   encryption:
    clusterWide: true
    storageClassWide: true / false
    kms: {
        enabled: true
    }
```
PR is on top of: https://github.com/red-hat-storage/ocs-operator/pull/1412
