### PR TITLE
ocs-ci: Update the build tools image to Fedora 34

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM fedora:33 as build-tools
+FROM fedora:34 as build-tools
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache


### PR DESCRIPTION
Signed-off-by: N Balachandran <nibalach@redhat.com>