### PR TITLE
add new required capability for rook

### DIFF
--- a/controllers/ocsinitialization/sccs.go
+++ b/controllers/ocsinitialization/sccs.go
@@ -71,7 +71,7 @@ func newRookCephSCC(namespace string) *secv1.SecurityContextConstraints {
 	scc.AllowHostIPC = true
 	scc.ReadOnlyRootFilesystem = false
 	scc.RequiredDropCapabilities = []corev1.Capability{}
-	scc.DefaultAddCapabilities = []corev1.Capability{}
+	scc.DefaultAddCapabilities = []corev1.Capability{"MKNOD"}
 	scc.RunAsUser = secv1.RunAsUserStrategyOptions{
 		Type: secv1.RunAsUserStrategyRunAsAny,
 	}


### PR DESCRIPTION
Rook is now using CAP_MKNOD in its code to execute some containers so
adding the corresponding SCC.

Signed-off-by: Sébastien Han <seb@redhat.com>