### PR TITLE
Introduce annotation to disable features in console

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1093,6 +1093,7 @@ metadata:
     external.features.ocs.openshift.io/validation: '{"secrets":["rook-ceph-operator-creds",
       "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints",
       "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}'
+    features.ocs.openshift.io/disabled: '["ss-list"]'
     features.ocs.openshift.io/enabled: '["kms", "arbiter", "flexible-scaling", "multus",
       "pool-management", "namespace-store", "mcg-standalone", "taint-nodes"]'
     olm.skipRange: '>=0.0.1 <4.9.0'

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -627,6 +627,10 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
 	// This can be used to enable/disable console support for any supported feature
 	// Example: "features.ocs.openshift.io/enabled": `["external", "foo1", "foo2", ...]`
 	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "pool-management", "namespace-store", "mcg-standalone", "taint-nodes"]`
+	// Feature disablement flag for Console. The array values are unique identifiers provided by the console.
+	// To be used to disable UI components. This is used to track migration of features.
+	// Example: "features.ocs.openshift.io/disabled": `["external", "foo1", "foo2", ...]`
+	ocsCSV.Annotations["features.ocs.openshift.io/disabled"] = `["ss-list"]`
 	// Used by UI to validate user uploaded metdata
 	// Metadata is used to connect to an external cluster
 	ocsCSV.Annotations["external.features.ocs.openshift.io/validation"] = `{"secrets":["rook-ceph-operator-creds", "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints", "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}`


### PR DESCRIPTION
OCP console will parse `features.ocs.openshift.io/disabled` annotation to disable features.
Disabling features of UI is required to aid migration of components from OCP to ODF repo. 
/assign @umangachapagain @jarrpa 