### PR TITLE
api: Add Id in the ExternalStorageClusterStatus struct

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -177,6 +177,9 @@ type ExternalStorageClusterStatus struct {
 	// GrantedCapacity Will report the actual capacity
 	// granted to the consumer cluster by the provider cluster.
 	GrantedCapacity resource.Quantity `json:"grantedCapacity,omitempty"`
+
+	// ConsumerID will hold the identity of this cluster inside the attached provider cluster
+	ConsumerID string `json:"id,omitempty"`
 }
 
 // StorageDeviceSet defines a set of storage devices.

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -4772,6 +4772,10 @@ spec:
                       to the consumer cluster by the provider cluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  id:
+                    description: ConsumerID will hold the identity of this cluster
+                      inside the attached provider cluster
+                    type: string
                 type: object
               failureDomain:
                 description: FailureDomain is the base CRUSH element Ceph will use

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -4770,6 +4770,10 @@ spec:
                       to the consumer cluster by the provider cluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  id:
+                    description: ConsumerID will hold the identity of this cluster
+                      inside the attached provider cluster
+                    type: string
                 type: object
               failureDomain:
                 description: FailureDomain is the base CRUSH element Ceph will use

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -4772,6 +4772,10 @@ spec:
                       to the consumer cluster by the provider cluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  id:
+                    description: ConsumerID will hold the identity of this cluster
+                      inside the attached provider cluster
+                    type: string
                 type: object
               failureDomain:
                 description: FailureDomain is the base CRUSH element Ceph will use


### PR DESCRIPTION
Id field is required to keep/save the UID of a storage consumer CR from
the provider cluster in the status. It will be used/passed while making
the API calls (offboarding, upscaling/downscaling) from the consumer
cluster after onboarding is successful.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

cc @nb-ohad @sp98 @kesavanvt 