### PR TITLE
ocs-to-ocs: Implement provider api server

### DIFF
--- a/services/provider/main.go
+++ b/services/provider/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"os"
+	"os/signal"
 
+	"github.com/red-hat-storage/ocs-operator/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/services/provider/server"
 	"google.golang.org/grpc"
 	"k8s.io/klog"
@@ -17,6 +21,20 @@ func main() {
 
 	klog.Info("Starting Provider API server")
 
-	var opts []grpc.ServerOption
-	server.Start(*port, opts)
+	namespace, err := util.GetWatchNamespace()
+	if err != nil {
+		klog.Errorf("failed to get provider cluster namespace. %v", err)
+		return
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	providerServer, err := server.NewOCSProviderServer(ctx, namespace)
+	if err != nil {
+		klog.Errorf("failed to start provider server. %v", err)
+		return
+	}
+
+	providerServer.Start(*port, []grpc.ServerOption{})
 }

--- a/services/provider/server/consumer.go
+++ b/services/provider/server/consumer.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	errTicketAlreadyExists = errors.New("onboarding ticket already used by another storageConsumer")
+)
+
+type ocsConsumerManager struct {
+	client       client.Client
+	namespace    string
+	nameByTicket map[string]string
+	nameByUID    map[types.UID]string
+	mutex        sync.RWMutex
+}
+
+func newConsumerManager(ctx context.Context, client client.Client, namespace string) (*ocsConsumerManager, error) {
+	consumers := &ocsv1alpha1.StorageConsumerList{}
+	err := client.List(ctx, consumers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list storage consumers. %v", err)
+	}
+
+	nameByTicket := map[string]string{}
+	nameByUID := map[types.UID]string{}
+
+	for _, consumer := range consumers.Items {
+		nameByUID[consumer.UID] = consumer.Name
+
+		if ticket, ok := consumer.GetAnnotations()[TicketAnnotation]; ok {
+			nameByTicket[ticket] = consumer.Name
+		}
+	}
+
+	return &ocsConsumerManager{
+		client:       client,
+		namespace:    namespace,
+		nameByTicket: nameByTicket,
+		nameByUID:    nameByUID,
+	}, nil
+}
+
+// Create creates a new storageConsumer resource, updates the consumer cache and returns the storageConsumer UID
+func (c *ocsConsumerManager) Create(ctx context.Context, name, ticket string, capacity resource.Quantity) (string, error) {
+	c.mutex.RLock()
+	if _, ok := c.nameByTicket[ticket]; ok {
+		c.mutex.RUnlock()
+		klog.Warning("onboarding ticket already in use")
+		return "", errTicketAlreadyExists
+	}
+	c.mutex.RUnlock()
+
+	consumerObj := &ocsv1alpha1.StorageConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.namespace,
+			Annotations: map[string]string{
+				TicketAnnotation: ticket,
+			},
+		},
+		Spec: ocsv1alpha1.StorageConsumerSpec{
+			Capacity: capacity,
+		},
+	}
+
+	err := c.client.Create(ctx, consumerObj)
+	if err != nil {
+		if kerrors.IsAlreadyExists(err) {
+			klog.Warningf("storageConsumer %q already exists", name)
+			return "", err
+		}
+		return "", fmt.Errorf("failed to create storageConsumer resource %q. %v", consumerObj.Name, err)
+	}
+
+	c.mutex.Lock()
+	c.nameByUID[consumerObj.UID] = consumerObj.Name
+	c.nameByTicket[ticket] = consumerObj.Name
+	c.mutex.Unlock()
+
+	klog.Infof("successfully created storageConsumer resource %q", name)
+
+	return string(consumerObj.UID), nil
+}
+
+// Delete deletes the storageConsumer resource using UID and updates the consumer cache
+func (c *ocsConsumerManager) Delete(ctx context.Context, id string) error {
+	uid := types.UID(id)
+	c.mutex.RLock()
+	consumerName, ok := c.nameByUID[uid]
+	if !ok {
+		klog.Warningf("no storageConsumer found with UID %q", id)
+		c.mutex.RUnlock()
+		return nil
+	}
+	c.mutex.RUnlock()
+
+	consumerObj := &ocsv1alpha1.StorageConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consumerName,
+			Namespace: c.namespace,
+		},
+	}
+	if err := c.client.Delete(ctx, consumerObj); err != nil {
+		if kerrors.IsNotFound(err) {
+			// update uidStore
+			c.mutex.Lock()
+			delete(c.nameByUID, uid)
+			c.mutex.Unlock()
+			klog.Warningf("storageConsumer %q not found.", consumerObj.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to delete storageConsumer %q. %v", consumerName, err)
+	}
+
+	c.mutex.Lock()
+	delete(c.nameByUID, uid)
+	c.mutex.Unlock()
+
+	klog.Infof("successfully deleted storageConsumer resource %q", consumerName)
+
+	return nil
+}
+
+// UpdateCapacity updates the capacity field in storageConsumer resource
+func (c *ocsConsumerManager) UpdateCapacity(ctx context.Context, id string, capacity resource.Quantity) error {
+	// Get storage consumer resource using UID
+	consumerObj, err := c.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	consumerObj.Spec.Capacity = capacity
+	err = c.client.Update(ctx, consumerObj)
+	if err != nil {
+		return fmt.Errorf("failed to update storageConfig resource %q. %v", consumerObj.Name, err)
+	}
+
+	klog.Infof("successfully updated requested capacity field in the StorageConsumer resource %q", consumerObj.Name)
+
+	return nil
+}
+
+// Get returns a storageConsumer resource using the UID
+func (c *ocsConsumerManager) Get(ctx context.Context, id string) (*ocsv1alpha1.StorageConsumer, error) {
+	uid := types.UID(id)
+
+	c.mutex.RLock()
+	consumerName, ok := c.nameByUID[uid]
+	if !ok {
+		c.mutex.RUnlock()
+		klog.Errorf("no storageConsumer found with the UID %q", id)
+		return nil, fmt.Errorf("no storageConsumer found with the UID %q", id)
+	}
+	c.mutex.RUnlock()
+
+	consumerObj := &ocsv1alpha1.StorageConsumer{}
+	if err := c.client.Get(ctx, types.NamespacedName{Name: consumerName, Namespace: c.namespace}, consumerObj); err != nil {
+		if kerrors.IsNotFound(err) {
+			// update uidStore
+			c.mutex.Lock()
+			delete(c.nameByUID, uid)
+			c.mutex.Unlock()
+			return nil, fmt.Errorf("storageConsumer resource %q not found. %v", consumerName, err)
+		}
+		return nil, fmt.Errorf("failed to get storageConsumer resource with name %q. %v", consumerName, err)
+	}
+
+	return consumerObj, nil
+}

--- a/services/provider/server/consumer_test.go
+++ b/services/provider/server/consumer_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/red-hat-storage/ocs-operator/api/v1"
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace = "test"
+)
+
+var (
+	consumer1 = &ocsv1alpha1.StorageConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consumer1",
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				TicketAnnotation: "ticket1",
+			},
+			UID: "uid1",
+		},
+		Spec: ocsv1alpha1.StorageConsumerSpec{
+			Capacity: resource.MustParse("1G"),
+		},
+	}
+
+	consumer2 = &ocsv1alpha1.StorageConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consumer2",
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				TicketAnnotation: "ticket2",
+			},
+			UID: "uid2",
+		},
+	}
+)
+
+func newFakeClient(t *testing.T, obj ...runtime.Object) client.Client {
+	scheme, err := api.SchemeBuilder.Build()
+	assert.NoError(t, err, "unable to build scheme")
+
+	err = corev1.AddToScheme(scheme)
+	assert.NoError(t, err, "failed to add corev1 scheme")
+
+	err = ocsv1alpha1.AddToScheme(scheme)
+	assert.NoError(t, err, "failed to add ocsv1alpha1 scheme")
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj...).Build()
+}
+
+func TestNewConsumerManager(t *testing.T) {
+	ctx := context.TODO()
+	obj := []runtime.Object{}
+
+	// Test NewConsumerManager with no StorageConsumer resources
+	client := newFakeClient(t)
+	consumerManager, err := newConsumerManager(ctx, client, testNamespace)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(consumerManager.nameByTicket))
+	assert.Equal(t, 0, len(consumerManager.nameByUID))
+
+	// Test NewConsumerManager when StorageConsumer resources are already available
+	obj = append(obj, consumer1, consumer2)
+	client = newFakeClient(t, obj...)
+	consumerManager, err = newConsumerManager(ctx, client, testNamespace)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(consumerManager.nameByTicket))
+	assert.Equal(t, "consumer1", consumerManager.nameByTicket["ticket1"])
+	assert.Equal(t, "consumer2", consumerManager.nameByTicket["ticket2"])
+	assert.Equal(t, 2, len(consumerManager.nameByUID))
+	assert.Equal(t, "consumer1", consumerManager.nameByUID["uid1"])
+	assert.Equal(t, "consumer2", consumerManager.nameByUID["uid2"])
+}
+
+func TestCreateStorageConsumer(t *testing.T) {
+	ctx := context.TODO()
+	obj := []runtime.Object{}
+
+	obj = append(obj, consumer1)
+	client := newFakeClient(t, obj...)
+	consumerManager, err := newConsumerManager(ctx, client, testNamespace)
+	assert.NoError(t, err)
+
+	// Create consumer should fail if consumer already exists
+	_, err = consumerManager.Create(ctx, "consumer1", "ticket1", resource.MustParse("1G"))
+	assert.Error(t, err)
+
+	// Create consumer should fail if ticket is already used
+	_, err = consumerManager.Create(ctx, "consumer3", "ticket1", resource.MustParse("1G"))
+	assert.Error(t, err)
+
+	// Create consumer successfully. (Can't validate the UID because fake client does not add UID)
+	assert.Equal(t, 1, len(consumerManager.nameByTicket))
+	_, err = consumerManager.Create(ctx, "consumer2", "ticket2", resource.MustParse("1G"))
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(consumerManager.nameByTicket))
+	assert.Equal(t, "consumer1", consumerManager.nameByTicket["ticket1"])
+	assert.Equal(t, "consumer2", consumerManager.nameByTicket["ticket2"])
+}
+
+func TestDeleteStorageConsumer(t *testing.T) {
+	ctx := context.TODO()
+	obj := []runtime.Object{}
+
+	obj = append(obj, consumer1)
+	client := newFakeClient(t, obj...)
+	consumerManager, err := newConsumerManager(ctx, client, testNamespace)
+	assert.NoError(t, err)
+
+	// Delete consumer should ignore error if consumer is not found
+	err = consumerManager.Delete(ctx, "invalid-uid")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(consumerManager.nameByUID))
+
+	// Delete consumer removes any stale references in the nameByUID map
+	consumerManager.nameByUID["stale-uid"] = "stale-consumer"
+	assert.Equal(t, 2, len(consumerManager.nameByUID))
+	err = consumerManager.Delete(ctx, "stale-uid")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(consumerManager.nameByUID))
+
+	// Delete consumer successfully deletes an existing consumer
+	err = consumerManager.Delete(ctx, "uid1")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(consumerManager.nameByUID))
+}
+
+func TestUpdateCapacity(t *testing.T) {
+	ctx := context.TODO()
+	obj := []runtime.Object{}
+
+	obj = append(obj, consumer1)
+	client := newFakeClient(t, obj...)
+	consumerManager, err := newConsumerManager(ctx, client, testNamespace)
+	assert.NoError(t, err)
+
+	// Updating capacity using invalid UID should fail
+	err = consumerManager.UpdateCapacity(ctx, "invalid-uid", resource.MustParse("10G"))
+	assert.Error(t, err)
+
+	// Updating capacity from 1G to 10G using valid UID should succeed
+	consumer, err := consumerManager.Get(ctx, "uid1")
+	assert.NoError(t, err)
+	assert.Equal(t, consumer.Spec.Capacity, resource.MustParse("1G"))
+	err = consumerManager.UpdateCapacity(ctx, "uid1", resource.MustParse("10G"))
+	assert.NoError(t, err)
+	consumer, err = consumerManager.Get(ctx, "uid1")
+	assert.NoError(t, err)
+	assert.Equal(t, consumer.Spec.Capacity, resource.MustParse("10G"))
+}
+
+func TestGetStorageConsumer(t *testing.T) {
+	ctx := context.TODO()
+	obj := []runtime.Object{}
+
+	obj = append(obj, consumer1)
+	client := newFakeClient(t, obj...)
+	consumerManager, err := newConsumerManager(ctx, client, testNamespace)
+	assert.NoError(t, err)
+
+	// Get storageConsumer should fail for invalid UID
+	_, err = consumerManager.Get(ctx, "invalid-uid")
+	assert.Error(t, err)
+
+	// Get storageConsumer should succeed for valid UID
+	consumer, err := consumerManager.Get(ctx, "uid1")
+	assert.NoError(t, err)
+	assert.Equal(t, "consumer1", consumer.Name)
+}

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -6,65 +6,186 @@ import (
 	"net"
 	"os"
 
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/services/provider/common"
 	pb "github.com/red-hat-storage/ocs-operator/services/provider/pb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-type ocsProviderServer struct {
+const (
+	TicketAnnotation = "ocs.openshift.io/provider-onboarding-ticket"
+)
+
+type OCSProviderServer struct {
 	pb.UnimplementedOCSProviderServer
+	client          client.Client
+	consumerManager *ocsConsumerManager
+	namespace       string
+}
+
+func NewOCSProviderServer(ctx context.Context, namespace string) (*OCSProviderServer, error) {
+	client, err := newClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new client. %v", err)
+	}
+
+	consumerManager, err := newConsumerManager(ctx, client, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new OCSConumer instance. %v", err)
+	}
+
+	return &OCSProviderServer{
+		client:          client,
+		consumerManager: consumerManager,
+		namespace:       namespace,
+	}, nil
 }
 
 // OnboardConsumer RPC call to onboard a new OCS consumer cluster.
-func (c *ocsProviderServer) OnboardConsumer(ctx context.Context, req *pb.OnboardConsumerRequest) (*pb.OnboardConsumerResponse, error) {
+func (s *OCSProviderServer) OnboardConsumer(ctx context.Context, req *pb.OnboardConsumerRequest) (*pb.OnboardConsumerResponse, error) {
 	mock := os.Getenv(common.MockProviderAPI)
 	if mock != "" {
 		return mockOnboardConsumer(common.MockError(mock))
 	}
-	return &pb.OnboardConsumerResponse{}, nil
+
+	// Validate capacity
+	capacity, err := resource.ParseQuantity(req.Capacity)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%q is not a valid storageConsumer capacity: %v", req.Capacity, err)
+	}
+
+	// Validate onboardingTicket
+	// TODO: check if ticket is already used.
+	// TODO: check expiry of the ticket
+	// TODO: validate ticket with public key
+
+	storageConsumerUUID, err := s.consumerManager.Create(ctx, req.ConsumerName, req.OnboardingTicket, capacity)
+	if err != nil {
+		if kerrors.IsAlreadyExists(err) || err == errTicketAlreadyExists {
+			return nil, status.Errorf(codes.AlreadyExists, "failed to create storageConsumer %q. %v", req.ConsumerName, err)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to create storageConsumer %q. %v", req.ConsumerName, err)
+	}
+
+	// TODO: send correct granted capacity
+	return &pb.OnboardConsumerResponse{StorageConsumerUUID: storageConsumerUUID, GrantedCapacity: req.Capacity}, nil
 }
 
 // GetStorageConfig RPC call to onboard a new OCS consumer cluster.
-func (c *ocsProviderServer) GetStorageConfig(ctx context.Context, req *pb.StorageConfigRequest) (*pb.StorageConfigResponse, error) {
+func (s *OCSProviderServer) GetStorageConfig(ctx context.Context, req *pb.StorageConfigRequest) (*pb.StorageConfigResponse, error) {
 	mock := os.Getenv(common.MockProviderAPI)
 	if mock != "" {
 		return mockGetStorageConfig(common.MockError(mock))
 	}
-	return &pb.StorageConfigResponse{}, nil
-}
 
-// OffboardConsumer RPC call to delete the StorageConsumer CR
-func (c *ocsProviderServer) OffboardConsumer(ctx context.Context, req *pb.OffboardConsumerRequest) (*pb.OffboardConsumerResponse, error) {
-	mock := os.Getenv(common.MockProviderAPI)
-	if mock != "" {
-		return mockOffboardConsumer(common.MockError(mock))
+	// Get storage consumer resource using UUID
+	consumerObj, err := s.consumerManager.Get(ctx, req.StorageConsumerUUID)
+	if err != nil {
+		return nil, err
 	}
-	return &pb.OffboardConsumerResponse{}, nil
+
+	// Verify Status
+	switch consumerObj.Status.State {
+	case ocsv1alpha1.StorageConsumerStateFailed:
+		// TODO: get correct error message from the storageConsumer status
+		return nil, status.Errorf(codes.Internal, "storageConsumer status failed")
+	case ocsv1alpha1.StorageConsumerStateConfiguring:
+		return nil, status.Errorf(codes.Unavailable, "waiting for the rook resources to be provisioned")
+	case ocsv1alpha1.StorageConsumerStateDeleting:
+		return nil, status.Errorf(codes.NotFound, "storageConsumer is already in deleting phase")
+	case ocsv1alpha1.StorageConsumerStateReady:
+		// TODO: Return json connection details
+		return &pb.StorageConfigResponse{}, nil
+	}
+
+	return nil, status.Errorf(codes.Unavailable, "storage consumer status is not set")
 }
 
 // UpdateCapacity PRC call to increase or decrease the storage pool size
-func (c *ocsProviderServer) UpdateCapacity(ctx context.Context, req *pb.UpdateCapacityRequest) (*pb.UpdateCapacityResponse, error) {
+func (s *OCSProviderServer) UpdateCapacity(ctx context.Context, req *pb.UpdateCapacityRequest) (*pb.UpdateCapacityResponse, error) {
 	mock := os.Getenv(common.MockProviderAPI)
 	if mock != "" {
 		return mockUpdateCapacity(common.MockError(mock))
 	}
+
+	capacity, err := resource.ParseQuantity(req.Capacity)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%q is not a valid resource capacity: %v", req.Capacity, err)
+	}
+
+	if err := s.consumerManager.UpdateCapacity(ctx, req.StorageConsumerUUID, capacity); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "failed to update capacity in the storageConsumer resource: %v", err)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to update capacity in the storageConsumer resource: %v", err)
+	}
+
+	// TODO: Return granted capacity correctly.
 	return &pb.UpdateCapacityResponse{}, nil
 }
 
-func Start(port int, opts []grpc.ServerOption) {
+// OffboardConsumer RPC call to delete the StorageConsumer CR
+func (s *OCSProviderServer) OffboardConsumer(ctx context.Context, req *pb.OffboardConsumerRequest) (*pb.OffboardConsumerResponse, error) {
+	mock := os.Getenv(common.MockProviderAPI)
+	if mock != "" {
+		return mockOffboardConsumer(common.MockError(mock))
+	}
+
+	err := s.consumerManager.Delete(ctx, req.StorageConsumerUUID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete storageConsumer resource with the provided UUID. %v", err)
+	}
+
+	return &pb.OffboardConsumerResponse{}, nil
+}
+
+func (s *OCSProviderServer) Start(port int, opts []grpc.ServerOption) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		klog.Fatalf("failed to listen: %v", err)
 	}
 
 	grpcServer := grpc.NewServer(opts...)
-	pb.RegisterOCSProviderServer(grpcServer, &ocsProviderServer{})
+	pb.RegisterOCSProviderServer(grpcServer, s)
 	// Register reflection service on gRPC server.
 	reflection.Register(grpcServer)
 	err = grpcServer.Serve(lis)
 	if err != nil {
 		klog.Fatalf("failed to start gRPC server: %v", err)
 	}
+}
+
+func newClient() (client.Client, error) {
+	scheme := runtime.NewScheme()
+	err := ocsv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add ocsv1alpha1 to scheme. %v", err)
+	}
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add ocsv1alpha1 to scheme. %v", err)
+	}
+
+	config, err := config.GetConfig()
+	if err != nil {
+		klog.Error(err, "failed to get rest.config")
+		return nil, err
+	}
+	client, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		klog.Error(err, "failed to create controller-runtime client")
+		return nil, err
+	}
+
+	return client, nil
 }


### PR DESCRIPTION
This PR implements the gRPC provider api-server. 

Pending items that will be taken up an follow up PR:
- [ ] New onbording ticket generation and validating ticket using public key
- [ ] Add TLS cert to api server 
- [ ] StorageCluster CR resource deletion should not be allowed in case there is one ore more StorageConsumer resources available.
