### PR TITLE
collect logs for Ramen Artifacts

### DIFF
--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -72,3 +72,23 @@ for command_desc in "${commands_desc[@]}"; do
      COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/desc_${command_desc// /_}
     { oc describe "${command_desc}"; } >> "${COMMAND_OUTPUT_FILE}"
 done
+
+# Collect logs for drpolicy and mirrorpeers
+isMirrorPeer=$(timeout 60 oc get crd | grep mirrorpeers |awk '{print $1}')
+if [ "${isMirrorPeer}" == "mirrorpeers.multicluster.odf.openshift.io" ]; then
+        # Collect logs for oc get mirrorpeers
+        echo "collecting oc command get mirrorpeers" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+        COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/get_mirrorpeers
+        { oc get mirrorpeers; } >> "${COMMAND_OUTPUT_FILE}"
+        # Collect logs for oc get drpolicy
+        echo "collecting oc command get drpolicy" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+        COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/get_drpolicy
+        { oc get drpolicy; } >> "${COMMAND_OUTPUT_FILE}"
+        # Collect logs for oc describe drpolicy
+        echo "collecting oc command describe drpolicy" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+        COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/desc_drpolicy
+        { oc describe drpolicy; } >> "${COMMAND_OUTPUT_FILE}"
+        { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect drpolicy --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+        else
+            { printf "No mirror peer CRD"; }
+        fi

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -147,3 +147,25 @@ echo "collecting dump of oc get volumereplication all namespaces" | tee -a  "${B
 echo "collecting dump of oc get volumereplicationgroups all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
 { oc get volumereplicationgroups --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/vrg_all_namespaces"
 { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect vrg --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+
+# Collect logs for Ramen DR Hub cluster Resources
+isMirrorPeer=$(timeout 60 oc get crd | grep mirrorpeers |awk '{print $1}')
+if [ "${isMirrorPeer}" == "mirrorpeers.multicluster.odf.openshift.io" ]; then
+            # For Channels of all namespaces
+            { oc get channel --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/channel_all_namespaces"
+            { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect channel --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+            # For DRPlacementControl of all namespaces
+            { oc get drplacementcontrol --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/drplacementcontrol_all_namespaces"
+            { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect drplacementcontrol --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+            # For placement rule of all namespaces
+            { oc get placementrule --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/placementrule_all_namespaces"
+            { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect placementrule --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+            # For subscription of all namespaces
+            { oc get subscription --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/subscription_all_namespaces"
+            { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect subscription --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+            # For ManagedClusterAddons of all namespaces
+            { oc get managedclusteraddons --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/managedclusteraddons_all_namespaces"
+            { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect managedclusteraddons --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+            else
+                { printf "No mirror peer CRD"; }
+            fi


### PR DESCRIPTION
This commits adds log collection of
Ramen artifacts for the hub cluster.
Here are the following details:
 * DRPolicy object
 * MirrorPeers object
 * Application namespace resources on the hub:
  - Channel(s) used by the Subscription(s)
  - All Subscription(s)
  - All PlacementRule(s)
  - DRPlacementControl
 * ACM resources across managed cluster namespaces as per drClusterSet in DRPolicy:
   - ManagedClusterView

BZ: #2017642

Signed-off-by: yati1998 <ypadia@redhat.com>