### PR TITLE
Decreasing the timeout of 'ODF_standardized_metrics.rules' group to 30s

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -10,19 +10,12 @@ spec:
   groups:
   - name: ocs_performance.rules
     rules:
-    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
-        \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
-        \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
-        (instance,device) \n    (1,\n      (\n        rate(node_disk_read_time_seconds_total[1m])
-        / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )\n)\n"
+    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"}, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by (instance,device) \n    (1,\n      (\n        rate(node_disk_read_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )\n)\n"
       record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m
-    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
-        \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
-        \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
-        (instance,device) \n    (1,\n      (\n        rate(node_disk_write_time_seconds_total[1m])
-        / (clamp_min(rate(node_disk_writes_completed_total[1m]), 1))\n      )\n    )\n)\n"
+    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"}, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by (instance,device) \n    (1,\n      (\n        rate(node_disk_write_time_seconds_total[1m]) / (clamp_min(rate(node_disk_writes_completed_total[1m]), 1))\n      )\n    )\n)\n"
       record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m
-  - name: ODF_standardized_metrics.rules
+  - interval: 30s
+    name: ODF_standardized_metrics.rules
     rules:
     - expr: |
         ceph_health_status
@@ -54,14 +47,7 @@ spec:
         system_type: OCS
         system_vendor: Red Hat
       record: odf_system_throughput_total_bytes
-    - expr: "avg by (namespace, managedBy, job, service)\n(\n  topk by (ceph_daemon)
-        (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
-        \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
-        \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left() topk by
-        (instance,device) \n  (1,\n    (\n      (  \n          rate(node_disk_read_time_seconds_total[1m])
-        / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      ) +\n      (\n
-        \         rate(node_disk_write_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]),
-        1))\n      )\n    )/2\n  )\n)\n"
+    - expr: "avg by (namespace, managedBy, job, service)\n(\n  topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"}, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left() topk by (instance,device) \n  (1,\n    (\n      (  \n          rate(node_disk_read_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      ) +\n      (\n          rate(node_disk_write_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )/2\n  )\n)\n"
       labels:
         system_type: OCS
         system_vendor: Red Hat
@@ -70,10 +56,7 @@ spec:
     rules:
     - alert: ObcQuotaBytesAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
-          of the size limit set by the quota(bytes) and will become read-only on reaching
-          the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
-          OBC custom resource.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.
         message: OBC has crossed 80% of the quota(bytes).
         severity_level: warning
         storage_type: RGW
@@ -84,10 +67,7 @@ spec:
         severity: warning
     - alert: ObcQuotaObjectsAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
-          of the size limit set by the quota(objects) and will become read-only on
-          reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
-          OBC custom resource.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.
         message: OBC has crossed 80% of the quota(object).
         severity_level: warning
         storage_type: RGW
@@ -98,9 +78,7 @@ spec:
         severity: warning
     - alert: ObcQuotaBytesExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
-          limit set by the quota(bytes) and will be read-only now. Increase the quota
-          in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
         message: OBC reached quota(bytes) limit.
         severity_level: error
         storage_type: RGW
@@ -111,9 +89,7 @@ spec:
         severity: critical
     - alert: ObcQuotaObjectsExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
-          limit set by the quota(objects) and will be read-only now. Increase the
-          quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
         message: OBC reached quota(object) limit.
         severity_level: error
         storage_type: RGW
@@ -126,10 +102,8 @@ spec:
     rules:
     - alert: ClusterObjectStoreState
       annotations:
-        description: Cluster Object Store is in unhealthy state for more than 15s.
-          Please check Ceph cluster health or RGW connection.
-        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster
-          health or RGW connection.
+        description: Cluster Object Store is in unhealthy state for more than 15s. Please check Ceph cluster health or RGW connection.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection.
         severity_level: error
         storage_type: RGW
       expr: |

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -10,19 +10,12 @@ spec:
   groups:
   - name: ocs_performance.rules
     rules:
-    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
-        \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
-        \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
-        (instance,device) \n    (1,\n      (\n        rate(node_disk_read_time_seconds_total[1m])
-        / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )\n)\n"
+    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"}, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by (instance,device) \n    (1,\n      (\n        rate(node_disk_read_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )\n)\n"
       record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m
-    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
-        \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
-        \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
-        (instance,device) \n    (1,\n      (\n        rate(node_disk_write_time_seconds_total[1m])
-        / (clamp_min(rate(node_disk_writes_completed_total[1m]), 1))\n      )\n    )\n)\n"
+    - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"}, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by (instance,device) \n    (1,\n      (\n        rate(node_disk_write_time_seconds_total[1m]) / (clamp_min(rate(node_disk_writes_completed_total[1m]), 1))\n      )\n    )\n)\n"
       record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m
-  - name: ODF_standardized_metrics.rules
+  - interval: 30s
+    name: ODF_standardized_metrics.rules
     rules:
     - expr: |
         ceph_health_status
@@ -54,14 +47,7 @@ spec:
         system_type: OCS
         system_vendor: Red Hat
       record: odf_system_throughput_total_bytes
-    - expr: "avg by (namespace, managedBy, job, service)\n(\n  topk by (ceph_daemon)
-        (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
-        \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
-        \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left() topk by
-        (instance,device) \n  (1,\n    (\n      (  \n          rate(node_disk_read_time_seconds_total[1m])
-        / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      ) +\n      (\n
-        \         rate(node_disk_write_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]),
-        1))\n      )\n    )/2\n  )\n)\n"
+    - expr: "avg by (namespace, managedBy, job, service)\n(\n  topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"}, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left() topk by (instance,device) \n  (1,\n    (\n      (  \n          rate(node_disk_read_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      ) +\n      (\n          rate(node_disk_write_time_seconds_total[1m]) / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )/2\n  )\n)\n"
       labels:
         system_type: OCS
         system_vendor: Red Hat
@@ -70,8 +56,7 @@ spec:
     rules:
     - alert: OdfMirrorDaemonStatus
       annotations:
-        description: Mirror daemon is in unhealthy status for more than 1m. Mirroring
-          on this cluster is not working as expected.
+        description: Mirror daemon is in unhealthy status for more than 1m. Mirroring on this cluster is not working as expected.
         message: Mirror daemon is unhealthy.
         severity_level: error
         storage_type: ceph
@@ -82,10 +67,8 @@ spec:
         severity: critical
     - alert: OdfPoolMirroringImageHealth
       annotations:
-        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in
-          Unknown state for more than 1m. Mirroring might not work as expected.
-        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown
-          state.
+        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state for more than 1m. Mirroring might not work as expected.
+        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state.
         severity_level: warning
         storage_type: ceph
       expr: |
@@ -95,10 +78,8 @@ spec:
         severity: warning
     - alert: OdfPoolMirroringImageHealth
       annotations:
-        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in
-          Warning state for more than 1m. Mirroring might not work as expected.
-        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning
-          state.
+        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for more than 1m. Mirroring might not work as expected.
+        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state.
         severity_level: warning
         storage_type: ceph
       expr: |
@@ -108,10 +89,8 @@ spec:
         severity: warning
     - alert: OdfPoolMirroringImageHealth
       annotations:
-        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in
-          Error state for more than 10s. Mirroring is not working as expected.
-        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error
-          state.
+        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for more than 10s. Mirroring is not working as expected.
+        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state.
         severity_level: error
         storage_type: ceph
       expr: |
@@ -123,10 +102,7 @@ spec:
     rules:
     - alert: ObcQuotaBytesAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
-          of the size limit set by the quota(bytes) and will become read-only on reaching
-          the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
-          OBC custom resource.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.
         message: OBC has crossed 80% of the quota(bytes).
         severity_level: warning
         storage_type: RGW
@@ -137,10 +113,7 @@ spec:
         severity: warning
     - alert: ObcQuotaObjectsAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
-          of the size limit set by the quota(objects) and will become read-only on
-          reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
-          OBC custom resource.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.
         message: OBC has crossed 80% of the quota(object).
         severity_level: warning
         storage_type: RGW
@@ -151,9 +124,7 @@ spec:
         severity: warning
     - alert: ObcQuotaBytesExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
-          limit set by the quota(bytes) and will be read-only now. Increase the quota
-          in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
         message: OBC reached quota(bytes) limit.
         severity_level: error
         storage_type: RGW
@@ -164,9 +135,7 @@ spec:
         severity: critical
     - alert: ObcQuotaObjectsExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
-          limit set by the quota(objects) and will be read-only now. Increase the
-          quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
         message: OBC reached quota(object) limit.
         severity_level: error
         storage_type: RGW
@@ -179,10 +148,8 @@ spec:
     rules:
     - alert: ClusterObjectStoreState
       annotations:
-        description: Cluster Object Store is in unhealthy state for more than 15s.
-          Please check Ceph cluster health.
-        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster
-          health.
+        description: Cluster Object Store is in unhealthy state for more than 15s. Please check Ceph cluster health.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster health.
         severity_level: error
         storage_type: RGW
       expr: |

--- a/metrics/mixin/alerts/alerts-external.libsonnet
+++ b/metrics/mixin/alerts/alerts-external.libsonnet
@@ -1,3 +1,2 @@
-(import 'cluster-resource-quota.libsonnet') +
 (import 'obc.libsonnet') +
 (import 'services-external.libsonnet')

--- a/metrics/mixin/alerts/alerts.libsonnet
+++ b/metrics/mixin/alerts/alerts.libsonnet
@@ -1,4 +1,3 @@
-(import 'cluster-resource-quota.libsonnet') +
 (import 'mirroring.libsonnet') +
 (import 'obc.libsonnet') +
 (import 'services.libsonnet')

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -36,6 +36,7 @@
       },
       {
         name: 'ODF_standardized_metrics.rules',
+        interval: '30s',
         rules: [
           {
             record: 'odf_system_health_status',


### PR DESCRIPTION
In order to make the 'odf_system_iops_total_bytes' recording rule to
collect more granular metric data points, we are decreasing the
recording rule group's time interval to 30s (where default is 1m).

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>