### PR TITLE
must-gather: remove unused file

### DIFF
--- a/must-gather/Centos-Base.repo
+++ b/must-gather/Centos-Base.repo
@@ -1,6 +1,0 @@
-[centos]
-name=CentOS-7
-baseurl=http://ftp.heanet.ie/pub/centos/7/os/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=http://ftp.heanet.ie/pub/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7


### PR DESCRIPTION
Removes the unused Centos.repo file.

Signed-off-by: N Balachandran <nibalach@redhat.com>