### PR TITLE
api: remove default value of Spec.ExternalStorage.StorageProviderKind

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -158,7 +158,6 @@ type ExternalStorageClusterSpec struct {
 	// +optional
 	Enable bool `json:"enable,omitempty"`
 
-	//+kubebuilder:default:=rhcs
 	//+kubebuilder:validation:Enum=ocs;rhcs
 	// StorageProviderKind Identify the type of storage provider cluster this consumer cluster is going to connect to.
 	StorageProviderKind ExternalStorageKind `json:"storageProviderKind,omitempty"`

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -316,7 +316,6 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageProviderKind:
-                    default: rhcs
                     description: StorageProviderKind Identify the type of storage
                       provider cluster this consumer cluster is going to connect to.
                     enum:

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -314,7 +314,6 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageProviderKind:
-                    default: rhcs
                     description: StorageProviderKind Identify the type of storage
                       provider cluster this consumer cluster is going to connect to.
                     enum:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -316,7 +316,6 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageProviderKind:
-                    default: rhcs
                     description: StorageProviderKind Identify the type of storage
                       provider cluster this consumer cluster is going to connect to.
                     enum:


### PR DESCRIPTION
having default value fills in a value even in the non external mode CR
which leads to a confusion.

instead of using a default value for the traditional external mode we
will treat Spec.ExternalStorage.StorageProviderKind="" as the "rhcs" if
the ExternalStorage is enabled.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Fix: https://github.com/red-hat-storage/ocs-operator/issues/1436