### PR TITLE
ocs-to-ocs: Fix error Service "ocs-provider-server" is invalid

### DIFF
--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -132,6 +132,9 @@ func (o *ocsProviderServer) createService(r *StorageClusterReconciler, instance 
 	_, err := controllerutil.CreateOrUpdate(
 		context.TODO(), r.Client, actualService,
 		func() error {
+			desiredService.Spec.ClusterIP = actualService.Spec.ClusterIP
+			desiredService.Spec.IPFamilies = actualService.Spec.IPFamilies
+
 			actualService.Spec = desiredService.Spec
 			return controllerutil.SetOwnerReference(instance, actualService, r.Client.Scheme())
 		},


### PR DESCRIPTION
The errors are seen while updating the service.

Errors:
- spec.clusterIPs[0]: Invalid value: []string(nil): primary clusterIP
can not be unset
- spec.ipFamilies[0]: Invalid value: []core.IPFamily(nil): primary
ipFamily can not be unset

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Fix: https://github.com/red-hat-storage/ocs-operator/issues/1437