### PR TITLE
Add check  to verify the presence of openshift-dr-system ns

### DIFF
--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -110,25 +110,30 @@ for resource in "${resources[@]}"; do
     { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 done
 
-echo "collecting dump of openshift-dr-system namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${RAMEN_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+{ timeout 60 oc get ns openshift-dr-system; }
+# Verify if openshift-dr-system namespace exists
+if [ $? == 0 ]; then
+     echo "collecting dump of openshift-dr-system namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+     oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${RAMEN_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 
-# Create the dir for oc_output for openshift-dr-system namespace
-mkdir -p "${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/"
+     # Create the dir for oc_output for openshift-dr-system namespace
+     mkdir -p "${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/"
 
-# Run the Collection of Resources to list
-for dr_resource in "${dr_resources[@]}"; do
-     echo "collecting oc command ${dr-resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
-     COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/${dr_resource// /_}
-     # shellcheck disable=SC2086
-     { oc get ${dr_resource} -n ${RAMEN_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
-done
-
-# Run collection of oc describe command for config map
-echo "collecting oc describe configmap -n ${RAMEN_NAMESPACE}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+     # Run the Collection of Resources to list
+     for dr_resource in "${dr_resources[@]}"; do
+          echo "collecting oc command ${dr-resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
+          COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/${dr_resource// /_}
+          # shellcheck disable=SC2086
+          { oc get ${dr_resource} -n ${RAMEN_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+     done
+     # Run collection of oc describe command for config map
+     echo "collecting oc describe configmap -n ${RAMEN_NAMESPACE}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
      COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/namespaces/${RAMEN_NAMESPACE}/oc_output/desc_configmap
      # shellcheck disable=SC2086
      { oc describe configmap -n ${RAMEN_NAMESPACE}; } >> "${COMMAND_OUTPUT_FILE}"
+else
+     { printf "No openshift-dr-system namespace"; }
+fi    
 
 # For pvc of all namespaces
 echo "collecting dump of oc get pvc all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"


### PR DESCRIPTION
This commit verifies if the openshift-dr-system namespace is
present or not before collecting the logs for Ramen artifacts.

Signed-off-by: yati1998 <ypadia@redhat.com>