### PR TITLE
Report versioning errors in StorageCluster's status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ golangci-lint:
 # use 'make functest' to run just the functional tests
 unit-test:
 	@echo "Executing unit tests"
-	go test -v -cover `go list ./... | grep -v "functest"`
+	hack/unit-test.sh
 
 ocs-operator-ci: shellcheck-test golangci-lint unit-test verify-deps verify-generated verify-latest-deploy-yaml
 

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -200,6 +200,12 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 		r.Log.Error(err, "Failed to validate StorageCluster version.", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
 		r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
+		instance.Status.Conditions = append(instance.Status.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionDegraded,
+			Status:  corev1.ConditionTrue,
+			Reason:  statusutil.EventReasonValidationFailed,
+			Message: err.Error(),
+		})
 		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			r.Log.Error(updateErr, "Failed to update StorageCluster.", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
 			return updateErr

--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -21,8 +21,9 @@ else
 	echo "GINKO binary found at $GINKGO"
 fi
 
+LDFLAGS="-X github.com/red-hat-storage/ocs-operator/version.Version=${VERSION}"
 
-"$GOBIN"/ginkgo build "functests/${suite}/"
+"$GOBIN"/ginkgo build --ldflags "${LDFLAGS}" "functests/${suite}/"
 
 mkdir -p $OUTDIR_BIN
 mv "functests/${suite}/${suite}.test" "${OUTDIR_BIN}/${suite}_tests"

--- a/hack/generate-unified-csv.sh
+++ b/hack/generate-unified-csv.sh
@@ -5,7 +5,10 @@ set -e
 source hack/common.sh
 
 CSV_MERGER="tools/csv-merger/csv-merger"
-(cd tools/csv-merger/ && go build)
+
+LDFLAGS="-X github.com/red-hat-storage/ocs-operator/version.Version=${VERSION}"
+
+(cd tools/csv-merger/ && go build -ldflags="${LDFLAGS}")
 
 function help_txt() {
 	echo "Environment Variables"

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source hack/common.sh
+
+LDFLAGS="-X github.com/red-hat-storage/ocs-operator/version.Version=${VERSION}"
+
+go test -ldflags="${LDFLAGS}" -v -cover `go list ./... | grep -v "functest"`

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -781,7 +781,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
 
 func injectCSVRelatedImages(r *unstructured.Unstructured) error {
 
-	relatedImages := []interface{}{}
+	var relatedImages []interface{}
 
 	if *rookContainerImage != "" {
 		relatedImages = append(relatedImages, map[string]interface{}{

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version of the operator
-	Version = "4.11.0"
+	Version = ""
 )


### PR DESCRIPTION
Earlier, only the status of the storage cluster was being updated,
because of which, side effects such as version mismatch came in to play.