### PR TITLE
hack: Add --container-tool argument in opm command while building index

### DIFF
--- a/hack/build-operator-index.sh
+++ b/hack/build-operator-index.sh
@@ -12,7 +12,7 @@ echo
 echo "Did you push the bundle image? It must be pullable from '$IMAGE_REGISTRY'."
 echo "Run '${IMAGE_BUILD_CMD} push ${BUNDLE_FULL_IMAGE_NAME}'"
 echo
-${OPM} index add --bundles "${BUNDLE_IMGS}" --tag "${INDEX_FULL_IMAGE_NAME}"
+${OPM} index add --container-tool "${IMAGE_BUILD_CMD}" --bundles "${BUNDLE_IMGS}" --tag "${INDEX_FULL_IMAGE_NAME}"
 
 echo
 echo "Run '${IMAGE_BUILD_CMD} push ${INDEX_FULL_IMAGE_NAME}' to push operator index to image registry."


### PR DESCRIPTION
opm uses podman by default, with --container-tool it will use the given
one.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>