### PR TITLE
controllers: change resourceManager interface

### DIFF
--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -105,7 +105,7 @@ func TestEnsureCephCluster(t *testing.T) {
 		}
 
 		var obj ocsCephCluster
-		err := obj.ensureCreated(&reconciler, sc)
+		_, err := obj.ensureCreated(&reconciler, sc)
 		assert.NilError(t, err)
 
 		actual := &cephv1.CephCluster{}
@@ -165,7 +165,7 @@ func TestCephClusterMonTimeout(t *testing.T) {
 		}
 
 		var obj ocsCephCluster
-		err := obj.ensureCreated(&reconciler, sc)
+		_, err := obj.ensureCreated(&reconciler, sc)
 		assert.NilError(t, err)
 
 		cc := newCephCluster(sc, "", 3, reconciler.serverVersion, nil, log)
@@ -511,7 +511,7 @@ func assertCephClusterKMSConfiguration(t *testing.T, kmsArgs struct {
 	// have to initialize the image status,
 	// without which the code will throw a 'nil pointer' exception
 	reconciler.initializeImagesStatus(cr)
-	err := obj.ensureCreated(&reconciler, cr)
+	_, err := obj.ensureCreated(&reconciler, cr)
 	if kmsArgs.failureExpected && err == nil {
 		// case 1: if a failure is expected and we don't receive any error
 		t.Errorf("Failed: %q. Expected an error", kmsArgs.testLabel)

--- a/controllers/storagecluster/cephconfig_test.go
+++ b/controllers/storagecluster/cephconfig_test.go
@@ -131,7 +131,7 @@ func TestDualStack(t *testing.T) {
 			Spec:       api.StorageClusterSpec{Network: &testCase.rookCephNetworkSpec},
 		}
 		cephConfigReconciler := &ocsCephConfig{}
-		err := cephConfigReconciler.ensureCreated(&r, sc)
+		_, err := cephConfigReconciler.ensureCreated(&r, sc)
 		if err != nil {
 			assert.NilError(t, err, "ensure created failed")
 		}

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type ocsCephFilesystems struct{}
@@ -59,15 +60,15 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initData *ocsv1.St
 
 // ensureCreated ensures that cephFilesystem resources exist in the desired
 // state.
-func (obj *ocsCephFilesystems) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (obj *ocsCephFilesystems) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 	reconcileStrategy := ReconcileStrategy(instance.Spec.ManagedResources.CephFilesystems.ReconcileStrategy)
 	if reconcileStrategy == ReconcileStrategyIgnore {
-		return nil
+		return reconcile.Result{}, nil
 	}
 
 	cephFilesystems, err := r.newCephFilesystemInstances(instance)
 	if err != nil {
-		return err
+		return reconcile.Result{}, err
 	}
 	for _, cephFilesystem := range cephFilesystems {
 		existing := cephv1.CephFilesystem{}
@@ -75,11 +76,11 @@ func (obj *ocsCephFilesystems) ensureCreated(r *StorageClusterReconciler, instan
 		switch {
 		case err == nil:
 			if reconcileStrategy == ReconcileStrategyInit {
-				return nil
+				return reconcile.Result{}, nil
 			}
 			if existing.DeletionTimestamp != nil {
 				r.Log.Info("Unable to restore CephFileSystem because it is marked for deletion.", "CephFileSystem", klog.KRef(existing.Namespace, existing.Name))
-				return fmt.Errorf("failed to restore initialization object %s because it is marked for deletion", existing.Name)
+				return reconcile.Result{}, fmt.Errorf("failed to restore initialization object %s because it is marked for deletion", existing.Name)
 			}
 
 			r.Log.Info("Restoring original CephFilesystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
@@ -88,27 +89,27 @@ func (obj *ocsCephFilesystems) ensureCreated(r *StorageClusterReconciler, instan
 			err = r.Client.Update(context.TODO(), &existing)
 			if err != nil {
 				r.Log.Error(err, "Unable to update CephFileSystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
-				return err
+				return reconcile.Result{}, err
 			}
 		case errors.IsNotFound(err):
 			r.Log.Info("Creating CephFileSystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
 			err = r.Client.Create(context.TODO(), cephFilesystem)
 			if err != nil {
 				r.Log.Error(err, "Unable to create CephFileSystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
-				return err
+				return reconcile.Result{}, err
 			}
 		}
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // ensureDeleted deletes the CephFilesystems owned by the StorageCluster
-func (obj *ocsCephFilesystems) ensureDeleted(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) error {
+func (obj *ocsCephFilesystems) ensureDeleted(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
 	foundCephFilesystem := &cephv1.CephFilesystem{}
 	cephFilesystems, err := r.newCephFilesystemInstances(sc)
 	if err != nil {
-		return err
+		return reconcile.Result{}, err
 	}
 
 	for _, cephFilesystem := range cephFilesystems {
@@ -119,7 +120,7 @@ func (obj *ocsCephFilesystems) ensureDeleted(r *StorageClusterReconciler, sc *oc
 				continue
 			}
 			r.Log.Error(err, "Uninstall: Unable to retrieve CephFileSystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
-			return fmt.Errorf("uninstall: Unable to retrieve CephFileSystem %v: %v", cephFilesystem.Name, err)
+			return reconcile.Result{}, fmt.Errorf("uninstall: Unable to retrieve CephFileSystem %v: %v", cephFilesystem.Name, err)
 		}
 
 		if cephFilesystem.GetDeletionTimestamp().IsZero() {
@@ -127,7 +128,7 @@ func (obj *ocsCephFilesystems) ensureDeleted(r *StorageClusterReconciler, sc *oc
 			err = r.Client.Delete(context.TODO(), foundCephFilesystem)
 			if err != nil {
 				r.Log.Error(err, "Uninstall: Failed to delete CephFileSystem.", "CephFileSystem", klog.KRef(foundCephFilesystem.Namespace, foundCephFilesystem.Name))
-				return fmt.Errorf("uninstall: Failed to delete CephFileSystem %v: %v", foundCephFilesystem.Name, err)
+				return reconcile.Result{}, fmt.Errorf("uninstall: Failed to delete CephFileSystem %v: %v", foundCephFilesystem.Name, err)
 			}
 		}
 
@@ -139,8 +140,8 @@ func (obj *ocsCephFilesystems) ensureDeleted(r *StorageClusterReconciler, sc *oc
 			}
 		}
 		r.Log.Error(err, "Uninstall: Waiting for CephFileSystem to be deleted.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
-		return fmt.Errorf("uninstall: Waiting for CephFileSystem %v to be deleted", cephFilesystem.Name)
+		return reconcile.Result{}, fmt.Errorf("uninstall: Waiting for CephFileSystem %v to be deleted", cephFilesystem.Name)
 
 	}
-	return nil
+	return reconcile.Result{}, nil
 }

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -228,21 +229,21 @@ func (r *StorageClusterReconciler) newExternalCephObjectStoreInstances(
 
 // ensureCreated ensures that requested resources for the external cluster
 // being created
-func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 	if r.sameExternalSecretData(instance) {
-		return nil
+		return reconcile.Result{}, nil
 	}
 	err := r.createExternalStorageClusterResources(instance)
 	if err != nil {
 		r.Log.Error(err, "Could not create ExternalStorageClusterResource.", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
-		return err
+		return reconcile.Result{}, err
 	}
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // ensureDeleted is dummy func for the ocsExternalResources
-func (obj *ocsExternalResources) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
-	return nil
+func (obj *ocsExternalResources) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
 }
 
 // createExternalStorageClusterResources creates external cluster resources

--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var extendClusterCommand = []string{
@@ -36,7 +37,7 @@ var osdCleanupArgs = []string{
 }
 
 // ensureCreated ensures if the osd removal job template exists
-func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) error {
+func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
 
 	tempFuncs := []func(*ocsv1.StorageCluster) *openshiftv1.Template{
 		osdCleanUpTemplate,
@@ -50,16 +51,16 @@ func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1
 		})
 
 		if err != nil && !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create Template : %v", err.Error())
+			return reconcile.Result{}, fmt.Errorf("failed to create Template : %v", err.Error())
 		}
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // ensureDeleted is dummy func for the ocsJobTemplates
-func (obj *ocsJobTemplates) ensureDeleted(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) error {
-	return nil
+func (obj *ocsJobTemplates) ensureDeleted(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
 }
 
 func osdCleanUpTemplate(sc *ocsv1.StorageCluster) *openshiftv1.Template {
@@ -77,8 +78,8 @@ func osdCleanUpTemplate(sc *ocsv1.StorageCluster) *openshiftv1.Template {
 				DisplayName: "OSD IDs",
 				Required:    true,
 				Description: `
-The parameter OSD IDs needs a comma-separated list of numerical FAILED_OSD_IDs 
-when a single job removes multiple OSDs. 
+The parameter OSD IDs needs a comma-separated list of numerical FAILED_OSD_IDs
+when a single job removes multiple OSDs.
 OSD removal is an advanced use case.
 In the event of errors or invalid user inputs,
 the Job will attempt to remove as many OSDs as can be processed and complete without returning an error condition.

--- a/controllers/storagecluster/noobaa_system_reconciler_test.go
+++ b/controllers/storagecluster/noobaa_system_reconciler_test.go
@@ -117,7 +117,7 @@ func TestEnsureNooBaaSystem(t *testing.T) {
 			err := reconciler.Client.Create(context.TODO(), &c.noobaa)
 			assert.NoError(t, err)
 		}
-		err := obj.ensureCreated(&reconciler, &sc)
+		_, err := obj.ensureCreated(&reconciler, &sc)
 		assert.NoError(t, err)
 
 		_ = reconciler.Client.Get(context.TODO(), namespacedName, &noobaa)
@@ -215,10 +215,10 @@ func TestNooBaaReconcileStrategy(t *testing.T) {
 		err := reconciler.Client.Create(context.TODO(), &cephCluster)
 		assert.NoError(t, err)
 
-		err = obj.ensureCreated(&reconciler, &c.sc)
+		_, err = obj.ensureCreated(&reconciler, &c.sc)
 		assert.NoError(t, err)
 
-		err = obj.ensureCreated(&reconciler, &c.sc)
+		_, err = obj.ensureCreated(&reconciler, &c.sc)
 		assert.NoError(t, err)
 
 		noobaa := v1alpha1.NooBaa{}
@@ -373,7 +373,7 @@ func assertNoobaaResource(t *testing.T, reconciler StorageClusterReconciler) {
 	err = reconciler.Client.Update(context.TODO(), foundCeph)
 	assert.NoError(t, err)
 	// calling 'ensureNoobaaSystem()' function and the expectation is that 'Noobaa' system is not be created
-	err = obj.ensureCreated(&reconciler, cr)
+	_, err = obj.ensureCreated(&reconciler, cr)
 	assert.NoError(t, err)
 	fNoobaa := &v1alpha1.NooBaa{}
 	request.Name = "noobaa"
@@ -387,7 +387,7 @@ func assertNoobaaResource(t *testing.T, reconciler StorageClusterReconciler) {
 	assert.NoError(t, err)
 	// call 'ensureNoobaaSystem()' to make sure it takes appropriate action
 	// when ceph cluster is connected to an external cluster
-	err = obj.ensureCreated(&reconciler, cr)
+	_, err = obj.ensureCreated(&reconciler, cr)
 	assert.NoError(t, err)
 	fNoobaa = &v1alpha1.NooBaa{}
 	request.Name = "noobaa"
@@ -459,7 +459,7 @@ func assertNoobaaKMSConfiguration(t *testing.T, kmsArgs struct {
 
 	var obj ocsCephCluster
 
-	err := obj.ensureCreated(&reconciler, cr)
+	_, err := obj.ensureCreated(&reconciler, cr)
 	if kmsArgs.failureExpected && err == nil {
 		// case 1: if we are expecting a failure and returned error is 'nil'
 		t.Errorf("Expecting the cephcluster creation to fail")
@@ -487,7 +487,7 @@ func assertNoobaaKMSConfiguration(t *testing.T, kmsArgs struct {
 
 	var objNoobaa ocsNoobaaSystem
 
-	err = objNoobaa.ensureCreated(&reconciler, cr)
+	_, err = objNoobaa.ensureCreated(&reconciler, cr)
 	assert.NoError(t, err, fmt.Sprintf("Failed to ensure Noobaa system: %v, %v", err, kmsArgs.testLabel))
 	nb := &v1alpha1.NooBaa{}
 	err = reconciler.Client.Get(ctxTodo, types.NamespacedName{Name: "noobaa"}, nb)

--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	"github.com/red-hat-storage/ocs-operator/controllers/util"
@@ -26,7 +27,7 @@ const (
 
 type ocsProviderServer struct{}
 
-func (o *ocsProviderServer) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (o *ocsProviderServer) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
 	if !instance.Spec.AllowRemoteStorageConsumers {
 		r.Log.Info("Spec.AllowRemoteStorageConsumers is disabled")
@@ -49,10 +50,10 @@ func (o *ocsProviderServer) ensureCreated(r *StorageClusterReconciler, instance 
 		}
 	}
 
-	return finalErr
+	return reconcile.Result{}, finalErr
 }
 
-func (o *ocsProviderServer) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (o *ocsProviderServer) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
 	// We do not check instance.Spec.AllowRemoteStorageConsumers because provider can disable this functionality
 	// and we need to delete the resources even the flag is not enabled (uninstall case).
@@ -81,7 +82,7 @@ func (o *ocsProviderServer) ensureDeleted(r *StorageClusterReconciler, instance 
 		r.Log.Info("Resource deletion for provider succeeded")
 	}
 
-	return finalErr
+	return reconcile.Result{}, finalErr
 }
 
 func (o *ocsProviderServer) createDeployment(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {

--- a/controllers/storagecluster/storagequota_test.go
+++ b/controllers/storagecluster/storagequota_test.go
@@ -82,10 +82,10 @@ func TestStorageQuotaEnsureCreatedDeleted(t *testing.T) {
 	for _, tc := range testcases {
 		var obj ocsStorageQuota
 		r := createFakeStorageClusterWithQuotaReconciler(t)
-		err := obj.ensureCreated(r, tc.storageCluster)
+		_, err := obj.ensureCreated(r, tc.storageCluster)
 		assert.NoError(t, err)
 		assert.Equal(t, len(listStorageQuotas(t, r)), len(tc.storageCluster.Spec.OverprovisionControl))
-		err = obj.ensureDeleted(r, tc.storageCluster)
+		_, err = obj.ensureDeleted(r, tc.storageCluster)
 		assert.NoError(t, err)
 		assert.Equal(t, len(listStorageQuotas(t, r)), 0)
 	}
@@ -95,10 +95,10 @@ func TestStorageQuotaWithFullStorageCluster(t *testing.T) {
 	sc := createStorageClusterWithOverprovision()
 
 	var obj ocsStorageQuota
-	err := obj.ensureCreated(r, sc)
+	_, err := obj.ensureCreated(r, sc)
 	assert.NoError(t, err)
 	assert.Equal(t, len(listStorageQuotas(t, r)), len(sc.Spec.OverprovisionControl))
-	err = obj.ensureDeleted(r, sc)
+	_, err = obj.ensureDeleted(r, sc)
 	assert.NoError(t, err)
 	assert.Equal(t, len(listStorageQuotas(t, r)), 0)
 }

--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,18 +23,18 @@ import (
 type ocsTopologyMap struct{}
 
 // ensureCreated ensures that StorageCluster.Status.Topology is up to date
-func (obj *ocsTopologyMap) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (obj *ocsTopologyMap) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 	if err := r.reconcileNodeTopologyMap(instance); err != nil {
 		r.Log.Error(err, "Failed to set node Topology Map for StorageCluster.", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
-		return err
+		return reconcile.Result{}, err
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // ensureDeleted is dummy func for the ocsTopologyMap
-func (obj *ocsTopologyMap) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
-	return nil
+func (obj *ocsTopologyMap) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
 }
 
 func (r *StorageClusterReconciler) getStorageClusterEligibleNodes(sc *ocsv1.StorageCluster) (nodes *corev1.NodeList, err error) {

--- a/controllers/storagecluster/uninstall_reconciler_test.go
+++ b/controllers/storagecluster/uninstall_reconciler_test.go
@@ -144,7 +144,7 @@ func assertTestDeleteStorageClasses(t *testing.T, reconciler StorageClusterRecon
 
 	var obj ocsStorageClass
 	if !storageClassExists {
-		err := obj.ensureDeleted(&reconciler, sc)
+		_, err := obj.ensureDeleted(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -157,7 +157,7 @@ func assertTestDeleteStorageClasses(t *testing.T, reconciler StorageClusterRecon
 		assert.Equal(t, !storageClassExists, errors.IsNotFound(err))
 	}
 
-	err = obj.ensureDeleted(&reconciler, sc)
+	_, err = obj.ensureDeleted(&reconciler, sc)
 	assert.NoError(t, err)
 
 	for _, scc := range sccs {
@@ -200,7 +200,7 @@ func assertTestDeleteSnapshotClasses(
 	var obj ocsSnapshotClass
 
 	if !SnapshotClassExists {
-		err := obj.ensureCreated(&reconciler, sc)
+		_, err := obj.ensureCreated(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -212,7 +212,7 @@ func assertTestDeleteSnapshotClasses(
 		assert.Equal(t, !SnapshotClassExists, errors.IsNotFound(err))
 	}
 
-	err := obj.ensureCreated(&reconciler, sc)
+	_, err := obj.ensureCreated(&reconciler, sc)
 	assert.NoError(t, err)
 
 	for _, vssc := range vsscs {
@@ -420,7 +420,7 @@ func assertTestDeleteCephCluster(
 	var obj ocsCephCluster
 
 	if !cephClusterExist {
-		err := obj.ensureDeleted(&reconciler, sc)
+		_, err := obj.ensureDeleted(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -434,7 +434,7 @@ func assertTestDeleteCephCluster(
 		assert.True(t, errors.IsNotFound(err))
 	}
 
-	err = obj.ensureDeleted(&reconciler, sc)
+	_, err = obj.ensureDeleted(&reconciler, sc)
 	assert.NoError(t, err)
 
 	cephCluster = &cephv1.CephCluster{}
@@ -476,7 +476,7 @@ func assertTestDeleteCephFilesystems(
 	var obj ocsCephFilesystems
 
 	if !cephFilesystemsExist {
-		err := obj.ensureDeleted(&reconciler, sc)
+		_, err := obj.ensureDeleted(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -495,7 +495,7 @@ func assertTestDeleteCephFilesystems(
 		}
 	}
 
-	err = obj.ensureDeleted(&reconciler, sc)
+	_, err = obj.ensureDeleted(&reconciler, sc)
 	assert.NoError(t, err)
 
 	for _, cephFilesystem := range cephFilesystems {
@@ -540,7 +540,7 @@ func assertTestDeleteCephBlockPools(
 	var obj ocsCephBlockPools
 
 	if !cephBlockPoolsExist {
-		err := obj.ensureDeleted(&reconciler, sc)
+		_, err := obj.ensureDeleted(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -559,7 +559,7 @@ func assertTestDeleteCephBlockPools(
 		}
 	}
 
-	err = obj.ensureDeleted(&reconciler, sc)
+	_, err = obj.ensureDeleted(&reconciler, sc)
 	assert.NoError(t, err)
 
 	for _, cephBlockPool := range cephBlockPools {
@@ -632,7 +632,7 @@ func assertTestDeleteCephObjectStoreUsers(
 	var obj ocsCephObjectStoreUsers
 
 	if !CephObjectStoreUsersExist {
-		err := obj.ensureDeleted(&reconciler, sc)
+		_, err := obj.ensureDeleted(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -651,7 +651,7 @@ func assertTestDeleteCephObjectStoreUsers(
 		}
 	}
 
-	err = obj.ensureDeleted(&reconciler, sc)
+	_, err = obj.ensureDeleted(&reconciler, sc)
 	assert.NoError(t, err)
 
 	for _, cephStoreUser := range cephStoreUsers {
@@ -731,7 +731,7 @@ func assertTestDeleteCephObjectStores(
 	var obj ocsCephObjectStores
 
 	if !CephObjectStoreExist {
-		err := obj.ensureDeleted(&reconciler, sc)
+		_, err := obj.ensureDeleted(&reconciler, sc)
 		assert.NoError(t, err)
 	}
 
@@ -750,7 +750,7 @@ func assertTestDeleteCephObjectStores(
 		}
 	}
 
-	err = obj.ensureDeleted(&reconciler, sc)
+	_, err = obj.ensureDeleted(&reconciler, sc)
 	assert.NoError(t, err)
 
 	for _, cephStore := range cephStores {

--- a/controllers/storagecluster/volumesnapshotterclasses.go
+++ b/controllers/storagecluster/volumesnapshotterclasses.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
@@ -128,19 +129,19 @@ func (r *StorageClusterReconciler) createSnapshotClasses(vsccs []SnapshotClassCo
 }
 
 // ensureCreated functions ensures that snpashotter classes are created
-func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 	vsccs := newSnapshotClassConfigurations(instance)
 
 	err := r.createSnapshotClasses(vsccs)
 	if err != nil {
-		return nil
+		return reconcile.Result{}, nil
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // ensureDeleted deletes the SnapshotClasses that the ocs-operator created
-func (obj *ocsSnapshotClass) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func (obj *ocsSnapshotClass) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
 	vsccs := newSnapshotClassConfigurations(instance)
 	for _, vscc := range vsccs {
@@ -169,5 +170,5 @@ func (obj *ocsSnapshotClass) ensureDeleted(r *StorageClusterReconciler, instance
 			r.Log.Error(err, "Uninstall: Error while getting SnapshotClass.", "SnapshotClass", klog.KRef(sc.Namespace, sc.Name))
 		}
 	}
-	return nil
+	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
With the current resourceManager interface there is no way to
communicate the reconcile.Result back to the reconcilePhases as it only
returns the error.

change the interface signature to return the reconcile.Result as well
with the error.

Why?
The change is required for ocs to ocs where we want to communicate the
reconcile.Result to the reconcilePhases.
    
While making GPRC calls we will get different error codes and based on
those error codes we will decide whether we need to requeue or not if
requeue when to requeue and this can be done with reconcile.Result. With
the existing design, we can return only errors and reconcile will get
requeue. That's why we are changing the interface to return the
reconcile.Result also.
    
Usecase:
let's say a user will create a storageCluster CR with the wrong
connection string and while making an onboarding request we will get an
error that says invalid connection string. This means there is no point
in re queueing at all as this can not be solved without user interaction.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>