### PR TITLE
update mock provider api

### DIFF
--- a/services/provider/client/client.go
+++ b/services/provider/client/client.go
@@ -21,11 +21,20 @@ func NewProviderClient(cc *grpc.ClientConn, timeout time.Duration) *OCSProviderC
 
 // NewGRPCConnection returns a grpc client connection which can be used to create the consumer client
 // Note: Close the connection after use
-func NewGRPCConnection(serverAddr string, opts []grpc.DialOption) (*grpc.ClientConn, error) {
-	conn, err := grpc.Dial(serverAddr, opts...)
+func NewGRPCConnection(serverAddr string, timeout time.Duration) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+	}
+
+	conn, err := grpc.DialContext(ctx, serverAddr, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %v", err)
 	}
+
 	return conn, err
 }
 

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -54,7 +54,7 @@ func (c *ocsProviderServer) UpdateCapacity(ctx context.Context, req *pb.UpdateCa
 }
 
 func Start(port int, opts []grpc.ServerOption) {
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		klog.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
- Use `DialContext` instead of `Dial`. This helps to pass context with
  timeout.
- Update NewGRPCConnection to create DialOption
- Remove `localhost` from server address

Signed-off-by: Santosh Pillai <sapillai@redhat.com>