### PR TITLE
controllers: always fetch the secret and store it in the map

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -261,16 +261,16 @@ func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, inst
 		externalClusterClient.Close()
 	} else {
 		// rhcs external mode
-		if r.sameExternalSecretData(instance) {
-			return reconcile.Result{}, nil
-		}
-
 		data, err := r.retrieveExternalSecretData(instance)
 		if err != nil {
 			r.Log.Error(err, "Failed to retrieve external secret resources.")
 			return reconcile.Result{}, err
 		}
 		externalOCSResources[instance.UID] = data
+
+		if r.sameExternalSecretData(instance) {
+			return reconcile.Result{}, nil
+		}
 	}
 
 	err := r.createExternalStorageClusterResources(instance)


### PR DESCRIPTION
after restarting a operator it was getting returned if there is no
change in the secret without saving the secret into the map and
cephcluster func is complaining that it can not found the secret in the
map. change the order of the if statement to always save the secret data
in the map.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>