### PR TITLE
Add HPCS secret name to Ceph and NooBaa CR

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -421,8 +421,12 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 			}
 			// Set TokenSecretName only for vault token based auth method
 			if kmsConfigMap.Data["VAULT_AUTH_METHOD"] == VaultTokenAuthMethod {
+				// Secret is created by UI in "openshift-storage" namespace
 				cephCluster.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName
 			}
+		} else if kmsConfigMap.Data["KMS_PROVIDER"] == IbmKeyProtectKMSProvider {
+			// Secret is created by UI in "openshift-storage" namespace
+			cephCluster.Spec.Security.KeyManagementService.TokenSecretName = kmsConfigMap.Data["IBM_KP_SECRET_NAME"]
 		}
 		cephCluster.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfigMap.Data
 	}

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -466,10 +466,10 @@ func createDummyKMSConfigMap(kmsProvider, kmsAddr string, kmsAuthMethod string) 
 		cm.Data["VAULT_BACKEND_PATH"] = "ocs"
 		cm.Data["VAULT_NAMESPACE"] = "my-ocs-namespace"
 	case IbmKeyProtectKMSProvider:
-		cm.Data["IBM_SERVICE_INSTANCE_ID"] = "my-instance-id"
-		cm.Data["IBM_KMS_KEY"] = "my-kms-key"
-		cm.Data["IBM_BASE_URL"] = "my-base-url"
-		cm.Data["IBM_TOKEN_URL"] = "my-token-url"
+		cm.Data["IBM_KP_SERVICE_INSTANCE_ID"] = "my-instance-id"
+		cm.Data["IBM_KP_SECRET_NAME"] = "my-kms-key"
+		cm.Data["IBM_KP_BASE_URL"] = "my-base-url"
+		cm.Data["IBM_KP_TOKEN_URL"] = "my-token-url"
 	}
 	return cm
 }

--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -200,8 +200,12 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 				}
 				// Set TokenSecretName only for vault token based auth method
 				if kmsConfig.Data["VAULT_AUTH_METHOD"] == VaultTokenAuthMethod {
+					// Secret is created by UI in "openshift-storage" namespace
 					nb.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName
 				}
+			} else if kmsConfig.Data["KMS_PROVIDER"] == IbmKeyProtectKMSProvider {
+				// Secret is created by UI in "openshift-storage" namespace
+				nb.Spec.Security.KeyManagementService.TokenSecretName = kmsConfig.Data["IBM_KP_SECRET_NAME"]
 			}
 			nb.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfig.Data
 		}


### PR DESCRIPTION
For HPCS KMS, UI creates a `Secret` (containing `IBM_KP_SERVICE_API_KEY` & `IBM_KP_CUSTOMER_ROOT_KEY`) in `openshift-storage` namespace. Name of that `Secret` needs to be passed in:
```
cephCluster.Spec.Security.KeyManagementService.TokenSecretName
nooBaa.Spec.Security.KeyManagementService.TokenSecretName
```
BZ#2047201

Signed-off-by: SanjalKatiyar <sanjaldhir@gmail.com>