### PR TITLE
enables csi-addons sidecar in configmap

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -345,6 +345,7 @@ func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
 	data["CSI_PROVISIONER_TOLERATIONS"] = defaultCSIToleration
 	data["CSI_PLUGIN_TOLERATIONS"] = defaultCSIToleration
 	data["CSI_LOG_LEVEL"] = "5"
+	data["CSI_ENABLE_CSIADDONS"] = "true"
 	config.Data = data
 
 	return config


### PR DESCRIPTION
This commit updates the configmap rook-ceph-operator-config
to include CSI_ENABLE_CSIADDONS: "true" so that rook can deploy
ceph-csi with csi-addons sidecar

BZ: #2043028

Signed-off-by: yati1998 <ypadia@redhat.com>