### PR TITLE
api: split connection string into 2 new fields

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -162,9 +162,11 @@ type ExternalStorageClusterSpec struct {
 	// StorageProviderKind Identify the type of storage provider cluster this consumer cluster is going to connect to.
 	StorageProviderKind ExternalStorageKind `json:"storageProviderKind,omitempty"`
 
-	// ConnectionString An encoded string holding connection and identity information
-	// that is needed in order to establish connection with the storage providing cluster.
-	ConnectionString string `json:"connectionString,omitempty"`
+	// StorageProviderEndpoint holds info to establish connection with the storage providing cluster.
+	StorageProviderEndpoint string `json:"storageProviderEndpoint,omitempty"`
+
+	// OnboardingTicket holds an identity information required for consumer to onboard.
+	OnboardingTicket string `json:"onboardingTicket,omitempty"`
 
 	// RequestedCapacity Will define the desired capacity requested by a consumer cluster.
 	RequestedCapacity *resource.Quantity `json:"requestedCapacity,omitempty"`

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -307,13 +307,12 @@ spec:
                   set to true, OCS will connect to an external OCS Storage Cluster
                   instead of provisioning one locally.
                 properties:
-                  connectionString:
-                    description: ConnectionString An encoded string holding connection
-                      and identity information that is needed in order to establish
-                      connection with the storage providing cluster.
-                    type: string
                   enable:
                     type: boolean
+                  onboardingTicket:
+                    description: OnboardingTicket holds an identity information required
+                      for consumer to onboard.
+                    type: string
                   requestedCapacity:
                     anyOf:
                     - type: integer
@@ -322,6 +321,10 @@ spec:
                       requested by a consumer cluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  storageProviderEndpoint:
+                    description: StorageProviderEndpoint holds info to establish connection
+                      with the storage providing cluster.
+                    type: string
                   storageProviderKind:
                     description: StorageProviderKind Identify the type of storage
                       provider cluster this consumer cluster is going to connect to.

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -242,8 +242,12 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 		return err
 	}
 
-	if isExternalOCSProvider(instance) && (instance.Spec.ExternalStorage.ConnectionString == "" || instance.Spec.ExternalStorage.RequestedCapacity == nil) {
-		err := fmt.Errorf("spec.externalStorage.connectionString or spec.externalStorage.requestedCapacity" +
+	if isExternalOCSProvider(instance) &&
+		(instance.Spec.ExternalStorage.StorageProviderEndpoint == "" ||
+			instance.Spec.ExternalStorage.OnboardingTicket == "" ||
+			instance.Spec.ExternalStorage.RequestedCapacity == nil) {
+
+		err := fmt.Errorf("spec.externalStorage.storageProviderEndpoint or spec.externalStorage.onboardingTicket or spec.externalStorage.requestedCapacity" +
 			" can not be empty when spec.externalStorage.storageProviderKind is set to ocs")
 		r.Log.Error(err, "Failed to validate Spec for ExternalStorage", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
 		r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -305,13 +305,12 @@ spec:
                   set to true, OCS will connect to an external OCS Storage Cluster
                   instead of provisioning one locally.
                 properties:
-                  connectionString:
-                    description: ConnectionString An encoded string holding connection
-                      and identity information that is needed in order to establish
-                      connection with the storage providing cluster.
-                    type: string
                   enable:
                     type: boolean
+                  onboardingTicket:
+                    description: OnboardingTicket holds an identity information required
+                      for consumer to onboard.
+                    type: string
                   requestedCapacity:
                     anyOf:
                     - type: integer
@@ -320,6 +319,10 @@ spec:
                       requested by a consumer cluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  storageProviderEndpoint:
+                    description: StorageProviderEndpoint holds info to establish connection
+                      with the storage providing cluster.
+                    type: string
                   storageProviderKind:
                     description: StorageProviderKind Identify the type of storage
                       provider cluster this consumer cluster is going to connect to.

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -307,13 +307,12 @@ spec:
                   set to true, OCS will connect to an external OCS Storage Cluster
                   instead of provisioning one locally.
                 properties:
-                  connectionString:
-                    description: ConnectionString An encoded string holding connection
-                      and identity information that is needed in order to establish
-                      connection with the storage providing cluster.
-                    type: string
                   enable:
                     type: boolean
+                  onboardingTicket:
+                    description: OnboardingTicket holds an identity information required
+                      for consumer to onboard.
+                    type: string
                   requestedCapacity:
                     anyOf:
                     - type: integer
@@ -322,6 +321,10 @@ spec:
                       requested by a consumer cluster.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  storageProviderEndpoint:
+                    description: StorageProviderEndpoint holds info to establish connection
+                      with the storage providing cluster.
+                    type: string
                   storageProviderKind:
                     description: StorageProviderKind Identify the type of storage
                       provider cluster this consumer cluster is going to connect to.


### PR DESCRIPTION
remove connectionString and create 2 new fields:
- OnboardingTicket
- ExternalServerAddress

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
