### PR TITLE
api: Add StorageProviderEndpoint field in the storageCluster status 

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -348,6 +348,10 @@ type StorageClusterStatus struct {
 	// +optional
 	FailureDomainValues []string `json:"failureDomainValues,omitempty"`
 
+	// StorageProviderEndpoint holds endpoint info on Provider cluster which is required
+	// for consumer to establish connection with the storage providing cluster.
+	StorageProviderEndpoint string `json:"storageProviderEndpoint,omitempty"`
+
 	// ExternalSecretHash holds the checksum value of external secret data.
 	ExternalSecretHash string `json:"externalSecretHash,omitempty"`
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -4921,6 +4921,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              storageProviderEndpoint:
+                description: StorageProviderEndpoint holds endpoint info on Provider
+                  cluster which is required for consumer to establish connection with
+                  the storage providing cluster.
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/storagecluster/external_ocs.go
+++ b/controllers/storagecluster/external_ocs.go
@@ -59,7 +59,7 @@ func (r *StorageClusterReconciler) onboardConsumer(instance *ocsv1.StorageCluste
 		return reconcile.Result{}, err
 	}
 
-	name := fmt.Sprintf("ocs-consumer-%s", clusterVersion.Spec.ClusterID)
+	name := fmt.Sprintf("storageconsumer-%s", clusterVersion.Spec.ClusterID)
 	response, err := externalClusterClient.OnboardConsumer(
 		context.Background(), instance.Spec.ExternalStorage.OnboardingTicket, name,
 		instance.Spec.ExternalStorage.RequestedCapacity.String())

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -4919,6 +4919,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              storageProviderEndpoint:
+                description: StorageProviderEndpoint holds endpoint info on Provider
+                  cluster which is required for consumer to establish connection with
+                  the storage providing cluster.
+                type: string
             type: object
         type: object
     served: true

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -4921,6 +4921,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              storageProviderEndpoint:
+                description: StorageProviderEndpoint holds endpoint info on Provider
+                  cluster which is required for consumer to establish connection with
+                  the storage providing cluster.
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
StorageProviderEndpoint will be used to save the endpoint info on the
provider cluster.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>