### PR TITLE
expose option to force remove the OSD in osd removal template

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -34,6 +34,8 @@ var osdCleanupArgs = []string{
 	"osd",
 	"remove",
 	"--osd-ids=${FAILED_OSD_IDS}",
+	"--force-osd-removal",
+	"${FORCE_OSD_REMOVAL}",
 }
 
 // ensureCreated ensures if the osd removal job template exists
@@ -84,6 +86,17 @@ OSD removal is an advanced use case.
 In the event of errors or invalid user inputs,
 the Job will attempt to remove as many OSDs as can be processed and complete without returning an error condition.
 Users should always check for errors and success in the log of the finished OSD removal Job.`,
+			},
+			{
+				Name:        "FORCE_OSD_REMOVAL",
+				DisplayName: "Force OSD Removal",
+				Required:    false,
+				Value:       "false",
+				Description: `
+A flag indicating whether the OSD should be forcefully removed. Valid values are true or false.
+The default value is false. If an OSD is being removed that could lead to data loss, the OSD
+will not be removed by default. If you see the osd removal fails and you are sure the OSD
+should be removed, set this flag to true and run the job again.`,
 			},
 		},
 		Objects: []runtime.RawExtension{

--- a/controllers/storagecluster/job_templates_test.go
+++ b/controllers/storagecluster/job_templates_test.go
@@ -23,7 +23,7 @@ func TestJobTemplates(t *testing.T) {
 	}{
 		{
 			jobTemplateName:    "ocs-osd-removal",
-			templateParameters: []string{"FAILED_OSD_IDS"},
+			templateParameters: []string{"FAILED_OSD_IDS", "FORCE_OSD_REMOVAL"},
 			jobCmds:            osdCleanupArgs,
 			jobFunc:            newosdCleanUpJob,
 		},


### PR DESCRIPTION
adding option to expose `--force-osd-removal` `<true/false>`.
It will help when Ceph indicates the OSD is not safe-to-destroy.

Signed-off-by: subhamkrai <srai@redhat.com>