### PR TITLE
Update CSV merger to inject Volume Replication Operator CRDs

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1436,7 +1436,7 @@ metadata:
       \   }\n\t"
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
-    operators.operatorframework.io/internal-objects: '["ocsinitializations.ocs.openshift.io","storageconsumers.ocs.openshift.io","cephclusters.ceph.rook.io","cephobjectstores.ceph.rook.io","cephobjectstoreusers.ceph.rook.io","cephnfses.ceph.rook.io","cephclients.ceph.rook.io","cephfilesystems.ceph.rook.io","cephfilesystemmirrors.ceph.rook.io","cephrbdmirrors.ceph.rook.io","cephobjectrealms.ceph.rook.io","cephobjectzonegroups.ceph.rook.io","cephobjectzones.ceph.rook.io","cephbucketnotifications.ceph.rook.io","cephbuckettopics.ceph.rook.io","cephfilesystemsubvolumegroups.ceph.rook.io","objectbucketclaims.objectbucket.io","objectbuckets.objectbucket.io","objectbucketclaims.objectbucket.io","objectbuckets.objectbucket.io"]'
+    operators.operatorframework.io/internal-objects: '["ocsinitializations.ocs.openshift.io","storageconsumers.ocs.openshift.io","cephclusters.ceph.rook.io","cephobjectstores.ceph.rook.io","cephobjectstoreusers.ceph.rook.io","cephnfses.ceph.rook.io","cephclients.ceph.rook.io","cephfilesystems.ceph.rook.io","cephfilesystemmirrors.ceph.rook.io","cephrbdmirrors.ceph.rook.io","cephobjectrealms.ceph.rook.io","cephobjectzonegroups.ceph.rook.io","cephobjectzones.ceph.rook.io","cephbucketnotifications.ceph.rook.io","cephbuckettopics.ceph.rook.io","cephfilesystemsubvolumegroups.ceph.rook.io","objectbucketclaims.objectbucket.io","objectbuckets.objectbucket.io","objectbucketclaims.objectbucket.io","objectbuckets.objectbucket.io","volumereplications.replication.storage.openshift.io","volumereplicationclasses.replication.storage.openshift.io"]'
     operators.operatorframework.io/operator-type: non-standalone
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/red-hat-storage/ocs-operator
@@ -1687,6 +1687,19 @@ spec:
       - kind: StatefulSet
         name: statefulsets.apps
         version: v1
+      version: v1alpha1
+    - description: VolumeReplication is a namespaced resource that contains references
+        to storage object to be replicated and VolumeReplicationClass corresponding
+        to the driver providing replication.
+      displayName: Volume Replication
+      kind: VolumeReplication
+      name: volumereplications.replication.storage.openshift.io
+      version: v1alpha1
+    - description: VolumeReplicationClass is a cluster scoped resource that contains
+        driver related configuration parameters.
+      displayName: Volume Replication Class
+      kind: VolumeReplicationClass
+      name: volumereplicationclasses.replication.storage.openshift.io
       version: v1alpha1
     required:
     - description: A NooBaa system - Create this to start

--- a/deploy/bundle/manifests/volumereplication.crd.yaml
+++ b/deploy/bundle/manifests/volumereplication.crd.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: volumereplications.replication.storage.openshift.io
+spec:
+  group: replication.storage.openshift.io
+  names:
+    kind: VolumeReplication
+    listKind: VolumeReplicationList
+    plural: volumereplications
+    singular: volumereplication
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VolumeReplication is the Schema for the volumereplications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeReplicationSpec defines the desired state of VolumeReplication
+            properties:
+              dataSource:
+                description: DataSource represents the object associated with the
+                  volume
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              replicationState:
+                description: ReplicationState represents the replication operation
+                  to be performed on the volume. Supported operations are "primary",
+                  "secondary" and "resync"
+                type: string
+              volumeReplicationClass:
+                description: VolumeReplicationClass is the VolumeReplicationClass
+                  name for this VolumeReplication resource
+                type: string
+            required:
+            - dataSource
+            - replicationState
+            - volumeReplicationClass
+            type: object
+          status:
+            description: VolumeReplicationStatus defines the observed state of VolumeReplication
+            properties:
+              conditions:
+                description: Conditions are the list of conditions and their status.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastCompletionTime:
+                format: date-time
+                type: string
+              lastStartTime:
+                format: date-time
+                type: string
+              message:
+                type: string
+              observedGeneration:
+                description: observedGeneration is the last generation change the
+                  operator has dealt with
+                format: int64
+                type: integer
+              state:
+                description: State captures the latest state of the replication operation
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/bundle/manifests/volumereplicationclass.crd.yaml
+++ b/deploy/bundle/manifests/volumereplicationclass.crd.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: volumereplicationclasses.replication.storage.openshift.io
+spec:
+  group: replication.storage.openshift.io
+  names:
+    kind: VolumeReplicationClass
+    listKind: VolumeReplicationClassList
+    plural: volumereplicationclasses
+    singular: volumereplicationclass
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VolumeReplicationClass is the Schema for the volumereplicationclasses
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeReplicationClassSpec specifies parameters that an underlying
+              storage system uses when creating a volume replica. A specific VolumeReplicationClass
+              is used by specifying its name in a VolumeReplication object.
+            properties:
+              parameters:
+                additionalProperties:
+                  type: string
+                description: Parameters is a key-value map with storage provisioner
+                  specific configurations for creating volume replicas
+                type: object
+              provisioner:
+                description: Provisioner is the name of storage provisioner
+                type: string
+            required:
+            - provisioner
+            type: object
+          status:
+            description: VolumeReplicationClassStatus defines the observed state of
+              VolumeReplicationClass
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -404,10 +404,33 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
 	ocsCSV := unmarshalCSV(*ocsCSVStr)
 	rookCSV := unmarshalCSV(*rookCSVStr)
 	noobaaCSV := unmarshalCSV(*noobaaCSVStr)
+	volumeReplicationCSV := &csvv1.ClusterServiceVersion{
+		Spec: csvv1.ClusterServiceVersionSpec{
+			CustomResourceDefinitions: csvv1.CustomResourceDefinitions{
+				Owned: []csvv1.CRDDescription{
+					{
+						Name:        "volumereplications.replication.storage.openshift.io",
+						Kind:        "VolumeReplication",
+						Version:     "v1alpha1",
+						DisplayName: "Volume Replication",
+						Description: "VolumeReplication is a namespaced resource that contains references to storage object to be replicated and VolumeReplicationClass corresponding to the driver providing replication.",
+					},
+					{
+						Name:        "volumereplicationclasses.replication.storage.openshift.io",
+						Kind:        "VolumeReplicationClass",
+						Version:     "v1alpha1",
+						DisplayName: "Volume Replication Class",
+						Description: "VolumeReplicationClass is a cluster scoped resource that contains driver related configuration parameters.",
+					},
+				},
+			},
+		},
+	}
 
 	mergeCsvs := []*csvv1.ClusterServiceVersion{
 		rookCSV,
 		noobaaCSV,
+		volumeReplicationCSV,
 	}
 
 	ocsCSV.Spec.CustomResourceDefinitions.Required = nil


### PR DESCRIPTION
Volume Replication Operator CRDs are not owned by default.
Since it is the part of ocs-operator bundle, we manually
create a mock CSV for volume replication operator and allow
ocs-operator to assume ownership of it's resources.