### PR TITLE
update imagefeature in rbd storageclass

### DIFF
--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -214,7 +214,7 @@ func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) S
 			Parameters: map[string]string{
 				"clusterID":                 initData.Namespace,
 				"pool":                      generateNameForCephBlockPool(initData),
-				"imageFeatures":             "layering",
+				"imageFeatures":             "layering,deep-flatten,exclusive-lock,object-map,fast-diff",
 				"csi.storage.k8s.io/fstype": "ext4",
 				"imageFormat":               "2",
 				"csi.storage.k8s.io/provisioner-secret-name":            "rook-csi-rbd-provisioner",

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -577,7 +577,7 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 			rbdStorageClass := map[string]string{
 				"clusterID":                 s.namespace,
 				"pool":                      cephRes.Name,
-				"imageFeatures":             "layering",
+				"imageFeatures":             "layering,deep-flatten,exclusive-lock,object-map,fast-diff",
 				"csi.storage.k8s.io/fstype": "ext4",
 				"imageFormat":               "2",
 				"csi.storage.k8s.io/provisioner-secret-name":       provisionerCephClientSecret,


### PR DESCRIPTION
update the image feature from layering to layering,exclusive-lock,object-map,fast-diff as this is required to enable the DR workflow on the rbd images created by this storageclass, and also it provides more crash consistent rbd snapshots.

PS: Minimum kernel version required to map images
created from this storageclass is 8.2+

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>