### PR TITLE
update capacity only if requested and granted capacity are different

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -245,7 +245,7 @@ func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, inst
 			if err != nil || !res.IsZero() {
 				return res, err
 			}
-		} else if instance.Spec.ExternalStorage.RequestedCapacity.Equal(instance.Status.ExternalStorage.GrantedCapacity) {
+		} else if !instance.Spec.ExternalStorage.RequestedCapacity.Equal(instance.Status.ExternalStorage.GrantedCapacity) {
 			res, err := r.updateConsumerCapacity(instance, externalClusterClient)
 			if err != nil || !res.IsZero() {
 				return res, err


### PR DESCRIPTION
Storage Consumer should only call the `UpdateCapacity` grpc if the `Requested` and `Granted` capacity are different. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>