### PR TITLE
[WIP] skip verifying the storage provider server's cert and hostname

### DIFF
--- a/services/provider/client/client.go
+++ b/services/provider/client/client.go
@@ -2,11 +2,13 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
 	pb "github.com/red-hat-storage/ocs-operator/services/provider/pb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 type OCSProviderClient struct {
@@ -20,8 +22,12 @@ func NewProviderClient(ctx context.Context, serverAddr string, timeout time.Dura
 	apiCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	config := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
 	opts := []grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(credentials.NewTLS(config)),
 		grpc.WithBlock(),
 	}
 


### PR DESCRIPTION
InsecureSkipVerify controls whether a client verifies the server
certificate chain and host name. If InsecureSkipVerify is true, crypto/tls
accepts any certificate presented by the server and any host name in
that certificate

Signed-off-by: Santosh Pillai <sapillai@redhat.com>