### PR TITLE
ocs to ocs: small general fixes

### DIFF
--- a/controllers/storagecluster/external_ocs.go
+++ b/controllers/storagecluster/external_ocs.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
@@ -117,10 +118,8 @@ func (r *StorageClusterReconciler) updateConsumerCapacity(instance *ocsv1.Storag
 	}
 
 	if !instance.Spec.ExternalStorage.RequestedCapacity.Equal(responseQuantity) {
-		r.Log.Error(err, "GrantedCapacity is not equal to the RequestedCapacity in the UpdateCapacity response.",
+		klog.Warningf("GrantedCapacity is not equal to the RequestedCapacity in the UpdateCapacity response.",
 			"GrantedCapacity", response.GrantedCapacity, "RequestedCapacity", instance.Spec.ExternalStorage.RequestedCapacity)
-		r.Log.Error(err, "empty response")
-		return reconcile.Result{}, err
 	}
 
 	instance.Status.ExternalStorage.GrantedCapacity = responseQuantity

--- a/controllers/storagecluster/external_ocs.go
+++ b/controllers/storagecluster/external_ocs.go
@@ -33,8 +33,8 @@ const (
 	GetStorageConfig = "GetStorageConfig"
 )
 
-// isExternalOCSProvider returns true if it is ocs to ocs ExternalStorage consumer cluster
-func isExternalOCSProvider(instance *ocsv1.StorageCluster) bool {
+// isOCSConsumerMode returns true if it is ocs to ocs ExternalStorage consumer cluster
+func isOCSConsumerMode(instance *ocsv1.StorageCluster) bool {
 	return instance.Spec.ExternalStorage.Enable && instance.Spec.ExternalStorage.StorageProviderKind == ocsv1.KindOCS
 }
 

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -232,7 +232,7 @@ func (r *StorageClusterReconciler) newExternalCephObjectStoreInstances(
 // being created
 func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
-	if isExternalOCSProvider(instance) {
+	if isOCSConsumerMode(instance) {
 
 		externalClusterClient, err := r.newExternalClusterClient(instance)
 		if err != nil {
@@ -285,7 +285,7 @@ func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, inst
 // ensureDeleted is dummy func for the ocsExternalResources
 func (obj *ocsExternalResources) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
-	if isExternalOCSProvider(instance) {
+	if isOCSConsumerMode(instance) {
 
 		// skip offboarding if consumer is not onboarded
 		if instance.Status.ExternalStorage.ConsumerID == "" {

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -242,7 +242,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 		return err
 	}
 
-	if isExternalOCSProvider(instance) &&
+	if isOCSConsumerMode(instance) &&
 		(instance.Spec.ExternalStorage.StorageProviderEndpoint == "" ||
 			instance.Spec.ExternalStorage.OnboardingTicket == "" ||
 			instance.Spec.ExternalStorage.RequestedCapacity == nil) {


### PR DESCRIPTION
* updateConsumerCapacity was logging an error returning nil if
RequestedCapacity is not equal to the GrantedCapacity. Instead
we should log an warning and should not return.
* controllers: rename isExternalOCSProvider to isOCSConsumerMode


Signed-off-by: Nitin Goyal <nigoyal@redhat.com>