### PR TITLE
Update rbac to correctly read rook resources

### DIFF
--- a/deploy/bundle/manifests/provider-role.yaml
+++ b/deploy/bundle/manifests/provider-role.yaml
@@ -12,6 +12,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephfilesystemsubvolumegroups
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ocs.openshift.io
   resources:
   - storageconsumers

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -12,6 +12,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephfilesystemsubvolumegroups
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ocs.openshift.io
   resources:
   - storageconsumers

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -223,6 +223,10 @@ func newClient() (client.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to add ocsv1alpha1 to scheme. %v", err)
 	}
+	err = rookCephv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add rookCephv1 to scheme. %v", err)
+	}
 
 	config, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
- adds rule to read `cephfilesystemsubvolumegroups` for provider api server deployment.
- adds rookCephv1 to provider api scheme to read `cephclient` and `cephfilesystemsubvolumegroups`