### PR TITLE
Return granted capacity in UpdataCapacity grpc response

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -169,8 +169,7 @@ func (s *OCSProviderServer) UpdateCapacity(ctx context.Context, req *pb.UpdateCa
 		return nil, status.Errorf(codes.Internal, "failed to update capacity in the storageConsumer resource: %v", err)
 	}
 
-	// TODO: Return granted capacity correctly.
-	return &pb.UpdateCapacityResponse{}, nil
+	return &pb.UpdateCapacityResponse{GrantedCapacity: req.Capacity}, nil
 }
 
 // OffboardConsumer RPC call to delete the StorageConsumer CR


### PR DESCRIPTION
If the updateCapacity grpc call is successfull, that is, the
storageConsumer is updated succcessfully, then return requested
capacity back as the granted capacity

Note:  This is a temporary solution for 4.10.  Ideally, we should check if the cluster if the provider cluster has atleast x amount of storage available for updating the capacity for the storage consumer. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>