### PR TITLE
rook-ceph: change osd_memory_target value to 0.8

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -36,7 +36,7 @@ mon_max_pg_per_osd = 600
 mon_pg_warn_max_object_skew = 0
 mon_data_avail_warn = 15
 [osd]
-osd_memory_target_cgroup_limit_ratio = 0.5
+osd_memory_target_cgroup_limit_ratio = 0.8
 `
 )
 


### PR DESCRIPTION
To make sure the OSD get 4G memory and not 2.5G

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>