### PR TITLE
Provider API server : Reduce length of the user secret name for consumer

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -338,7 +338,7 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 				keyProp = "adminKey"
 			}
 			extR = append(extR, &pb.ExternalResource{
-				Name: clientSecretName,
+				Name: strings.ReplaceAll(clientSecretName, "-"+consumerResource.Name, ""),
 				Kind: "Secret",
 				Data: mustMarshal(map[string]string{
 					idProp:  i.Name,
@@ -365,10 +365,14 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 				return nil, err
 			}
 
+			nodeCephClientSecret = strings.ReplaceAll(nodeCephClientSecret, "-"+consumerResource.Name, "")
+
 			provisionerCephClientSecret, err := s.getCephClientSecretName(ctx, i.CephClients["provisioner"])
 			if err != nil {
 				return nil, err
 			}
+
+			provisionerCephClientSecret = strings.ReplaceAll(provisionerCephClientSecret, "-"+consumerResource.Name, "")
 
 			extR = append(extR, &pb.ExternalResource{
 				Name: "ceph-rbd",
@@ -395,10 +399,14 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 				return nil, err
 			}
 
+			nodeCephClientSecret = strings.ReplaceAll(nodeCephClientSecret, "-"+consumerResource.Name, "")
+
 			provisionerCephClientSecret, err := s.getCephClientSecretName(ctx, i.CephClients["provisioner"])
 			if err != nil {
 				return nil, err
 			}
+
+			provisionerCephClientSecret = strings.ReplaceAll(provisionerCephClientSecret, "-"+consumerResource.Name, "")
 
 			extR = append(extR, &pb.ExternalResource{
 				Name: "cephfs",


### PR DESCRIPTION
This PR is to reduce the length of the user secret name that needs to be created in the consumer as Kubernetes expects the length should not be more than 63 characters when on provisioning volumes  

Signed-off-by: kesavan <kvellalo@redhat.com>