### PR TITLE
controllers: exit reconcile loop immediately after updating the storagecluster annotations

### DIFF
--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -132,6 +132,10 @@ func createExternalClusterReconcilerFromCustomResources(
 	cr := &api.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ocsinit",
+			Annotations: map[string]string{
+				UninstallModeAnnotation: string(UninstallModeGraceful),
+				CleanupPolicyAnnotation: string(CleanupPolicyDelete),
+			},
 		},
 		Spec: api.StorageClusterSpec{
 			ExternalStorage: api.ExternalStorageClusterSpec{

--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -34,6 +34,10 @@ func createStorageCluster(scName, failureDomainName string,
 	cr := &api.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: scName,
+			Annotations: map[string]string{
+				UninstallModeAnnotation: string(UninstallModeGraceful),
+				CleanupPolicyAnnotation: string(CleanupPolicyDelete),
+			},
 		},
 		Spec: api.StorageClusterSpec{
 			Monitoring: &api.MonitoringSpec{

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -318,7 +318,10 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			}
 		}
 
-		if err := r.reconcileUninstallAnnotations(instance); err != nil {
+		if scWasUpdated, err := r.reconcileUninstallAnnotations(instance); err != nil {
+			return reconcile.Result{}, err
+		} else if scWasUpdated {
+			r.Log.Info("exiting reconcile loop immediately after updating the storagecluster annotations")
 			return reconcile.Result{}, err
 		}
 

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -62,6 +62,10 @@ var mockStorageCluster = &api.StorageCluster{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      mockStorageClusterRequest.Name,
 		Namespace: mockStorageClusterRequest.Namespace,
+		Annotations: map[string]string{
+			UninstallModeAnnotation: string(UninstallModeGraceful),
+			CleanupPolicyAnnotation: string(CleanupPolicyDelete),
+		},
 	},
 	Spec: api.StorageClusterSpec{
 		Monitoring: &api.MonitoringSpec{


### PR DESCRIPTION
while onboarding we are not able to update the status of the
storagecluster and we loose the storagecosumer id, there is not a really
easy way to get the consumer id again. Returning exactly after updating
storagecluster will reduce the chances of onboarding to be failed.

Update will trigger a new reconcile itself so we don't even have to
requeue at all.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2056634