### PR TITLE
[review comment] Set allowVolumeExpansion to False for encrypted SC

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -383,7 +383,7 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 				scc = newCephFilesystemStorageClassConfiguration(instance)
 				enableRookCSICephFS = true
 			} else if d.Name == cephRbdStorageClassName {
-				scc = newCephBlockPoolStorageClassConfiguration(instance, true)
+				scc = newCephBlockPoolStorageClassConfiguration(instance)
 			} else if d.Name == cephRgwStorageClassName {
 				rgwEndpoint := d.Data[externalCephRgwEndpointKey]
 				if err := checkEndpointReachable(rgwEndpoint, 5*time.Second); err != nil {

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -593,7 +593,7 @@ func TestErasureCodedExternalResources(t *testing.T) {
 
 	for _, extR := range externalResource {
 		t.Run(extR.Name, func(t *testing.T) {
-			actualSC := newCephBlockPoolStorageClassConfiguration(cr, true)
+			actualSC := newCephBlockPoolStorageClassConfiguration(cr)
 			// To override the values for external cluster
 			for k, v := range extR.Data {
 				actualSC.storageClass.Parameters[k] = v

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -195,8 +195,9 @@ func newCephFilesystemStorageClassConfiguration(initData *ocsv1.StorageCluster) 
 }
 
 // newCephBlockPoolStorageClassConfiguration generates configuration options for a Ceph Block Pool StorageClass.
-func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster, allowVolumeExpansion bool) StorageClassConfiguration {
+func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) StorageClassConfiguration {
 	persistentVolumeReclaimDelete := corev1.PersistentVolumeReclaimDelete
+	allowVolumeExpansion := true
 	managementSpec := initData.Spec.ManagedResources.CephBlockPools
 	return StorageClassConfiguration{
 		storageClass: &storagev1.StorageClass{
@@ -233,9 +234,7 @@ func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster, a
 // newEncryptedCephBlockPoolStorageClassConfiguration generates configuration options for an encrypted Ceph Block Pool StorageClass.
 // when user has asked for PV encryption during deployment.
 func newEncryptedCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster, serviceName string) StorageClassConfiguration {
-	// PV resize of encrypted volume is not officially supported in ODF 4.10 hence setting it to False
-	allowVolumeExpansion := false
-	encryptedStorageClassConfig := newCephBlockPoolStorageClassConfiguration(initData, allowVolumeExpansion)
+	encryptedStorageClassConfig := newCephBlockPoolStorageClassConfiguration(initData)
 	encryptedStorageClassConfig.storageClass.ObjectMeta.Name = generateNameForEncryptedCephBlockPoolSC(initData)
 	encryptedStorageClassConfig.storageClass.Parameters["encrypted"] = "true"
 	encryptedStorageClassConfig.storageClass.Parameters["encryptionKMSID"] = serviceName
@@ -271,10 +270,9 @@ func newCephOBCStorageClassConfiguration(initData *ocsv1.StorageCluster) Storage
 // newStorageClassConfigurations returns the StorageClassConfiguration instances that should be created
 // on first run.
 func (r *StorageClusterReconciler) newStorageClassConfigurations(initData *ocsv1.StorageCluster) ([]StorageClassConfiguration, error) {
-	allowVolumeExpansion := true
 	ret := []StorageClassConfiguration{
 		newCephFilesystemStorageClassConfiguration(initData),
-		newCephBlockPoolStorageClassConfiguration(initData, allowVolumeExpansion),
+		newCephBlockPoolStorageClassConfiguration(initData),
 	}
 	// OBC storageclass will be returned only in TWO conditions,
 	// a. either 'externalStorage' is enabled

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -234,10 +234,13 @@ func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) S
 // newEncryptedCephBlockPoolStorageClassConfiguration generates configuration options for an encrypted Ceph Block Pool StorageClass.
 // when user has asked for PV encryption during deployment.
 func newEncryptedCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster, serviceName string) StorageClassConfiguration {
+	// PV resize of encrypted volume is not officially supported in ODF 4.10 hence setting it to False
+	allowVolumeExpansion := false
 	encryptedStorageClassConfig := newCephBlockPoolStorageClassConfiguration(initData)
 	encryptedStorageClassConfig.storageClass.ObjectMeta.Name = generateNameForEncryptedCephBlockPoolSC(initData)
 	encryptedStorageClassConfig.storageClass.Parameters["encrypted"] = "true"
 	encryptedStorageClassConfig.storageClass.Parameters["encryptionKMSID"] = serviceName
+	encryptedStorageClassConfig.storageClass.AllowVolumeExpansion = &allowVolumeExpansion
 	return encryptedStorageClassConfig
 }
 


### PR DESCRIPTION
PV resize of encrypted volume is not officially supported in ODF 4.10
Hence, setting allowVolumeExpansion parameter of storage class
to False. This PR reverts 8ee4f858563c016f59804aea357d6d00ac50ab11
and addresses https://github.com/red-hat-storage/ocs-operator/pull/1558/files#r813956062

Signed-off-by: Afreen Rahman <afrahman@redhat.com>