### PR TITLE
Bug 2044288: [release-4.10] Set allowVolumeExpansion to False for encrypted SC

### DIFF
--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -234,10 +234,13 @@ func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) S
 // newEncryptedCephBlockPoolStorageClassConfiguration generates configuration options for an encrypted Ceph Block Pool StorageClass.
 // when user has asked for PV encryption during deployment.
 func newEncryptedCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster, serviceName string) StorageClassConfiguration {
+	// PV resize of encrypted volume is not officially supported in ODF 4.10 hence setting it to False
+	allowVolumeExpansion := false
 	encryptedStorageClassConfig := newCephBlockPoolStorageClassConfiguration(initData)
 	encryptedStorageClassConfig.storageClass.ObjectMeta.Name = generateNameForEncryptedCephBlockPoolSC(initData)
 	encryptedStorageClassConfig.storageClass.Parameters["encrypted"] = "true"
 	encryptedStorageClassConfig.storageClass.Parameters["encryptionKMSID"] = serviceName
+	encryptedStorageClassConfig.storageClass.AllowVolumeExpansion = &allowVolumeExpansion
 	return encryptedStorageClassConfig
 }
 


### PR DESCRIPTION
PV resize of encrypted volume is not officially supported in ODF 4.10
Hence, setting allowVolumeExpansion parameter of storage class
to False.
    
Signed-off-by: Afreen Rahman <afrahman@redhat.com>
(cherry picked from commit ca720eee21892360cc61a910ef3e4ccb28a2520c)
