### PR TITLE
Add default toleration to rbd-mirror pod

### DIFF
--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -103,6 +103,12 @@ var (
 				getOcsToleration(),
 			},
 		},
+
+		"rbd-mirror": {
+			Tolerations: []corev1.Toleration{
+				getOcsToleration(),
+			},
+		},
 	}
 )
 

--- a/controllers/storagecluster/cephrbdmirrors.go
+++ b/controllers/storagecluster/cephrbdmirrors.go
@@ -57,6 +57,7 @@ func (r *StorageClusterReconciler) newCephRbdMirrorInstances(initData *ocsv1.Sto
 			Spec: cephv1.RBDMirroringSpec{
 				Count:     1,
 				Resources: defaults.GetDaemonResources("rbd-mirror", initData.Spec.Resources),
+				Placement: getPlacement(initData, "rbd-mirror"),
 			},
 		},
 	}


### PR DESCRIPTION
This commit adds default OCS toleration rbd-mirror pod to allow it to be
run on nodes with OCS taints.

Fixes : https://bugzilla.redhat.com/show_bug.cgi?id=2057489