### PR TITLE
Define which type of nodes to label on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ watching and configuring their CustomResources (CRs).
 
 OCS Operator will install its components only on nodes labelled for OCS with `cluster.ocs.openshift.io/openshift-storage=''`.
 
-To label the nodes from CLI,
+To label the worker nodes from CLI,
 
 ```console
 $ oc label nodes <NodeName> cluster.ocs.openshift.io/openshift-storage=''

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ $ oc label nodes <NodeName> cluster.ocs.openshift.io/openshift-storage=''
 OCS requires at least 3 nodes labelled this way.
 
 > Note: When deploying via Console, the creation wizard takes care of labelling the selected nodes.
+>
+> OpenShift cluster's "master" nodes will need to add toleration for all taints to be used, do this, or choose "worker" nodes to install on.
 
 ### Dedicated nodes
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ watching and configuring their CustomResources (CRs).
 
 OCS Operator will install its components only on nodes labelled for OCS with `cluster.ocs.openshift.io/openshift-storage=''`.
 
-To label the worker nodes from CLI,
+To label the nodes from CLI,
 
 ```console
 $ oc label nodes <NodeName> cluster.ocs.openshift.io/openshift-storage=''


### PR DESCRIPTION

Adds the word "worker" to the labeling for install notes in README.
Helps user avoid error of labeling master nodes instead.


Signed-off-by: Brett Tofel <btofel@redhat.com>