### PR TITLE
validate correct cephUserType annotation

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -347,7 +347,7 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 				}),
 			})
 
-			if cephUserType == "healthChecker" {
+			if cephUserType == "healthchecker" {
 				// TODO
 				// This is just a temporary fix to get the ceph client name. In the future, we'll change it and will not depend on string conditions.
 				extR = append(extR, &pb.ExternalResource{

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -379,7 +379,7 @@ func TestGetExternalResources(t *testing.T) {
 			Name:      "cephclient-health-checker",
 			Namespace: server.namespace,
 			Annotations: map[string]string{
-				controllers.StorageCephUserTypeAnnotation: "healthChecker",
+				controllers.StorageCephUserTypeAnnotation: "healthchecker",
 			},
 		},
 		Status: &rookCephv1.CephClientStatus{


### PR DESCRIPTION
OCS provider server checks for `healthChecker` annotation on the client
but the actual annotation is `healthchecker`. This PR changes
`healthChecker` to `healthchecker`.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>