### PR TITLE
Bug 2062990:[release-4.10] controllers: correct logging of verifyNoStorageConsumerExist func

### DIFF
--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -272,10 +272,10 @@ func (r *StorageClusterReconciler) verifyNoStorageConsumerExist(instance *ocsv1.
 	}
 
 	if len(storageConsumers.Items) != 0 {
-		err = fmt.Errorf("Failed to uninstall storage cluster. StorageConsumers are present in the %s namespace. "+
-			"Clean all StorageConsumers for the uninstallation to proceed", instance.Namespace)
-		r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, "", err.Error())
-		r.Log.Error(err, "Uninstall: Waiting for StorageConsumers to be deleted via user.")
+		err = fmt.Errorf("Failed to cleanup provider resources. StorageConsumers are present in the %s namespace. "+
+			"Offboard all consumer clusters for the provider cleanup to proceed", instance.Namespace)
+		r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, "ProviderCleanup", err.Error())
+		r.Log.Error(err, "Waiting for all consumer clusters to offboard.")
 		return err
 	}
 


### PR DESCRIPTION
The func verifyNoStorageConsumerExist is called at 2 places and one of
them is uninstall and the other one is not. Using uninstall keyword
create a confusion among the user.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
(cherry picked from commit 94c993a86f0f8ded2b7096287c3adca263f92ba0)

Backport of https://github.com/red-hat-storage/ocs-operator/pull/1586