### PR TITLE
set upgrade conditions to true in external mode deployment

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -441,8 +441,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 
 		// If no operator whose conditions we are watching reports an error, then it is safe
 		// to set upgradeable to true.
-		if instance.Status.Phase != statusutil.PhaseClusterExpanding &&
-			!instance.Spec.ExternalStorage.Enable {
+		if instance.Status.Phase != statusutil.PhaseClusterExpanding {
 			instance.Status.Phase = statusutil.PhaseReady
 			returnErr := r.SetOperatorConditions(message, reason, metav1.ConditionTrue, nil)
 			if returnErr != nil {


### PR DESCRIPTION
We were setting `Upgradable: false` in some cases but we
never set it to `Upgradable: true` for external mode
deployments. This caused further upgrades to be blocked.

This commit changes that behavior to set `Upgradable: true`
even for external mode deployments when none of the components
report an error.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>