### PR TITLE
add termination policy to TLS in cephobjectstore route

### DIFF
--- a/controllers/storagecluster/routes.go
+++ b/controllers/storagecluster/routes.go
@@ -141,6 +141,10 @@ func (r *StorageClusterReconciler) newCephRGWRoutes(initData *ocsv1.StorageClust
 					Kind: "Service",
 					Name: generateNameForCephObjectStoreService(initData),
 				},
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationReencrypt,
+					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The route for cephobjectstore does not define termination policy in TLS
config of the Spec and this PR defines one. With this change only
`https` endpoint of RGW will exposed via route.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>