### PR TITLE
fix cluster resource quota names containing double ocs prefix

### DIFF
--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -81,5 +81,5 @@ func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string)
 
 // generateStorageQuotaName function generates a name for ClusterResourceQuota
 func generateStorageQuotaName(storageClassName, quotaName string) string {
-	return fmt.Sprintf("ocs-%s-%s", storageClassName, quotaName)
+	return fmt.Sprintf("%s-%s", storageClassName, quotaName)
 }


### PR DESCRIPTION
fixed the issue of cluster resource quota names having double ocs
prefix.

Signed-off-by: riya-singhal31 <riyasinghalji@gmail.com>