### PR TITLE
cleanup: resolve syntax error

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -376,4 +376,4 @@ for ns in $namespaces; do
 done
 
 cat "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
-rm -rf "${BASE_COLLECTION_PATH}/"gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+rm -rf "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1


### PR DESCRIPTION
This commit resolves a small syntax error
due to which the ceph collection was showing error

Signed-off-by: yati1998 <ypadia@redhat.com>