### PR TITLE
must-gather: collect mirroring resources in separate files

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -280,11 +280,11 @@ for ns in $namespaces; do
         done
         # Collecting rbd mirroring info for ceph rbd volumes
         printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-        COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_mirror_info
-        # Checking snapshot schedule status
-        printf "checking snapshot schedule status \n" >> "${COMMAND_OUTPUT_FILE}"
-        printf "collecting snapshot schedule status \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
-        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
+        # Checking snapshot schedule status and list
+        printf "collecting snapshot schedule status and list \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json --pretty-format" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_status; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
+        pids_ceph+=($!)
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule ls --recursive --format=json --pretty-format" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_snapshot_schedule_ls; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-debug.log 2>&1 &
         pids_ceph+=($!)
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n openshift-storage -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
@@ -292,21 +292,39 @@ for ns in $namespaces; do
             # Check if mirroring is enabled here.
             isEnabled=$(timeout 60 oc -n openshift-storage exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json | jq --raw-output '.mode'")
             if [ "${isEnabled}" != "disabled" ]; then
-                { printf "Mirroring is enabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_FILE}"; }
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule list --pool=$bp --fromat=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-"${bp}"-debug.log 2>&1 &
-                pids_ceph+=($!)
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status $bp --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log 2>&1 &
-                pids_ceph+=($!)
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-info-"${bp}"-debug.log 2>&1 &
-                pids_ceph+=($!)
+                pids_rbd=()
+                printf "Mirroring is enabled on: %s\n" "${bp}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                {
+                    printf "Collecting mirror pool status for: %s\n" "${bp}";
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status --verbose $bp --format=json --pretty-format" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log;
+                } >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_status &
+                pids_rbd+=($!)
+                {
+                    printf "Collecting mirror pool info for: %s\n" "${bp}";
+                    timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json --pretty-format" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-info-"${bp}"-debug.log;
+                } >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_info &
+                pids_rbd+=($!)
+                printf "Collecting mirror image status for images in: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
                 images=$(timeout 60 oc -n openshift-storage exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
                 for image in $images; do
-                    { printf "Printing information for image: %s\n" "${image}" >> "${COMMAND_OUTPUT_FILE}"; }
-                    { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log 2>&1 &
-                    pids_ceph+=($!)
+                    printf "Printing information for image: %s\n" "${image}" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+                    {
+                        printf "Collecting mirror image status for: %s/%s\n" "${bp}" "${image}";
+                        timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json --pretty-format" 2>> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log;
+                    } >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status_"${image}".part &
+                    pids_rbd+=($!)
                 done
+                if [ -n "${pids_rbd[*]}" ]; then
+                    # wait for all pids
+                    echo "waiting for ${pids_rbd[*]} to terminate" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+                    wait "${pids_rbd[@]}"
+                fi
+                find "${COMMAND_OUTPUT_DIR}" -name "rbd_mirror_image_status_*.part" -print0 | xargs -0 cat >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
+                find "${COMMAND_OUTPUT_DIR}" -name "rbd_mirror_image_status_*.part" -print0 | xargs -0 rm -f
             else
-                { printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_FILE}"; }
+                printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_status
+                printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_pool_info
+                printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_DIR}"/rbd_mirror_image_status
             fi
         done
 


### PR DESCRIPTION
This commit collects the rbd mirror info in different
files for clear debuging.

Signed-off-by: yati1998 <ypadia@redhat.com>