### PR TITLE
must-gather: empty the pids as it is exceeding the limits

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -258,6 +258,13 @@ for ns in $namespaces; do
             done
         done
 
+        # CRI-O have a limitation to upper limit to number of PIDs, so we found that when `ps aux | wc -l` exceeds 115 the resource cannot be collected
+        # hence to keep a buffer, we are waiting for 2 seconds until we have PIDs available, https://access.redhat.com/solutions/5597061
+        while [ "$(ps aux | wc -l)" -gt 100 ]
+            do
+               printf "waiting for PIDs to be empty before proceeding \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+               sleep 2
+        done
         # Collecting rbd mirroring info for ceph rbd volumes
         printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_mirror_info


### PR DESCRIPTION
This commit adds code to empty the pids for further
resource collections as it is crossing the limits and
as the result rbd mirroring info is not being collected

Signed-off-by: yati1998 <ypadia@redhat.com>