### PR TITLE
Update ceph-csi/api and use k8s.gcr.io for csi nfsplugin image 

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2651,7 +2651,7 @@ spec:
                 - name: ROOK_CSIADDONS_IMAGE
                   value: quay.io/csiaddons/k8s-sidecar:v0.2.1
                 - name: ROOK_CSI_NFS_IMAGE
-                  value: mcr.microsoft.com/k8s/csi/nfs-csi:v3.1.0
+                  value: k8s.gcr.io/sig-storage/nfsplugin:v3.1.0
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 
@@ -3022,7 +3022,7 @@ spec:
     name: volume-replication-operator
   - image: quay.io/csiaddons/k8s-sidecar:v0.2.1
     name: csiaddons-sidecar
-  - image: mcr.microsoft.com/k8s/csi/nfs-csi:v3.1.0
+  - image: k8s.gcr.io/sig-storage/nfsplugin:v3.1.0
     name: rook-csi-nfs
   - image: quay.io/ocs-dev/ocs-must-gather:latest
     name: ocs-must-gather

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/RHsyseng/operator-utils v1.4.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
-	github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70
+	github.com/ceph/ceph-csi/api v0.0.0-20220413173542-2205145654cd
 	github.com/ceph/go-ceph v0.12.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4r
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70 h1:QOGXUOQKNB8+8+7lzqr0B2kGHCINE1gWNNtjPGNXmJU=
-github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70/go.mod h1:H15KD1Pe+9+a/zk5IEC+bMZ2A39hwAvqbkt1ncuuQBk=
+github.com/ceph/ceph-csi/api v0.0.0-20220413173542-2205145654cd h1:JC4LA3XXZTVnOQfCniIKn1QYBeqh71vQiY6taY7MmnU=
+github.com/ceph/ceph-csi/api v0.0.0-20220413173542-2205145654cd/go.mod h1:EwnbYHK8lmLFjQ1ZEk/KMDLNQUSdaamMOg6IUtua2Nw=
 github.com/ceph/go-ceph v0.9.1-0.20210607162346-8179bd4437f9/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
 github.com/ceph/go-ceph v0.12.0 h1:nlFgKQZXOFR4oMnzXsKwTr79Y6EYDwqTrpigICGy/Tw=
 github.com/ceph/go-ceph v0.12.0/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -55,7 +55,7 @@ LATEST_NOOBAA_DB_IMAGE="centos/postgresql-12-centos7"
 LATEST_CEPH_IMAGE="ceph/daemon-base:latest-pacific"
 LATEST_VOLUME_REPLICATION_OPERATOR_IMAGE="csiaddons/volumereplication-operator:v0.1.0"
 LATEST_ROOK_CSIADDONS_IMAGE="csiaddons/k8s-sidecar:v0.2.1"
-LATEST_ROOK_CSI_NFS_IMAGE="mcr.microsoft.com/k8s/csi/nfs-csi:v3.1.0"
+LATEST_ROOK_CSI_NFS_IMAGE="k8s.gcr.io/sig-storage/nfsplugin:v3.1.0"
 
 DEFAULT_IMAGE_REGISTRY="quay.io"
 DEFAULT_REGISTRY_NAMESPACE="ocs-dev"

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
@@ -41,3 +41,5 @@ users:
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-plugin-sa"
   # yamllint disable-line rule:line-length
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-provisioner-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-plugin-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-provisioner-sa"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/blang/semver/v4
 # github.com/cenkalti/backoff/v3 v3.0.0
 ## explicit; go 1.12
 github.com/cenkalti/backoff/v3
-# github.com/ceph/ceph-csi/api v0.0.0-20211006172825-b9beb2106b70
+# github.com/ceph/ceph-csi/api v0.0.0-20220413173542-2205145654cd
 ## explicit; go 1.16
 github.com/ceph/ceph-csi/api/deploy/ocp
 # github.com/ceph/go-ceph v0.12.0


### PR DESCRIPTION
- update ceph-csi api to add nfs sa

This commit updates `github.com/ceph/ceph-csi/api`
so nfs sa is added to `rook-ceph-csi` scc.

Signed-off-by: Rakshith R <rar@redhat.com>

- use k8s.gcr.io for csi nfsplugin image

Use k8s.gcr.io like other kubernetes sidecar
image to pull the nfsplugin image.

Signed-off-by: Rakshith R <rar@redhat.com>

/cc @Madhu-1 @agarwal-mudit @nixpanic @BlaineEXE 