### PR TITLE
use `quay.io/ceph/ceph:v16` for ceph image

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2597,7 +2597,7 @@ spec:
                 - name: ROOK_CEPH_IMAGE
                   value: rook/ceph:v1.9.0
                 - name: CEPH_IMAGE
-                  value: ceph/daemon-base:latest-pacific
+                  value: quay.io/ceph/ceph:v16
                 - name: NOOBAA_CORE_IMAGE
                   value: noobaa/noobaa-core:master-20210912
                 - name: NOOBAA_DB_IMAGE
@@ -3047,7 +3047,7 @@ spec:
   relatedImages:
   - image: rook/ceph:v1.9.0
     name: rook-container
-  - image: ceph/daemon-base:latest-pacific
+  - image: quay.io/ceph/ceph:v16
     name: ceph-container
   - image: quay.io/csiaddons/volumereplication-operator:v0.1.0
     name: volume-replication-operator

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -48,11 +48,7 @@ LATEST_ROOK_IMAGE="rook/ceph:v1.9.0"
 LATEST_NOOBAA_IMAGE="noobaa/noobaa-operator:master-20210912"
 LATEST_NOOBAA_CORE_IMAGE="noobaa/noobaa-core:master-20210912"
 LATEST_NOOBAA_DB_IMAGE="centos/postgresql-12-centos7"
-# The stretch cluster feature will come in ceph pacific(v16).  We don't have an
-# image for it yet. Meanwhile, we will use an image that has the required
-# patches. This is required for the CI and does not impact anything else.
-# TODO: revert to using ceph/ceph image once v16 is out.)
-LATEST_CEPH_IMAGE="ceph/daemon-base:latest-pacific"
+LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v16"
 LATEST_VOLUME_REPLICATION_OPERATOR_IMAGE="csiaddons/volumereplication-operator:v0.1.0"
 LATEST_ROOK_CSIADDONS_IMAGE="csiaddons/k8s-sidecar:v0.2.1"
 LATEST_ROOK_CSI_NFS_IMAGE="k8s.gcr.io/sig-storage/nfsplugin:v3.1.0"


### PR DESCRIPTION
Ceph now pushes latest images to quay only.
This will ensure we are using the latest ceph
pacific image.

Signed-off-by: Rakshith R <rar@redhat.com>

/cc @agarwal-mudit @iamniting @Madhu-1 