### PR TITLE
Moving the defaults for rookceph operator from configmap to csv

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
-	"github.com/red-hat-storage/ocs-operator/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/controllers/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -177,24 +176,12 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // returns a ConfigMap with default settings for rook-ceph operator
 func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
-	var defaultCSIToleration = `
-- key: ` + defaults.NodeTolerationKey + `
-  operator: Equal
-  value: "true"
-  effect: NoSchedule`
-
 	config := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rookCephOperatorConfigName,
 			Namespace: namespace,
 		},
 	}
-	data := make(map[string]string)
-	data["CSI_PROVISIONER_TOLERATIONS"] = defaultCSIToleration
-	data["CSI_PLUGIN_TOLERATIONS"] = defaultCSIToleration
-	data["CSI_LOG_LEVEL"] = "5"
-	data["CSI_ENABLE_CSIADDONS"] = "true"
-	config.Data = data
 
 	return config
 }

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2714,6 +2714,10 @@ spec:
                       operator: Equal
                       value: "true"
                       effect: NoSchedule
+                - name: CSI_LOG_LEVEL
+                  value: "5"
+                - name: CSI_ENABLE_CSIADDONS
+                  value: "true"
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -252,6 +252,14 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
   effect: NoSchedule`,
 			},
 			{
+				Name:  "CSI_LOG_LEVEL",
+				Value: "5",
+			},
+			{
+				Name:  "CSI_ENABLE_CSIADDONS",
+				Value: "true",
+			},
+			{
 				Name: "NODE_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{


### PR DESCRIPTION
Going forward the configmap created by ocsinitialization will be
reserved purely for customer overrides (higher precedence), and
the csv will have the env vars for our defaults.

We had discussed this here in odf virtual teams space, 
[https://chat.google.com/room/AAAAREGEba8/JO7SyyGIA0k](https://chat.google.com/room/AAAAREGEba8/JO7SyyGIA0k)

Also the corresponding BZ link for the discussion that happened there.
[https://bugzilla.redhat.com/show_bug.cgi?id=1986016](https://bugzilla.redhat.com/show_bug.cgi?id=1986016)