### PR TITLE
Make use of SHA256 digests explicit

### DIFF
--- a/hack/ticketgen/ticketcheck.sh
+++ b/hack/ticketgen/ticketcheck.sh
@@ -58,6 +58,6 @@ JSON="$(echo "${PAYLOAD}" | base64 -d)"
 echo "${JSON}"
 echo -n "${SIG}" | base64 -d > "${SIG_FILE}"
 
-echo -n "${JSON}" | openssl dgst -verify "${KEY_FILE}" -signature "${SIG_FILE}"
+echo -n "${JSON}" | openssl dgst -sha256 -verify "${KEY_FILE}" -signature "${SIG_FILE}"
 
 rm "${SIG_FILE}"

--- a/hack/ticketgen/ticketgen.sh
+++ b/hack/ticketgen/ticketgen.sh
@@ -52,5 +52,5 @@ add_var "id" "${NEW_CONSUMER_ID}"
 add_var "expirationDate" "${EXPIRATION_DATE}"
 
 PAYLOAD="$(echo -n "{${JSON}}" | base64 | tr -d "\n")"
-SIG="$(echo -n "{${JSON}}"| openssl dgst -sign "${KEY_FILE}" | base64 | tr -d "\n")"
+SIG="$(echo -n "{${JSON}}"| openssl dgst -sha256 -sign "${KEY_FILE}" | base64 | tr -d "\n")"
 cat <<< "${PAYLOAD}.${SIG}"


### PR DESCRIPTION
Some platforms do not default to using SHA256 for digests, instead
using MD5. On one of those platforms, a token will fail verification
at the provider since it explicitly verifies using SHA256.