### PR TITLE
Fix bugs found in the testing

### DIFF
--- a/deploy/bundle/manifests/provider-role.yaml
+++ b/deploy/bundle/manifests/provider-role.yaml
@@ -41,3 +41,12 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclassclaims
+  verbs:
+  - get
+  - list
+  - create
+  - delete

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -41,3 +41,12 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclassclaims
+  verbs:
+  - get
+  - list
+  - create
+  - delete

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -500,6 +500,7 @@ func (s *OCSProviderServer) FulfillStorageClassClaim(ctx context.Context, req *p
 	err = s.storageClassClaimManager.Create(ctx, consumerObj, req.StorageClassClaimName, req.StorageType.String(), req.EncryptionMethod)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fulfill storage class claim for %q. %v", req.StorageConsumerUUID, err)
+		klog.Error(errMsg)
 		if kerrors.IsAlreadyExists(err) {
 			return nil, status.Error(codes.AlreadyExists, errMsg)
 		}
@@ -514,7 +515,9 @@ func (s *OCSProviderServer) FulfillStorageClassClaim(ctx context.Context, req *p
 func (s *OCSProviderServer) RevokeStorageClassClaim(ctx context.Context, req *pb.RevokeStorageClassClaimRequest) (*pb.RevokeStorageClassClaimResponse, error) {
 	err := s.storageClassClaimManager.Delete(ctx, req.StorageConsumerUUID, req.StorageClassClaimName)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to revoke storage class claim %q for %q. %v", req.StorageClassClaimName, req.StorageConsumerUUID, err)
+		errMsg := fmt.Sprintf("failed to revoke storage class claim %q for %q. %v", req.StorageClassClaimName, req.StorageConsumerUUID, err)
+		klog.Error(errMsg)
+		return nil, status.Errorf(codes.Internal, errMsg)
 	}
 
 	return &pb.RevokeStorageClassClaimResponse{}, nil
@@ -524,14 +527,16 @@ func (s *OCSProviderServer) RevokeStorageClassClaim(ctx context.Context, req *pb
 func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req *pb.StorageClassClaimConfigRequest) (*pb.StorageClassClaimConfigResponse, error) {
 	storageClassClaim, err := s.storageClassClaimManager.Get(ctx, req.StorageConsumerUUID, req.StorageClassClaimName)
 	if err != nil {
+		errMsg := fmt.Sprintf("failed to get storage class claim config %q for %q. %v", req.StorageClassClaimName, req.StorageConsumerUUID, err)
 		if kerrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "failed to get storage class claim config %q for %q. %v", req.StorageClassClaimName, req.StorageConsumerUUID, err)
+			return nil, status.Error(codes.NotFound, errMsg)
 		}
-		return nil, status.Errorf(codes.Internal, "failed to get storage class claim config %q for %q. %v", req.StorageClassClaimName, req.StorageConsumerUUID, err)
+		return nil, status.Error(codes.Internal, errMsg)
 	}
 
 	// Verify Status.Phase
 	msg := fmt.Sprintf("storage class claim %q for %q is in %q phase", req.StorageClassClaimName, req.StorageConsumerUUID, storageClassClaim.Status.Phase)
+	klog.Info(msg)
 	if storageClassClaim.Status.Phase != ocsv1alpha1.StorageClassClaimReady {
 		switch storageClassClaim.Status.Phase {
 		case ocsv1alpha1.StorageClassClaimFailed:
@@ -640,6 +645,7 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 				})})
 		}
 	}
+	klog.Infof("successfully returned the storage class claim %q for %q", req.StorageClassClaimName, req.StorageConsumerUUID)
 	return &pb.StorageClassClaimConfigResponse{ExternalResource: extR}, nil
 
 }

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -642,6 +642,7 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 				Kind: "StorageClass",
 				Data: mustMarshal(map[string]string{
 					"clusterID": getSubVolumeGroupClusterID(subVolumeGroup),
+					"fsName":    subVolumeGroup.Spec.FilesystemName,
 					"csi.storage.k8s.io/provisioner-secret-name":       provisionerCephClientSecret,
 					"csi.storage.k8s.io/node-stage-secret-name":        nodeCephClientSecret,
 					"csi.storage.k8s.io/controller-expand-secret-name": provisionerCephClientSecret,

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -497,7 +497,17 @@ func (s *OCSProviderServer) FulfillStorageClassClaim(ctx context.Context, req *p
 
 	klog.Infof("Found StorageConsumer %q (%q)", consumerObj.Name, req.StorageConsumerUUID)
 
-	err = s.storageClassClaimManager.Create(ctx, consumerObj, req.StorageClassClaimName, req.StorageType.String(), req.EncryptionMethod)
+	var storageType string
+	switch req.StorageType {
+	case pb.FulfillStorageClassClaimRequest_BLOCKPOOL:
+		storageType = "blockpool"
+	case pb.FulfillStorageClassClaimRequest_SHAREDFILESYSTEM:
+		storageType = "sharedfilesystem"
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "encountered an unknown stroage type, %s", storageType)
+	}
+
+	err = s.storageClassClaimManager.Create(ctx, consumerObj, req.StorageClassClaimName, storageType, req.EncryptionMethod)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fulfill storage class claim for %q. %v", req.StorageConsumerUUID, err)
 		klog.Error(errMsg)

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -526,6 +526,7 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 				Kind: "StorageClass",
 				Data: map[string]string{
 					"clusterID": "8d26c7378c1b0ec9c2455d1c3601c4cd",
+					"fsName":    "myfs",
 					"csi.storage.k8s.io/provisioner-secret-name":       "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",
 					"csi.storage.k8s.io/node-stage-secret-name":        "rook-ceph-client-1b042fcc8812fe4203689eec38fdfbfa",
 					"csi.storage.k8s.io/controller-expand-secret-name": "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",


### PR DESCRIPTION
* Improve logging in storageclass claim to help to debug in error cases.
* The storageType should be of type string sharedfilesystem or blockpool when creating the storageclassclaim CR it's not always the string format of the auto generated RPC names.
* Added RBAC role for provider api-server for the storageclassclaim CR.
* The fsName is the key in the storageclass parameters matching the key to sending back in GetStorageClassClaimConfig to create the storageclass
* Get operation on the consumer will not have the TypeMeta objects set causing the problem of setting the ownerRef, use the helper function to set the ownerRef

/assign @umangachapagain 
/assign @nb-ohad 
/assign @iamniting 