### PR TITLE
add more details to kubectl get operation

### DIFF
--- a/api/v1alpha1/storageclassclaim_types.go
+++ b/api/v1alpha1/storageclassclaim_types.go
@@ -57,6 +57,8 @@ type StorageClassClaimStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="StorageType",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 
 // StorageClassClaim is the Schema for the storageclassclaims API
 type StorageClassClaim struct {

--- a/config/crd/bases/ocs.openshift.io_storageclassclaims.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclassclaims.yaml
@@ -15,7 +15,14 @@ spec:
     singular: storageclassclaim
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: StorageType
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: StorageClassClaim is the Schema for the storageclassclaims API

--- a/deploy/bundle/manifests/storageclassclaim.crd.yaml
+++ b/deploy/bundle/manifests/storageclassclaim.crd.yaml
@@ -14,7 +14,14 @@ spec:
     singular: storageclassclaim
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: StorageType
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: StorageClassClaim is the Schema for the storageclassclaims API

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclassclaims.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclassclaims.yaml
@@ -15,7 +15,14 @@ spec:
     singular: storageclassclaim
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: StorageType
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: StorageClassClaim is the Schema for the storageclassclaims API


### PR DESCRIPTION
add phase and storagetype to the kubectl get operation as its helps to get an idea of what the claim is without checking the yaml output.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

/assign @umangachapagain 
/assign @nb-ohad 