### PR TITLE
ocs-to-ocs: revert disabling cephfs csi driver

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -561,9 +561,13 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 		r.Log.Error(err, "Failed to create needed StorageClasses.")
 		return err
 	}
-	if err = r.setRookCSICephFS(enableRookCSICephFS, instance); err != nil {
-		r.Log.Error(err, "Failed to set RookEnableCephFSCSIKey to EnableRookCSICephFS.", "RookEnableCephFSCSIKey", rookEnableCephFSCSIKey, "EnableRookCSICephFS", enableRookCSICephFS)
-		return err
+	// We do not want to disable CephFS csi driver in consumer mode since
+	// CephFS storageclass is available by default.
+	if !IsOCSConsumerMode(instance) {
+		if err = r.setRookCSICephFS(enableRookCSICephFS, instance); err != nil {
+			r.Log.Error(err, "Failed to set RookEnableCephFSCSIKey to EnableRookCSICephFS.", "RookEnableCephFSCSIKey", rookEnableCephFSCSIKey, "EnableRookCSICephFS", enableRookCSICephFS)
+			return err
+		}
 	}
 	if extCephObjectStores != nil {
 		if err = r.createCephObjectStores(extCephObjectStores, instance); err != nil {


### PR DESCRIPTION
In case of OCS to OCS, consumer OCS cluster has a default
CephFS based StorageClass. So, to allow PV creation using
this StorageClass CephFS CSI driver should also be enabled
by default.

This PR skips the toggle added in #701.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>