### PR TITLE
Fix storageclassname problem

### DIFF
--- a/controllers/storageclassclaim/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim/storageclassclaim_controller.go
@@ -503,8 +503,7 @@ func (r *StorageClassClaimReconciler) getCephFSStorageClass(data map[string]stri
 	allowVolumeExpansion := true
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.storageClassClaim.Name,
-			Namespace: r.storageClassClaim.Namespace,
+			Name: r.storageClassClaim.Name,
 			Annotations: map[string]string{
 				"description": "Provides RWO and RWX Filesystem volumes",
 			},
@@ -522,8 +521,7 @@ func (r *StorageClassClaimReconciler) getCephRBDStorageClass(data map[string]str
 	allowVolumeExpansion := true
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.storageClassClaim.Name,
-			Namespace: r.storageClassClaim.Namespace,
+			Name: r.storageClassClaim.Name,
 			Annotations: map[string]string{
 				"description": "Provides RWO Filesystem volumes, and RWO and RWX Block volumes",
 			},


### PR DESCRIPTION
If the storageclass already exits and is backed by another storage-class claim in a different namespace block the new request for the same name in a different namespace.
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>