### PR TITLE
Bug 2083993: [release-4.11] use GVK to get Kind of consumer obj

### DIFF
--- a/controllers/storageclassclaim/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim/storageclassclaim_controller.go
@@ -40,6 +40,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -372,10 +373,15 @@ func (r *StorageClassClaimReconciler) reconcileProviderPhases() (reconcile.Resul
 
 	r.storageClassClaim.Status.Phase = v1alpha1.StorageClassClaimInitializing
 
+	gvk, err := apiutil.GVKForObject(r.storageConsumer, r.Client.Scheme())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get gvk for consumer  %w", err)
+	}
 	// reading storageConsumer Name from storageClassClaim ownerReferences
 	ownerRefs := r.storageClassClaim.GetOwnerReferences()
 	for i := range ownerRefs {
-		if ownerRefs[i].Kind == r.storageConsumer.Kind {
+		if ownerRefs[i].Kind == gvk.Kind {
+			r.storageConsumer = &v1alpha1.StorageConsumer{}
 			r.storageConsumer.Name = ownerRefs[i].Name
 		}
 	}


### PR DESCRIPTION
Instead of using hardcoded kind use  GVK to get the consumer Kind and use it for comparison.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 5aa617f514437c48effb3546ced9b20f23fb7f0b)

@agarwal-mudit manual backport of https://github.com/red-hat-storage/ocs-operator/pull/1664