### PR TITLE
Remove annotation to enable add-capacity for csv

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1199,8 +1199,8 @@ metadata:
     external.features.ocs.openshift.io/validation: '{"secrets":["rook-ceph-operator-creds",
       "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints",
       "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}'
-    features.ocs.openshift.io/disabled: '["ss-list", "install-wizard", "add-capacity",
-      "block-pool", "mcg-resource", "odf-dashboard", "common"]'
+    features.ocs.openshift.io/disabled: '["ss-list", "install-wizard", "block-pool",
+      "mcg-resource", "odf-dashboard", "common"]'
     features.ocs.openshift.io/enabled: '["kms", "arbiter", "flexible-scaling", "multus",
       "pool-management", "namespace-store", "mcg-standalone", "taint-nodes", "vault-sa-kms",
       "hpcs-kms"]'

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -645,7 +645,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
 	// Feature disablement flag for Console. The array values are unique identifiers provided by the console.
 	// To be used to disable UI components. This is used to track migration of features.
 	// Example: "features.ocs.openshift.io/disabled": `["external", "foo1", "foo2", ...]`
-	ocsCSV.Annotations["features.ocs.openshift.io/disabled"] = `["ss-list", "install-wizard", "add-capacity", "block-pool", "mcg-resource", "odf-dashboard", "common"]`
+	ocsCSV.Annotations["features.ocs.openshift.io/disabled"] = `["ss-list", "install-wizard", "block-pool", "mcg-resource", "odf-dashboard", "common"]`
 	// Used by UI to validate user uploaded metdata
 	// Metadata is used to connect to an external cluster
 	ocsCSV.Annotations["external.features.ocs.openshift.io/validation"] = `{"secrets":["rook-ceph-operator-creds", "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints", "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}`


### PR DESCRIPTION
Removed a flag which is disabling UI components in Console.
Used to track migration of features from OCP to ODF.
Signed-off-by: SanjalKatiyar <sanjaldhir@gmail.com>