### PR TITLE
metrics: fetch creds during add & resync events

### DIFF
--- a/metrics/internal/collectors/registry.go
+++ b/metrics/internal/collectors/registry.go
@@ -1,10 +1,6 @@
 package collectors
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,25 +9,14 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 )
 
 const (
 	// name of the project/exporter
-	namespace      = "ocs"
-	cephConfigRoot = "/etc/ceph"
-	cephConfigPath = "/etc/ceph/ceph.conf"
-	keyRing        = "/etc/ceph/keyring"
+	namespace = "ocs"
 )
-
-var cephConfig = []byte(`[global]
-auth_cluster_required = cephx
-auth_service_required = cephx
-auth_client_required = cephx
-`)
 
 // RegisterCustomResourceCollectors registers the custom resource collectors
 // in the given prometheus.Registry
@@ -65,52 +50,15 @@ func enablePVStore(opts *options.Options) {
 }
 
 var rbdMirrorStoreEnabled bool
-var rbdMirrorStore = internalcache.NewRBDMirrorStore()
+var rbdMirrorStore *internalcache.RBDMirrorStore
 
-type csiClusterConfig struct {
-	ClusterID string   `json:"clusterID"`
-	Monitors  []string `json:"monitors"`
-}
-
-func enableRBDMirrorStore(opts *options.Options) error {
-	client := clientset.NewForConfigOrDie(opts.Kubeconfig)
-	secret, err := client.CoreV1().Secrets("openshift-storage").Get(context.TODO(), "rook-ceph-mon", v1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get secret: %v", err)
-	}
-	key, ok := secret.Data["ceph-secret"]
-	if !ok {
-		return fmt.Errorf("failed to get client key from secret")
-	}
-	id := "admin"
-
-	configmap, err := client.CoreV1().ConfigMaps("openshift-storage").Get(context.TODO(), "rook-ceph-csi-config", v1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get configmap: %v", err)
-	}
-
-	data := configmap.Data["csi-cluster-config-json"]
-	var clusterConfig []csiClusterConfig
-	err = json.Unmarshal([]byte(data), &clusterConfig)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal csi-cluster-config-json: %v", err)
-	}
-
-	// write Ceph config file before issuing RBD mirror commands
-	err = writeCephConfig()
-	if err != nil {
-		return err
-	}
-
-	rbdMirrorStore.WithRBDCommandInput(clusterConfig[0].Monitors[0], id, string(key))
-
+func enableRBDMirrorStore(opts *options.Options) {
+	rbdMirrorStore = internalcache.NewRBDMirrorStore(opts)
 	rookClient := rookclient.NewForConfigOrDie(opts.Kubeconfig)
 	lw := internalcache.CreateCephBlockPoolListWatch(rookClient, corev1.NamespaceAll, "")
 	reflector := cache.NewReflector(lw, &cephv1.CephBlockPool{}, rbdMirrorStore, 30*time.Second)
 	go reflector.Run(opts.StopCh)
 	rbdMirrorStoreEnabled = true
-
-	return nil
 }
 
 // RegisterPersistentVolumeAttributesCollector registers PV attribute colletor to registry
@@ -128,49 +76,8 @@ func RegisterRBDMirrorCollector(registry *prometheus.Registry, opts *options.Opt
 		enablePVStore(opts)
 	}
 	if !rbdMirrorStoreEnabled {
-		err := enableRBDMirrorStore(opts)
-		if err != nil {
-			klog.Error(err)
-		}
+		enableRBDMirrorStore(opts)
 	}
 	rbdMirrorCollector := NewRBDMirrorCollector(rbdMirrorStore, pvStore, opts)
 	registry.MustRegister(rbdMirrorCollector)
-}
-
-/*
-	Copied from https://github.com/ceph/ceph-csi/blob/70fc6db2cfe3f00945c030f0d7f83ea1e2d21a00/internal/util/cephconf.go
-	Functions to create ceph.conf and keyring files internally.
-*/
-
-func createCephConfigRoot() error {
-	return os.MkdirAll(cephConfigRoot, 0o755)
-}
-
-// createKeyRingFile creates the keyring files to fix above error message logging.
-func createKeyRingFile() error {
-	var err error
-	if _, err = os.Stat(keyRing); os.IsNotExist(err) {
-		_, err = os.Create(keyRing)
-	}
-
-	return err
-}
-
-// writeCephConfig writes out a basic ceph.conf file, making it easy to use
-// ceph related CLIs.
-func writeCephConfig() error {
-	var err error
-	if err = createCephConfigRoot(); err != nil {
-		return err
-	}
-
-	if _, err = os.Stat(cephConfigPath); os.IsNotExist(err) {
-		err = os.WriteFile(cephConfigPath, cephConfig, 0o600)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return createKeyRingFile()
 }


### PR DESCRIPTION
rbd-mirror collector requires credentials from Ceph to collect data.
If Ceph is not available, rbd-mirror metrics will not be available.

We fetch credentials from Rook when an add or resync event is
received on CephBlockPool object. This helps us avoid pre-fetching
credentials and keeps the credentials updated.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>