### PR TITLE
metrics-exporter: ignore rbd daemon debug logs

### DIFF
--- a/metrics/internal/cache/rbd-mirror.go
+++ b/metrics/internal/cache/rbd-mirror.go
@@ -248,7 +248,7 @@ func (in *rbdCommandInput) rbdImageStatus(poolName string) (RBDMirrorStatusVerbo
 		return rbdMirrorStatusVerbose, errors.New("unable to get RBD mirror data. RBD command input not specified")
 	}
 
-	args := []string{"mirror", "pool", "status", poolName, "--verbose", "--format", "json", "-m", in.monitor, "--id", in.id, "--key", in.key}
+	args := []string{"mirror", "pool", "status", poolName, "--verbose", "--format", "json", "-m", in.monitor, "--id", in.id, "--key", in.key, "--debug-rbd", "0"}
 	cmd, err := execCommand("rbd", args)
 	if err != nil {
 		return rbdMirrorStatusVerbose, err


### PR DESCRIPTION
When debug log is enabled in rbd mirror daemon, rbd cli
commands dump a lot of non json output along with the
expected json. This causes json parsing to fail and disrupts
metrics collection.

This commit adds  "--debug-rbd 0" to ignore debug logs and get
valid json for metrics generation.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>