### PR TITLE
fix namespace problem in storageclassclaim controller

### DIFF
--- a/controllers/storageclassclaim/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim/storageclassclaim_controller.go
@@ -226,7 +226,7 @@ func (r *StorageClassClaimReconciler) reconcileConsumerPhases() (reconcile.Resul
 			sccEncryptionMethod := r.storageClassClaim.Spec.EncryptionMethod
 			_, scIsFSType := existing.Parameters["fsName"]
 			scEncryptionMethod, scHasEncryptionMethod := existing.Parameters["encryptionMethod"]
-			if !((sccType == "filesystem" && scIsFSType && !scHasEncryptionMethod) ||
+			if !((sccType == "sharedfilesystem" && scIsFSType && !scHasEncryptionMethod) ||
 				(sccType == "blockpool" && !scIsFSType && sccEncryptionMethod == scEncryptionMethod)) {
 				r.log.Error(fmt.Errorf("storageClassClaim is not compatible with existing StorageClass"),
 					"StorageClassClaim validation failed.")

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -18,3 +18,16 @@ func GetWatchNamespace() (string, error) {
 	}
 	return ns, nil
 }
+
+// OperatorNamespaceEnvVar is the constant for env variable OPERATOR_NAMESPACE
+// which is the namespace where operator pod is deployed.
+const OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
+
+// GetOperatorNamespace returns the namespace where the operator is deployed.
+func GetOperatorNamespace() (string, error) {
+	ns, found := os.LookupEnv(OperatorNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", OperatorNamespaceEnvVar)
+	}
+	return ns, nil
+}

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2630,6 +2630,10 @@ spec:
                   value: centos/postgresql-12-centos7
                 - name: PROVIDER_API_SERVER_IMAGE
                   value: quay.io/ocs-dev/ocs-operator:latest
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 image: quay.io/ocs-dev/ocs-operator:latest
                 imagePullPolicy: Always
                 name: ocs-operator

--- a/main.go
+++ b/main.go
@@ -39,7 +39,8 @@ import (
 	"github.com/red-hat-storage/ocs-operator/controllers/persistentvolume"
 	"github.com/red-hat-storage/ocs-operator/controllers/storageclassclaim"
 	"github.com/red-hat-storage/ocs-operator/controllers/storagecluster"
-	"github.com/red-hat-storage/ocs-operator/controllers/storageconsumer"
+	controllers "github.com/red-hat-storage/ocs-operator/controllers/storageconsumer"
+	"github.com/red-hat-storage/ocs-operator/controllers/util"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -169,9 +170,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorNamespace, err := util.GetOperatorNamespace()
+	if err != nil {
+		setupLog.Error(err, "unable to get opeartor namespace")
+		os.Exit(1)
+	}
 	if err = (&storageclassclaim.StorageClassClaimReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		OperatorNamespace: operatorNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "StorageClassClaim")
 		os.Exit(1)

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/operator-framework/api/pkg/lib/version"
 	csvv1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/red-hat-storage/ocs-operator/controllers/util"
 	ocsversion "github.com/red-hat-storage/ocs-operator/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -155,6 +156,14 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 			{
 				Name:  "PROVIDER_API_SERVER_IMAGE",
 				Value: *ocsContainerImage,
+			},
+			{
+				Name: util.OperatorNamespaceEnvVar,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
 			},
 		}
 


### PR DESCRIPTION
Whenever a claim is created in namespaces other than `openshift-storage` namespace we are failing to list the storagecluster because we are trying to list the storagecluster on the namespace where the claim is created and also
we are creating the ceph resources on the namespace where the claim is created but we should not do it we should only create the claims in the namespace where operator is running.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>