### PR TITLE
odf to odf: start using LoadBalancer type for ocs-provider-server svc

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -245,7 +245,8 @@ func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, inst
 
 		externalClusterClient, err := r.newExternalClusterClient(instance)
 		if err != nil {
-			return reconcile.Result{}, err
+			r.Log.Error(err, "Failed to connect to the provider cluster")
+			return reconcile.Result{}, fmt.Errorf("%s: %s", err.Error(), "Failed to connect to the provider cluster")
 		}
 		defer externalClusterClient.Close()
 
@@ -308,7 +309,8 @@ func (obj *ocsExternalResources) ensureDeleted(r *StorageClusterReconciler, inst
 
 		externalClusterClient, err := r.newExternalClusterClient(instance)
 		if err != nil {
-			return reconcile.Result{}, err
+			r.Log.Error(err, "Failed to connect to the provider cluster")
+			return reconcile.Result{}, fmt.Errorf("%s: %s", err.Error(), "Failed to connect to the provider cluster")
 		}
 		defer externalClusterClient.Close()
 


### PR DESCRIPTION
We were using service of type NodePort which is prune to failures
whenever a used node goes down or removed from a OCP cluster.

Start using the service of type LoadBalancer which creates a external IP
which can be used via consumers.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2060487

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>