### PR TITLE
cleanup: No NODE_OUTPUT_DIR to collect volume logs

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -381,7 +381,7 @@ for ns in $namespaces; do
     # Collecting ceph prepare volume logs
     volume_collection(){
         printf "collecting prepare volume logs from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
-        oc rsync -n "${ns}" "$(oc get pods -n "${ns}"| grep "${node//./}-debug"| awk '{print $1}')":/host/var/lib/rook/openshift-storage/log "${NODE_OUTPUT_DIR}"
+        oc rsync -n "${ns}" "$(oc get pods -n "${ns}"| grep "${node//./}-debug"| awk '{print $1}')":/host/var/lib/rook/openshift-storage/log "${VOLUME_OUTPUT_DIR}"
     }
 
     crash_collection(){


### PR DESCRIPTION
This commit chnages NODE_OUTPUT_DIR to
VOLUME_OUTPUT_DIR as the NODE_OUTPUT_DIR doesn't exists.
And we are creating VOLUME_OUTPUT_DIR to collect volume logs

Signed-off-by: yati1998 <ypadia@redhat.com>