### PR TITLE
enable cephfs in consumer mode.

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -565,11 +565,12 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 	}
 	// We do not want to disable CephFS csi driver in consumer mode since
 	// CephFS storageclass is available by default.
-	if !IsOCSConsumerMode(instance) {
-		if err = r.setRookCSICephFS(enableRookCSICephFS, instance); err != nil {
-			r.Log.Error(err, "Failed to set RookEnableCephFSCSIKey to EnableRookCSICephFS.", "RookEnableCephFSCSIKey", rookEnableCephFSCSIKey, "EnableRookCSICephFS", enableRookCSICephFS)
-			return err
-		}
+	if IsOCSConsumerMode(instance) {
+		enableRookCSICephFS = true
+	}
+	if err = r.setRookCSICephFS(enableRookCSICephFS, instance); err != nil {
+		r.Log.Error(err, "Failed to set RookEnableCephFSCSIKey to EnableRookCSICephFS.", "RookEnableCephFSCSIKey", rookEnableCephFSCSIKey, "EnableRookCSICephFS", enableRookCSICephFS)
+		return err
 	}
 	if extCephObjectStores != nil {
 		if err = r.createCephObjectStores(extCephObjectStores, instance); err != nil {


### PR DESCRIPTION
This commits handles the upgrade where ROOK_CSI_ENABLE_CEPHFS is set to false in 4.10 we need to change it back to true
to enable cephfs in 4.11

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>