### PR TITLE
disable cephObjectStore for IBMCloud

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -187,7 +187,7 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	platform, err := r.platform.GetPlatform(r.Client)
 	if err != nil {
 		r.Log.Error(err, "Failed to get Platform.", "Platform", platform)
-	} else if platform == v1.IBMCloudPlatformType || platform == IBMCloudCosPlatformType {
+	} else if platform == v1.IBMCloudPlatformType {
 		r.Log.Info("Increasing Mon failover timeout to 15m.", "Platform", platform)
 		cephCluster.Spec.HealthCheck.DaemonHealth.Monitor.Timeout = "15m"
 	}

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -174,10 +174,6 @@ func TestCephClusterMonTimeout(t *testing.T) {
 			label:    "case 2", // when platform is IBMCloudPlatformType
 			platform: v1.IBMCloudPlatformType,
 		},
-		{
-			label:    "case 3", // when platform is IBMCloudCosPlatformType
-			platform: IBMCloudCosPlatformType,
-		},
 	}
 
 	for _, c := range cases {
@@ -199,7 +195,7 @@ func TestCephClusterMonTimeout(t *testing.T) {
 		cc := newCephCluster(sc, "", 3, reconciler.serverVersion, nil, log)
 		err = reconciler.Client.Get(context.TODO(), mockCephClusterNamespacedName, cc)
 		assert.NilError(t, err)
-		if c.platform == v1.IBMCloudPlatformType || c.platform == IBMCloudCosPlatformType {
+		if c.platform == v1.IBMCloudPlatformType {
 			assert.Equal(t, "15m", cc.Spec.HealthCheck.DaemonHealth.Monitor.Timeout)
 		} else {
 			assert.Equal(t, "", cc.Spec.HealthCheck.DaemonHealth.Monitor.Timeout)

--- a/controllers/storagecluster/platform_detection.go
+++ b/controllers/storagecluster/platform_detection.go
@@ -6,20 +6,9 @@ import (
 	"sync"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/red-hat-storage/ocs-operator/controllers/util"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	//IBMCloud COS[Cloud Object Storage] secret name
-	ibmCloudCosSecretName = "ibm-cloud-cos-creds"
-
-	//IBMCloudPlatform with COS Secret
-	IBMCloudCosPlatformType configv1.PlatformType = "IBMCloudCosPlatform"
 )
 
 // SkipObjectStorePlatforms is a list of all PlatformTypes where CephObjectStores will not be deployed.
@@ -27,7 +16,7 @@ var SkipObjectStorePlatforms = []configv1.PlatformType{
 	configv1.AWSPlatformType,
 	configv1.GCPPlatformType,
 	configv1.AzurePlatformType,
-	IBMCloudCosPlatformType,
+	configv1.IBMCloudPlatformType,
 }
 
 // TuneFastPlatforms is a list of all PlatformTypes where TuneFastDeviceClass has to be set True.
@@ -64,15 +53,6 @@ func (p *Platform) getPlatform(c client.Client) (configv1.PlatformType, error) {
 
 	p.platform = infrastructure.Status.Platform //nolint:staticcheck
 
-	// if IBMCloudPlatformType check for COS secret in cluster
-	if p.platform == configv1.IBMCloudPlatformType {
-		platformIBM, platErr := getActualIBMPlatformType(c)
-		if platErr != nil {
-			return "", fmt.Errorf("Error checking COS secret in IBMCloud: %v", platErr)
-		}
-		p.platform = platformIBM
-	}
-
 	return p.platform, nil
 }
 
@@ -83,40 +63,6 @@ func skipObjectStore(p configv1.PlatformType) bool {
 		}
 	}
 	return false
-}
-
-func getActualIBMPlatformType(c client.Client) (configv1.PlatformType, error) {
-	isSecretPresent, secErr := IsCosSecretPresent(c)
-	if secErr != nil {
-		return "", fmt.Errorf("Error checking COS secret in IBMCloud: %v", secErr)
-	}
-	if isSecretPresent {
-		// IsIBMCloud and COS Secret present.
-		// return new CloudProviderType
-		return IBMCloudCosPlatformType, nil
-	}
-	//COS secret is not present in IBMCloudPlatform
-	return configv1.IBMCloudPlatformType, nil
-}
-
-// IsCosSecretPresent checks for ibm-cos-cred secret in the concerned namespace
-// if platform is IBMCloud, enable CephObjectStore only if ibm-cloud-cos-creds secret is not present
-// in the target namespace
-func IsCosSecretPresent(c client.Client) (bool, error) {
-	// TODO: better way to get target namespace
-	ns, nsErr := util.GetWatchNamespace()
-	if nsErr != nil {
-		return false, nsErr
-	}
-	foundSecret := &corev1.Secret{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: ibmCloudCosSecretName, Namespace: ns}, foundSecret)
-	if err != nil && errors.IsNotFound(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	// Secret is present.
-	return true, nil
 }
 
 func (r *StorageClusterReconciler) DevicesDefaultToFastForThisPlatform() (bool, error) {


### PR DESCRIPTION
CephObjectStore is disabled for all cloud platforms
Earlier, we were disabling it for IBMCloud only if COS was used as default backing store
However, with this change, we are disabling it for IBM Cloud platform irrespective of COS being used for backing store