### PR TITLE
hack: make golangci-lint.sh more verbose

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,5 +18,5 @@ linters:
     - structcheck
     - unused
     - varcheck
-    - golint
     - gofmt
+    - revive

--- a/controllers/storageclassclaim/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim/storageclassclaim_controller.go
@@ -711,7 +711,7 @@ func (r *StorageClassClaimReconciler) reconcileCephBlockPool() error {
 			return err
 		}
 		deviceSetList := r.storageCluster.Spec.StorageDeviceSets
-		var deviceSet *v1.StorageDeviceSet = nil
+		var deviceSet *v1.StorageDeviceSet
 		for i := range deviceSetList {
 			ds := &deviceSetList[i]
 			if ds.Name == "default" {

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -208,7 +208,7 @@ func (r *StorageClusterReconciler) newExternalCephObjectStoreInstances(
 		r.Log.Info("Empty RGW Endpoint specified, external CephObjectStore won't be created.")
 		return nil, nil
 	}
-	var tlsEnabled bool = false
+	var tlsEnabled = false
 	_, err := r.retrieveSecret(cephRgwTLSSecretKey, initData)
 	// if we could retrieve a TLS secret, then enable TLS
 	if err == nil {

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -126,7 +126,7 @@ func generateStorageQuotaName(storageClassName, quotaName string) string {
 // GenerateCephFSProviderParameters function generates extra parameters required for provider storage clusters
 func GenerateCephFSProviderParameters(initData *ocsv1.StorageCluster) (map[string]string, error) {
 	deviceSetList := initData.Spec.StorageDeviceSets
-	var deviceSet *ocsv1.StorageDeviceSet = nil
+	var deviceSet *ocsv1.StorageDeviceSet
 	for i := range deviceSetList {
 		ds := &deviceSetList[i]
 		if ds.Name == "default" {

--- a/hack/golangci_lint.sh
+++ b/hack/golangci_lint.sh
@@ -1,18 +1,50 @@
 #!/bin/bash
 
-set -e
-
 source hack/common.sh
 
 # check for golangci-lint in *.go files
 
-echo "Installing golangci-lint"
-
 mkdir -p ${OUTDIR_TOOLS}
-curl -JL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${OUTDIR_TOOLS}" v1.45.2
+LINT_BIN="${OUTDIR_TOOLS}/golangci-lint"
+LINT_VER="1.45.2"
+
+check_bin_exists() {
+  which "${LINT_BIN}" >/dev/null 2>&1 && [[ "$(${LINT_BIN} --version)" == *"${LINT_VER}"* ]]
+}
+
+install_from_github() {
+  SCRIPT="${OUTDIR_TOOLS}/golangci-lint_install.sh"
+  URL="https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+
+  echo ""; echo "Downloading golangci-lint installation script: ${URL}"
+  curl -JL -o "${SCRIPT}" "${URL}"
+  chmod +x "${SCRIPT}"
+
+  echo "Installing golangci-lint"
+  "${SCRIPT}" -db "${OUTDIR_TOOLS}" "v${LINT_VER}"; RET=$?
+  rm -f "${SCRIPT}"
+  return ${RET}
+}
+
+install_from_downstream() {
+  TGZ="${OUTDIR_TOOLS}/golangci-lint.tgz"
+  URL="https://mirror2.openshift.com/pub/ci/x86_64/golangci-lint/golangci-lint-${LINT_VER}/golangci-lint-${LINT_VER}-linux-amd64.tar.gz"
+
+  echo ""; echo "Upstream installation failed, trying downstream fallback: ${URL}"
+  curl -JL -o "${TGZ}" "${URL}"
+  tar -xzf "${TGZ}" -C "${OUTDIR_TOOLS}" --strip-components=1 "*/golangci-lint"; RET=$?
+  rm -f "${TGZ}"
+  return ${RET}
+}
+
+if ! (check_bin_exists || install_from_github || install_from_downstream); then
+  echo "Failed to install golangci-lint"
+  exit 1
+fi
+
 chmod +x "${OUTDIR_TOOLS}"/golangci-lint
 
-echo "Running golangci-lint"
+echo ""; echo "Running golangci-lint"
 GOLANGCI_LINT_CACHE=/tmp/golangci-cache "${OUTDIR_TOOLS}"/golangci-lint run ./...
 
 exit


### PR DESCRIPTION
This is to help debug problems when running in the OpenShift CI, but
also should be generally useful.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>