### PR TITLE
Removed the wildcard rbac permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,7 +23,13 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ceph.rook.io
   resources:
@@ -46,7 +52,12 @@ rules:
   - cephobjectstoreusers
   - cephrbdmirrors
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ceph.rook.io
   resources:
@@ -92,7 +103,11 @@ rules:
   resources:
   - consolequickstarts
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -114,7 +129,13 @@ rules:
   - secrets
   - services
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -147,11 +168,16 @@ rules:
   resources:
   - noobaas
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - watch
 - apiGroups:
   - ocs.openshift.io
   resources:
-  - '*'
+  - ocsinitializations
+  - storageclusters
   verbs:
   - create
   - delete
@@ -225,13 +251,19 @@ rules:
   resources:
   - clusterresourcequotas
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - security.openshift.io
   resources:
@@ -256,13 +288,15 @@ rules:
   - volumesnapshotclasses
   - volumesnapshots
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
   verbs:
-  - '*'
   - create
   - delete
   - get
@@ -275,4 +309,9 @@ rules:
   resources:
   - templates
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -49,7 +49,7 @@ type OCSInitializationReconciler struct {
 	SecurityClient secv1client.SecurityV1Interface
 }
 
-// +kubebuilder:rbac:groups=ocs.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ocs.openshift.io,resources=ocsinitializations;storageclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;create;update
 // +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=get;create;update
 

--- a/controllers/persistentvolume/reconcile.go
+++ b/controllers/persistentvolume/reconcile.go
@@ -15,7 +15,7 @@ import (
 type ensureFunc func(*corev1.PersistentVolume) error
 
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch;create;update;delete
 
 // Reconcile ...
 func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -106,24 +106,24 @@ var validTopologyLabelKeys = []string{
 	labelRookPrefix,
 }
 
-// +kubebuilder:rbac:groups=ocs.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors,verbs=*
-// +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=*
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=*
-// +kubebuilder:rbac:groups=core,resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
+// +kubebuilder:rbac:groups=ocs.openshift.io,resources=ocsinitializations;storageclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors,verbs=get;list;watch;update;create;delete
+// +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=get;list;watch;patch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
-// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;patch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=*
-// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*
+// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch
-// +kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=*
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=create;update;delete;get;list
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=*
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;create;update;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=operatorconditions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=*
+// +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list;watch
 
 // Reconcile reads that state of the cluster for a StorageCluster object and makes changes based on the state read
 // and what is in the StorageCluster.Spec

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1616,7 +1616,13 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ceph.rook.io
           resources:
@@ -1639,7 +1645,12 @@ spec:
           - cephobjectstoreusers
           - cephrbdmirrors
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - ceph.rook.io
           resources:
@@ -1685,7 +1696,11 @@ spec:
           resources:
           - consolequickstarts
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
         - apiGroups:
           - coordination.k8s.io
           resources:
@@ -1707,7 +1722,13 @@ spec:
           - secrets
           - services
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -1740,11 +1761,16 @@ spec:
           resources:
           - noobaas
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - watch
         - apiGroups:
           - ocs.openshift.io
           resources:
-          - '*'
+          - ocsinitializations
+          - storageclusters
           verbs:
           - create
           - delete
@@ -1818,13 +1844,19 @@ spec:
           resources:
           - clusterresourcequotas
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
         - apiGroups:
           - route.openshift.io
           resources:
           - routes
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - security.openshift.io
           resources:
@@ -1849,13 +1881,15 @@ spec:
           - volumesnapshotclasses
           - volumesnapshots
           verbs:
-          - '*'
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - storage.k8s.io
           resources:
           - storageclasses
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -1868,7 +1902,12 @@ spec:
           resources:
           - templates
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         serviceAccountName: ocs-operator
       - rules:
         - apiGroups:

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -124,7 +124,13 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ceph.rook.io
           resources:
@@ -147,7 +153,12 @@ spec:
           - cephobjectstoreusers
           - cephrbdmirrors
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - ceph.rook.io
           resources:
@@ -193,7 +204,11 @@ spec:
           resources:
           - consolequickstarts
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
         - apiGroups:
           - coordination.k8s.io
           resources:
@@ -215,7 +230,13 @@ spec:
           - secrets
           - services
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -248,11 +269,16 @@ spec:
           resources:
           - noobaas
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - watch
         - apiGroups:
           - ocs.openshift.io
           resources:
-          - '*'
+          - ocsinitializations
+          - storageclusters
           verbs:
           - create
           - delete
@@ -326,13 +352,19 @@ spec:
           resources:
           - clusterresourcequotas
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
         - apiGroups:
           - route.openshift.io
           resources:
           - routes
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - security.openshift.io
           resources:
@@ -357,13 +389,15 @@ spec:
           - volumesnapshotclasses
           - volumesnapshots
           verbs:
-          - '*'
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - storage.k8s.io
           resources:
           - storageclasses
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -376,7 +410,12 @@ spec:
           resources:
           - templates
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         serviceAccountName: ocs-operator
       deployments:
       - name: ocs-operator


### PR DESCRIPTION
Removes the wildcard permissions from the RBAC definitions and put specific verbs, resources, and API groups to limit access provided to each service account.

Signed-off-by: Rishabh Bhandari <rishabhbhandari6@gmail.com>