### PR TITLE
ocs: Update Volume Snapshots secret name generation

### DIFF
--- a/controllers/storagecluster/volumesnapshotterclasses.go
+++ b/controllers/storagecluster/volumesnapshotterclasses.go
@@ -48,7 +48,7 @@ func newVolumeSnapshotClass(instance *ocsv1.StorageCluster, snapShotterType Snap
 		Driver: generateNameForSnapshotClassDriver(instance, snapShotterType),
 		Parameters: map[string]string{
 			"clusterID":                instance.Namespace,
-			snapshotterSecretName:      generateNameForSnapshotClassSecret(snapShotterType),
+			snapshotterSecretName:      generateNameForSnapshotClassSecret(instance, snapShotterType),
 			snapshotterSecretNamespace: instance.Namespace,
 		},
 		DeletionPolicy: snapapi.VolumeSnapshotContentDelete,


### PR DESCRIPTION
For external restriced mode the csi-secrets name will
not be default, so updating the name accordingly in the
volume snapshot class so snapshots can work

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2091998

Signed-off-by: parth-gr <paarora@redhat.com>