### PR TITLE
odf to odf: keep the old nodeport provider service

### DIFF
--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -26,7 +26,8 @@ const (
 	ocsProviderServerName  = "ocs-provider-server"
 	providerAPIServerImage = "PROVIDER_API_SERVER_IMAGE"
 
-	ocsProviderServicePort = int32(50051)
+	ocsProviderServicePort     = int32(50051)
+	ocsProviderServiceNodePort = int32(31659)
 
 	ocsProviderCertSecretName = ocsProviderServerName + "-cert"
 )
@@ -53,6 +54,14 @@ func (o *ocsProviderServer) ensureCreated(r *StorageClusterReconciler, instance 
 		return reconcile.Result{}, err
 	} else if !res.IsZero() {
 		return res, nil
+	}
+
+	// TODO: we are keeping this to enable the transition of node port based connectivity
+	// to load balancer based connectivity during 4.11 lifetime.
+	// In future versions, node port based connectivity will be deprecated
+	// and this code will be removed from the code base
+	if err := o.createNodePortService(r, instance); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	if res, err := o.createDeployment(r, instance); err != nil {
@@ -200,6 +209,44 @@ func (o *ocsProviderServer) createService(r *StorageClusterReconciler, instance 
 	return reconcile.Result{}, nil
 }
 
+func (o *ocsProviderServer) createNodePortService(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+
+	desiredService := GetProviderAPIServerServiceWithNodePort(instance)
+	actualService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desiredService.Name,
+			Namespace: desiredService.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(
+		context.TODO(), r.Client, actualService,
+		func() error {
+			desiredService.Spec.ClusterIP = actualService.Spec.ClusterIP
+			desiredService.Spec.IPFamilies = actualService.Spec.IPFamilies
+
+			if actualService.Annotations == nil {
+				actualService.Annotations = map[string]string{}
+			}
+
+			for key, value := range desiredService.Annotations {
+				actualService.Annotations[key] = value
+			}
+
+			actualService.Spec = desiredService.Spec
+			return controllerutil.SetOwnerReference(instance, actualService, r.Client.Scheme())
+		},
+	)
+	if err != nil {
+		r.Log.Error(err, "Failed to create/update service", "Name", desiredService.Name)
+		return err
+	}
+
+	r.Log.Info("Service create/update succeeded", "Name", desiredService.Name)
+
+	return nil
+}
+
 func (o *ocsProviderServer) createSecret(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
 
 	desiredSecret := GetProviderAPIServerSecret(instance)
@@ -324,6 +371,33 @@ func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service
 				},
 			},
 			Type: corev1.ServiceTypeLoadBalancer,
+		},
+	}
+}
+
+func GetProviderAPIServerServiceWithNodePort(instance *ocsv1.StorageCluster) *corev1.Service {
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ocsProviderServerName + "-node-port-svc",
+			Namespace: instance.Namespace,
+			Annotations: map[string]string{
+				"service.beta.openshift.io/serving-cert-secret-name": ocsProviderCertSecretName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+
+			Selector: map[string]string{
+				"app": "ocsProviderApiServer",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					NodePort:   ocsProviderServiceNodePort,
+					Port:       ocsProviderServicePort,
+					TargetPort: intstr.FromString("ocs-provider"),
+				},
+			},
+			Type: corev1.ServiceTypeNodePort,
 		},
 	}
 }


### PR DESCRIPTION
In ODF v4.10.z the providerService is of type nodePort so the consumer
can give any worker nodeIP:31659 to connect with the provider. But in
ODF v4.11.z this service is changed to the service of the type of
loadBalancer where the consumers will need to update the
storageProviderEndpoint to hostname:50051. The consumers won't
be able to reach out to the provider unless the storageProviderEndpoint
is updated.

Create both the services to allow consumers still be connected and
change the storageProviderEndpoint as per their cadence.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>