### PR TITLE
odf-to-odf: create default scc when updgrading

### DIFF
--- a/api/v1alpha1/storageclassclaim_types.go
+++ b/api/v1alpha1/storageclassclaim_types.go
@@ -48,6 +48,11 @@ const (
 	StorageClassClaimDeleting storageClassClaimState = "Deleting"
 )
 
+const (
+	StorageClassClaimFinalizer  = "storageclassclaim.ocs.openshift.io"
+	StorageClassClaimAnnotation = "ocs.openshift.io.storagesclassclaim"
+)
+
 // StorageClassClaimStatus defines the observed state of StorageClassClaim
 type StorageClassClaimStatus struct {
 	Phase storageClassClaimState `json:"phase,omitempty"`

--- a/controllers/storageclassclaim/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim/storageclassclaim_controller.go
@@ -73,11 +73,6 @@ type StorageClassClaimReconciler struct {
 	cephResourcesByName          map[string]*v1alpha1.CephResourcesSpec
 }
 
-const (
-	StorageClassClaimFinalizer  = "storageclassclaim.ocs.openshift.io"
-	StorageClassClaimAnnotation = "ocs.openshift.io.storagesclassclaim"
-)
-
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclassclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclassclaims/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclients,verbs=get;list;watch;create;update;delete
@@ -162,7 +157,7 @@ func (r *StorageClassClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	enqueueStorageConsumerRequest := handler.EnqueueRequestsFromMapFunc(
 		func(obj client.Object) []reconcile.Request {
 			annotations := obj.GetAnnotations()
-			if annotation, found := annotations[StorageClassClaimAnnotation]; found {
+			if annotation, found := annotations[v1alpha1.StorageClassClaimAnnotation]; found {
 				parts := strings.Split(annotation, "/")
 				return []reconcile.Request{{
 					NamespacedName: types.NamespacedName{
@@ -244,10 +239,10 @@ func (r *StorageClassClaimReconciler) reconcileConsumerPhases() (reconcile.Resul
 		r.storageClassClaim.Status.Phase = v1alpha1.StorageClassClaimConfiguring
 
 		// Check if finalizers are present, if not, add them.
-		if !contains(r.storageClassClaim.GetFinalizers(), StorageClassClaimFinalizer) {
+		if !contains(r.storageClassClaim.GetFinalizers(), v1alpha1.StorageClassClaimFinalizer) {
 			storageClassClaimRef := klog.KRef(r.storageClassClaim.Name, r.storageClassClaim.Namespace)
 			r.log.Info("Finalizer not found for StorageClassClaim. Adding finalizer.", "StorageClassClaim", storageClassClaimRef)
-			r.storageClassClaim.SetFinalizers(append(r.storageClassClaim.GetFinalizers(), StorageClassClaimFinalizer))
+			r.storageClassClaim.SetFinalizers(append(r.storageClassClaim.GetFinalizers(), v1alpha1.StorageClassClaimFinalizer))
 			if err := r.update(r.storageClassClaim); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update StorageClassClaim [%v] with finalizer: %s", storageClassClaimRef, err)
 			}
@@ -349,7 +344,7 @@ func (r *StorageClassClaimReconciler) reconcileConsumerPhases() (reconcile.Resul
 				} else if resource.Name == "ceph-rbd" {
 					storageClass = r.getCephRBDStorageClass(data)
 				}
-				addAnnotation(storageClass, StorageClassClaimAnnotation, r.getNamespacedName())
+				addAnnotation(storageClass, v1alpha1.StorageClassClaimAnnotation, r.getNamespacedName())
 				err = r.createOrReplaceStorageClass(storageClass)
 				if err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to create or update StorageClass: %s", err)
@@ -364,7 +359,7 @@ func (r *StorageClassClaimReconciler) reconcileConsumerPhases() (reconcile.Resul
 				} else if resource.Name == "ceph-rbd" {
 					volumeSnapshotClass = r.getCephRBDVolumeSnapshotClass(data)
 				}
-				addAnnotation(volumeSnapshotClass, StorageClassClaimAnnotation, r.getNamespacedName())
+				addAnnotation(volumeSnapshotClass, v1alpha1.StorageClassClaimAnnotation, r.getNamespacedName())
 				if err := r.createOrReplaceVolumeSnapshotClass(volumeSnapshotClass); err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to create or update VolumeSnapshotClass: %s", err)
 				}
@@ -439,8 +434,8 @@ func (r *StorageClassClaimReconciler) reconcileConsumerPhases() (reconcile.Resul
 			r.log.Info("VolumeSnapshotClass already deleted", "Name", volumeSnapshotClass.Name)
 		}
 
-		if contains(r.storageClassClaim.GetFinalizers(), StorageClassClaimFinalizer) {
-			r.storageClassClaim.Finalizers = remove(r.storageClassClaim.Finalizers, StorageClassClaimFinalizer)
+		if contains(r.storageClassClaim.GetFinalizers(), v1alpha1.StorageClassClaimFinalizer) {
+			r.storageClassClaim.Finalizers = remove(r.storageClassClaim.Finalizers, v1alpha1.StorageClassClaimFinalizer)
 			if err := r.update(r.storageClassClaim); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from storageClassClaim: %s", err)
 			}
@@ -976,7 +971,7 @@ func addStorageRelatedAnnotations(obj client.Object, storageClassClaimNamespaced
 		obj.SetAnnotations(annotations)
 	}
 
-	annotations[StorageClassClaimAnnotation] = storageClassClaimNamespacedName
+	annotations[v1alpha1.StorageClassClaimAnnotation] = storageClassClaimNamespacedName
 	annotations[controllers.StorageClaimAnnotation] = storageClaim
 	annotations[controllers.StorageCephUserTypeAnnotation] = cephUserType
 }

--- a/controllers/storagecluster/external_ocs.go
+++ b/controllers/storagecluster/external_ocs.go
@@ -99,8 +99,10 @@ func (r *StorageClusterReconciler) acknowledgeOnboarding(instance *ocsv1.Storage
 	}
 
 	// claims should be created only once and should not be created/updated again if user deletes/update it.
-	err = r.createDefaultStorageClassClaims(instance)
-	if err != nil {
+	if err := r.createDefaultStorageClassClaimsForRBD(instance); err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := r.createDefaultStorageClassClaimsForCephFS(instance); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -18,6 +18,7 @@ import (
 	statusutil "github.com/red-hat-storage/ocs-operator/controllers/util"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -268,7 +269,13 @@ func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, inst
 			}
 			externalOCSResources[instance.UID] = externalConfig
 		}
+
 		externalClusterClient.Close()
+
+		if err := r.createClaimsFor410DefaultStorageClasses(instance); err != nil {
+			return reconcile.Result{}, err
+		}
+
 	} else {
 		// rhcs external mode
 		data, err := r.retrieveExternalSecretData(instance)
@@ -289,6 +296,29 @@ func (obj *ocsExternalResources) ensureCreated(r *StorageClusterReconciler, inst
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *StorageClusterReconciler) createClaimsFor410DefaultStorageClasses(instance *ocsv1.StorageCluster) error {
+
+	cephFsStorageClass := &storagev1.StorageClass{}
+	cephFsStorageClassName := generateNameForCephFilesystemSC(instance)
+	if err := r.Client.Get(r.ctx, types.NamespacedName{Name: cephFsStorageClassName}, cephFsStorageClass); err == nil {
+		err = r.createDefaultStorageClassClaimsForCephFS(instance)
+		if err != nil {
+			return fmt.Errorf("failed to created sharedfilesystem storageClassClaim %s. %v", cephFsStorageClassName, err)
+		}
+	}
+
+	cephRbdStorageClass := &storagev1.StorageClass{}
+	cephRbdStorageClassName := generateNameForCephBlockPoolSC(instance)
+	if err := r.Client.Get(r.ctx, types.NamespacedName{Name: cephRbdStorageClassName}, cephRbdStorageClass); err == nil {
+		err := r.createDefaultStorageClassClaimsForRBD(instance)
+		if err != nil {
+			return fmt.Errorf("failed to created blockpool storageClassClaim %s. %v", cephRbdStorageClassName, err)
+		}
+	}
+
+	return nil
 }
 
 // ensureDeleted is dummy func for the ocsExternalResources
@@ -340,22 +370,7 @@ func (obj *ocsExternalResources) ensureDeleted(r *StorageClusterReconciler, inst
 	return reconcile.Result{}, nil
 }
 
-// claims should be created only once and should not be created/updated again if user deletes/update it.
-func (r *StorageClusterReconciler) createDefaultStorageClassClaims(instance *ocsv1.StorageCluster) error {
-
-	storageClassClaimFile := &ocsv1alpha1.StorageClassClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      generateNameForCephFilesystemSC(instance),
-			Namespace: instance.Namespace,
-			Labels: map[string]string{
-				defaultStorageClassClaimLabel: "true",
-			},
-		},
-		Spec: ocsv1alpha1.StorageClassClaimSpec{
-			Type: "sharedfilesystem",
-		},
-	}
-
+func (r *StorageClusterReconciler) createDefaultStorageClassClaimsForRBD(instance *ocsv1.StorageCluster) error {
 	storageClassClaimBlock := &ocsv1alpha1.StorageClassClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateNameForCephBlockPoolSC(instance),
@@ -369,14 +384,28 @@ func (r *StorageClusterReconciler) createDefaultStorageClassClaims(instance *ocs
 		},
 	}
 
-	err := r.createAndOwnStorageClassClaim(instance, storageClassClaimFile)
-	if err != nil {
-		return err
+	if err := r.createAndOwnStorageClassClaim(instance, storageClassClaimBlock); err != nil {
+		return fmt.Errorf("failed to create default blockpool storageClassClaim %s. %v", storageClassClaimBlock.Name, err)
+	}
+	return nil
+}
+
+func (r *StorageClusterReconciler) createDefaultStorageClassClaimsForCephFS(instance *ocsv1.StorageCluster) error {
+	storageClassClaimFile := &ocsv1alpha1.StorageClassClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephFilesystemSC(instance),
+			Namespace: instance.Namespace,
+			Labels: map[string]string{
+				defaultStorageClassClaimLabel: "true",
+			},
+		},
+		Spec: ocsv1alpha1.StorageClassClaimSpec{
+			Type: "sharedfilesystem",
+		},
 	}
 
-	err = r.createAndOwnStorageClassClaim(instance, storageClassClaimBlock)
-	if err != nil {
-		return err
+	if err := r.createAndOwnStorageClassClaim(instance, storageClassClaimFile); err != nil {
+		return fmt.Errorf("failed to create default blockpool storageClassClaim %s. %v", storageClassClaimFile.Name, err)
 	}
 
 	return nil

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -135,6 +136,7 @@ func (r *StorageClusterReconciler) Reconcile(ctx context.Context, request reconc
 	prevLogger := r.Log
 	defer func() { r.Log = prevLogger }()
 	r.Log = r.Log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	r.ctx = ctrllog.IntoContext(ctx, r.Log)
 
 	// Fetch the StorageCluster instance
 	sc := &ocsv1.StorageCluster{}

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -1,6 +1,7 @@
 package storagecluster
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -76,6 +77,7 @@ type ImageMap struct {
 //nolint
 type StorageClusterReconciler struct {
 	client.Client
+	ctx                context.Context
 	Log                logr.Logger
 	Scheme             *runtime.Scheme
 	serverVersion      *version.Info

--- a/controllers/storagecluster/volumesnapshotterclasses.go
+++ b/controllers/storagecluster/volumesnapshotterclasses.go
@@ -130,6 +130,11 @@ func (r *StorageClusterReconciler) createSnapshotClasses(vsccs []SnapshotClassCo
 
 // ensureCreated functions ensures that snpashotter classes are created
 func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+
+	if IsOCSConsumerMode(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	vsccs := newSnapshotClassConfigurations(instance)
 
 	err := r.createSnapshotClasses(vsccs)
@@ -142,6 +147,10 @@ func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance
 
 // ensureDeleted deletes the SnapshotClasses that the ocs-operator created
 func (obj *ocsSnapshotClass) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+
+	if IsOCSConsumerMode(instance) {
+		return reconcile.Result{}, nil
+	}
 
 	vsccs := newSnapshotClassConfigurations(instance)
 	for _, vscc := range vsccs {


### PR DESCRIPTION
when upgrading from 4.10 to 4.11 default storageClassClaim(scc)
where not created. Now, in ensureCreated method we'll add a
check is scc is not created but sc is present without
annotation then we'll create the default scc.

Signed-off-by: subhamkrai <srai@redhat.com>