### PR TITLE
Add support to create volumesnapshotclass per storageclassclaim

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -254,6 +254,16 @@ rules:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
   - volumesnapshots
   verbs:
   - '*'

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1847,6 +1847,16 @@ spec:
           - snapshot.storage.k8s.io
           resources:
           - volumesnapshotclasses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
           - volumesnapshots
           verbs:
           - '*'

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -355,6 +355,16 @@ spec:
           - snapshot.storage.k8s.io
           resources:
           - volumesnapshotclasses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
           - volumesnapshots
           verbs:
           - '*'

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -618,6 +618,14 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 				Kind: "StorageClass",
 				Data: mustMarshal(rbdStorageClass)})
 
+			extR = append(extR, &pb.ExternalResource{
+				Name: "ceph-rbd",
+				Kind: "VolumeSnapshotClass",
+				Data: mustMarshal(map[string]string{
+					"clusterID": s.namespace,
+					"csi.storage.k8s.io/snapshotter-secret-name": provisionerCephClientSecret,
+				})})
+
 		case "CephFilesystemSubVolumeGroup":
 			subVolumeGroup := &rookCephv1.CephFilesystemSubVolumeGroup{}
 			err := s.client.Get(ctx, types.NamespacedName{Name: cephRes.Name, Namespace: s.namespace}, subVolumeGroup)
@@ -651,6 +659,14 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 				Kind: cephRes.Kind,
 				Data: mustMarshal(map[string]string{
 					"filesystemName": subVolumeGroup.Spec.FilesystemName,
+				})})
+
+			extR = append(extR, &pb.ExternalResource{
+				Name: "cephfs",
+				Kind: "VolumeSnapshotClass",
+				Data: mustMarshal(map[string]string{
+					"clusterID": getSubVolumeGroupClusterID(subVolumeGroup),
+					"csi.storage.k8s.io/snapshotter-secret-name": provisionerCephClientSecret,
 				})})
 		}
 	}

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -488,7 +488,7 @@ func TestOCSProviderServerRevokeStorageClassClaim(t *testing.T) {
 func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 	var (
 		mockBlockPoolClaimExtR = map[string]*externalResource{
-			"ceph-rbd": {
+			"ceph-rbd-storageclass": {
 				Name: "ceph-rbd",
 				Kind: "StorageClass",
 				Data: map[string]string{
@@ -500,6 +500,14 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 					"csi.storage.k8s.io/provisioner-secret-name":       "rook-ceph-client-3de200d5c23524a4612bde1fdbeb717e",
 					"csi.storage.k8s.io/node-stage-secret-name":        "rook-ceph-client-995e66248ad3e8642de868f461cdd827",
 					"csi.storage.k8s.io/controller-expand-secret-name": "rook-ceph-client-3de200d5c23524a4612bde1fdbeb717e",
+				},
+			},
+			"ceph-rbd-volumesnapshotclass": {
+				Name: "ceph-rbd",
+				Kind: "VolumeSnapshotClass",
+				Data: map[string]string{
+					"clusterID": serverNamespace,
+					"csi.storage.k8s.io/snapshotter-secret-name": "rook-ceph-client-3de200d5c23524a4612bde1fdbeb717e",
 				},
 			},
 			"rook-ceph-client-3de200d5c23524a4612bde1fdbeb717e": {
@@ -521,7 +529,7 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 		}
 
 		mockShareFilesystemClaimExtR = map[string]*externalResource{
-			"cephfs": {
+			"cephfs-storageclass": {
 				Name: "cephfs",
 				Kind: "StorageClass",
 				Data: map[string]string{
@@ -530,6 +538,14 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 					"csi.storage.k8s.io/provisioner-secret-name":       "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",
 					"csi.storage.k8s.io/node-stage-secret-name":        "rook-ceph-client-1b042fcc8812fe4203689eec38fdfbfa",
 					"csi.storage.k8s.io/controller-expand-secret-name": "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",
+				},
+			},
+			"cephfs-volumesnapshotclass": {
+				Name: "cephfs",
+				Kind: "VolumeSnapshotClass",
+				Data: map[string]string{
+					"clusterID": "8d26c7378c1b0ec9c2455d1c3601c4cd",
+					"csi.storage.k8s.io/snapshotter-secret-name": "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",
 				},
 			},
 			"rook-ceph-client-4ffcb503ff8044c8699dac415f82d604": {
@@ -818,7 +834,13 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 
 	for i := range storageConRes.ExternalResource {
 		extResource := storageConRes.ExternalResource[i]
-		mockResoruce, ok := mockBlockPoolClaimExtR[extResource.Name]
+		name := extResource.Name
+		if extResource.Kind == "VolumeSnapshotClass" {
+			name = fmt.Sprintf("%s-volumesnapshotclass", name)
+		} else if extResource.Kind == "StorageClass" {
+			name = fmt.Sprintf("%s-storageclass", name)
+		}
+		mockResoruce, ok := mockBlockPoolClaimExtR[name]
 		assert.True(t, ok)
 
 		data, err := json.Marshal(mockResoruce.Data)
@@ -839,7 +861,13 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 
 	for i := range storageConRes.ExternalResource {
 		extResource := storageConRes.ExternalResource[i]
-		mockResoruce, ok := mockShareFilesystemClaimExtR[extResource.Name]
+		name := extResource.Name
+		if extResource.Kind == "VolumeSnapshotClass" {
+			name = fmt.Sprintf("%s-volumesnapshotclass", name)
+		} else if extResource.Kind == "StorageClass" {
+			name = fmt.Sprintf("%s-storageclass", name)
+		}
+		mockResoruce, ok := mockShareFilesystemClaimExtR[name]
 		assert.True(t, ok)
 
 		data, err := json.Marshal(mockResoruce.Data)


### PR DESCRIPTION
When we storageclassclaim is created we are creating the storageclass object for it. Like storageclass, we need to create the volumesnapshotclass to support snapshot functionality.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

cc @nb-ohad 

/hold still need testing