### PR TITLE
Fix 'CephOSDVersionMismatch' and 'CephMonVersionMismatch' alerts

### DIFF
--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -263,7 +263,7 @@ spec:
         severity_level: warning
         storage_type: ceph
       expr: |
-        count(count(ceph_osd_metadata{job="rook-ceph-mgr"}) by (ceph_version, namespace)) by (ceph_version, namespace) > 1
+        count by (namespace) (count by (ceph_version, namespace) (ceph_osd_metadata{job="rook-ceph-mgr", ceph_version != ""})) > 1
       for: 10m
       labels:
         severity: warning
@@ -274,7 +274,7 @@ spec:
         severity_level: warning
         storage_type: ceph
       expr: |
-        count(count(ceph_mon_metadata{job="rook-ceph-mgr", ceph_version != ""}) by (ceph_version)) > 1
+        count by (namespace) (count by (ceph_version, namespace) (ceph_mon_metadata{job="rook-ceph-mgr", ceph_version != ""})) > 1
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Alerts, 'CephOSDVersionMismatch' and 'CephMonVersionMismatch' had a
minor issue in the query. Earlier we were counting a combination of
'namespace' and 'ceph_version', but in actual we should count
only by 'namespace' (for the second count) thus making sure we don't
have more than one ceph versions in a single namespace.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>