### PR TITLE
Enable rbd-mirror daemon restart config automatically

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -28,6 +28,7 @@ const (
 var (
 	defaultRookConfigData = `
 [global]
+rbd_mirror_die_after_seconds = 3600
 bdev_flock_retry = 20
 mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8


### PR DESCRIPTION
Currently, the user has to set this value ceph config set global rbd_mirror_die_after_seconds 3600 via the toolbox,
and that is not a good way for the customer as they don't have toolbox access. So setting this value in the rook-config-override 
configmap.

Note- it will work on fresh clusters not on the upgraded cluster as someone needs to restart rook pods after this configuration is applied

BZ Link-
[https://bugzilla.redhat.com/show_bug.cgi?id=2093266](https://bugzilla.redhat.com/show_bug.cgi?id=2093266)


Signed-off-by: Malay Kumar Parida <mparida@redhat.com>