### PR TITLE
must-gather: removes duplicate pods -owide output

### DIFF
--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -40,7 +40,6 @@ mkdir -p "${BASE_COLLECTION_PATH}/oc_output/"
 commands_get=()
 
 # collect oc output of OC get commands
-commands_get+=("pods -owide")
 commands_get+=("subscription")
 commands_get+=("csv")
 commands_get+=("installplan")


### PR DESCRIPTION
The output of `oc get pods -owide` is collected
twice in must-gather.
1. As pods -owide
2. As all -owide
This commit removes collecting output of get pods
-owide separately

Signed-off-by: yati1998 <ypadia@redhat.com>