### PR TITLE
add metrics for total objects and bucket count

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -67,6 +67,18 @@ spec:
         system_type: OCS
         system_vendor: Red Hat
       record: odf_system_latency_seconds
+    - expr: |
+        sum by (namespace, managedBy, job, service) (ocs_objectbucket_objects_total)
+      labels:
+        system_type: OCS
+        system_vendor: Red Hat
+      record: odf_system_objects_total
+    - expr: |
+        ocs_objectbucket_count_total
+      labels:
+        system_type: OCS
+        system_vendor: Red Hat
+      record: odf_system_bucket_count
   - name: odf-obc-quota-alert.rules
     rules:
     - alert: ObcQuotaBytesAlert

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -67,6 +67,18 @@ spec:
         system_type: OCS
         system_vendor: Red Hat
       record: odf_system_latency_seconds
+    - expr: |
+        sum by (namespace, managedBy, job, service) (ocs_objectbucket_objects_total)
+      labels:
+        system_type: OCS
+        system_vendor: Red Hat
+      record: odf_system_objects_total
+    - expr: |
+        ocs_objectbucket_count_total
+      labels:
+        system_type: OCS
+        system_vendor: Red Hat
+      record: odf_system_bucket_count
   - name: mirroring-alert.rules
     rules:
     - alert: OdfMirrorDaemonStatus

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -112,6 +112,26 @@
               system_type: 'OCS',
             },
           },
+          {
+            record: 'odf_system_objects_total',
+            expr: |||
+              sum by (namespace, managedBy, job, service) (ocs_objectbucket_objects_total)
+            ||| % $._config,
+            labels: {
+              system_vendor: 'Red Hat',
+              system_type: 'OCS',
+            },
+          },
+          {
+            record: 'odf_system_bucket_count',
+            expr: |||
+              ocs_objectbucket_count_total
+            ||| % $._config,
+            labels: {
+              system_vendor: 'Red Hat',
+              system_type: 'OCS',
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
this commit adds metrics for total number of objects in the rgw buckets
created by the user, also adds the number of object bucket.

Jira Issue: https://issues.redhat.com/browse/RHSTOR-3471