### PR TITLE
Bug 2107073: [release-4.10] mark enableRookCSICephFS as true always in consumer cluster

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -437,6 +437,11 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 		r.Log.Error(err, "Failed to create needed StorageClasses.")
 		return err
 	}
+	// We do not want to disable CephFS csi driver in consumer mode since
+	// CephFS storageclass is available by default.
+	if isOCSConsumerMode(instance) {
+		enableRookCSICephFS = true
+	}
 	if err = r.setRookCSICephFS(enableRookCSICephFS, instance); err != nil {
 		r.Log.Error(err, "Failed to set RookEnableCephFSCSIKey to EnableRookCSICephFS.", "RookEnableCephFSCSIKey", rookEnableCephFSCSIKey, "EnableRookCSICephFS", enableRookCSICephFS)
 		return err


### PR DESCRIPTION
We do not want to disable CephFS CSI driver in consumer mode since
CephFS storageclass is available by default.

This is a fix for the problem that ROOK_CSI_ENABLE_CEPHFS is "false" after upgrading the provider cluster alone to ODF 4.11.0.

Fixes-
https://bugzilla.redhat.com/show_bug.cgi?id=2110274
https://bugzilla.redhat.com/show_bug.cgi?id=2107073

This is the manual backport of this PR-https://github.com/red-hat-storage/ocs-operator/pull/1710.
Which was a fix for https://bugzilla.redhat.com/show_bug.cgi?id=2096823. A manual backport was chosen as there was a chain of merge conflicts with automated cherry-pick.

