### PR TITLE
Additional rules required for external clusters

### DIFF
--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -802,7 +802,7 @@ func TestParsePrometheusRules(t *testing.T) {
 
 	prometheusRules, err = parsePrometheusRule(externalPrometheusRules)
 	assert.NilError(t, err)
-	assert.Equal(t, 1, len(prometheusRules.Spec.Groups))
+	assert.Equal(t, 2, len(prometheusRules.Spec.Groups))
 }
 
 func TestGetNetworkSpec(t *testing.T) {

--- a/controllers/storagecluster/prometheus/externalcephrules.yaml
+++ b/controllers/storagecluster/prometheus/externalcephrules.yaml
@@ -8,6 +8,11 @@ metadata:
   namespace: rook-ceph
 spec:
   groups:
+  - name: ceph.rules
+    rules:
+    - expr: |
+        count(kube_persistentvolume_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})
+      record: job:kube_pv:count
   - name: persistent-volume-alert.rules
     rules:
     - alert: PersistentVolumeUsageNearFull


### PR DESCRIPTION
Require job:kube_pv:count metric from external ceph clusters
Signed-off-by: Kaustav Majumder <kmajumde@redhat.com>