### PR TITLE
Enable adjustable control for sidecar logs

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2832,6 +2832,8 @@ spec:
                       effect: NoSchedule
                 - name: CSI_LOG_LEVEL
                   value: "5"
+                - name: CSI_SIDECAR_LOG_LEVEL
+                  value: "1"
                 - name: CSI_ENABLE_CSIADDONS
                   value: "true"
                 - name: NODE_NAME

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -265,6 +265,10 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				Value: "5",
 			},
 			{
+				Name:  "CSI_SIDECAR_LOG_LEVEL",
+				Value: "1",
+			},
+			{
 				Name:  "CSI_ENABLE_CSIADDONS",
 				Value: "true",
 			},


### PR DESCRIPTION
Refers- [RHSTOR-3627](https://issues.redhat.com/browse/RHSTOR-3627)

instead of just having one CSI_LOG_LEVEL, we are adding
one more control for sidecar logs. The default value, for
now, would be "1".

More implementation-related details are here-
[ceph/ceph-csi/pull/3264](https://github.com/ceph/ceph-csi/pull/3264)
[rook/rook/pull/10639](https://github.com/rook/rook/pull/10639)


