### PR TITLE
Initialize the rookcephoperatorconfig CM while creation & cleanup externalresources test

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -182,6 +182,8 @@ func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
 			Namespace: namespace,
 		},
 	}
+	data := make(map[string]string)
+	config.Data = data
 
 	return config
 }

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -12,7 +12,6 @@ import (
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	api "github.com/red-hat-storage/ocs-operator/api/v1"
-	"github.com/red-hat-storage/ocs-operator/controllers/defaults"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -88,11 +87,6 @@ func TestEnsureExternalStorageClusterResources(t *testing.T) {
 }
 
 func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
-	var defaultCSIToleration = `
-- key: ` + defaults.NodeTolerationKey + `
-  operator: Equal
-  value: "true"
-  effect: NoSchedule`
 	config := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rookCephOperatorConfigName,
@@ -100,9 +94,6 @@ func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
 		},
 	}
 	data := make(map[string]string)
-	data["CSI_PROVISIONER_TOLERATIONS"] = defaultCSIToleration
-	data["CSI_PLUGIN_TOLERATIONS"] = defaultCSIToleration
-	data["CSI_LOG_LEVEL"] = "5"
 	config.Data = data
 	return config
 }


### PR DESCRIPTION
We recently merged [ocs-operator/pull/1648](https://github.com/red-hat-storage/ocs-operator/pull/1648), in which we moved the configurations from the CM to csv env. But we forgot to initialize the CM while it's being created, which may create unexpected behavior elsewhere.

And we also forgot to clean up the externalresources_test, which had tests for those variables which we moved.