### PR TITLE
Add two new variables for Ceph-CSI to set as metadata on RBD & CephFS

### DIFF
--- a/controllers/ocsinitialization/ocsoperator_config.go
+++ b/controllers/ocsinitialization/ocsoperator_config.go
@@ -1,0 +1,78 @@
+package ocsinitialization
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// This configmap is purely for the OCS operator to use
+	ocsOperatorConfigName = "ocs-operator-config"
+)
+
+// ensureOCSOperatorConfig ensures that the OCS operator config is present in the
+// cluster & has the correct values
+func (r *OCSInitializationReconciler) ensureOCSOperatorConfig(initialData *ocsv1.OCSInitialization) error {
+	ocsOperatorConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ocsOperatorConfigName,
+			Namespace: initialData.Namespace,
+		},
+		Data: map[string]string{
+			"CSI_CLUSTER_NAME": r.getClusterID(),
+		},
+	}
+	_, err := ctrl.CreateOrUpdate(context.TODO(), r.Client, ocsOperatorConfig, func() error {
+		err := controllerutil.SetControllerReference(initialData, ocsOperatorConfig, r.Scheme)
+		if err != nil {
+			return fmt.Errorf("failed to set owner reference: %v", err)
+		}
+		if ocsOperatorConfig.Data["CSI_CLUSTER_NAME"] != r.getClusterID() {
+			ocsOperatorConfig.Data["CSI_CLUSTER_NAME"] = r.getClusterID()
+			// restart the rook-ceph-operator pod to pick up the new change
+			r.restartRookOperatorPod(initialData.Namespace)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// getClusterID returns the cluster ID of the OCP-Cluster
+func (r *OCSInitializationReconciler) getClusterID() string {
+	clusterVersion := &configv1.ClusterVersion{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+	if err != nil {
+		r.Log.Error(err, "Failed to get the clusterVersion version of the OCP cluster")
+		return ""
+	}
+	return fmt.Sprint(clusterVersion.Spec.ClusterID)
+}
+
+// restartRookOperatorPod restarts the rook-operator pod in the OCP cluster
+func (r *OCSInitializationReconciler) restartRookOperatorPod(namespace string) {
+	podList := &corev1.PodList{}
+	err := r.Client.List(context.TODO(), podList, client.InNamespace(namespace), client.MatchingLabels{"app": "rook-ceph-operator"})
+	if err != nil {
+		r.Log.Error(err, "Failed to list rook-ceph-operator pod")
+		return
+	}
+	for _, pod := range podList.Items {
+		err := r.Client.Delete(context.TODO(), &pod)
+		if err != nil {
+			r.Log.Error(err, "Failed to delete rook-ceph-operator pod")
+			return
+		}
+	}
+}

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2816,6 +2816,13 @@ spec:
                   value: quay.io/csiaddons/k8s-sidecar:v0.2.1
                 - name: ROOK_CSI_NFS_IMAGE
                   value: k8s.gcr.io/sig-storage/nfsplugin:v3.1.0
+                - name: CSI_ENABLE_METADATA
+                  value: "true"
+                - name: CSI_CLUSTER_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_CLUSTER_NAME
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -245,6 +245,21 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				Value: *rookCsiNFSImage,
 			},
 			{
+				Name:  "CSI_ENABLE_METADATA",
+				Value: "true",
+			},
+			{
+				Name: "CSI_CLUSTER_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "CSI_CLUSTER_NAME",
+					},
+				},
+			},
+			{
 				Name: "CSI_PROVISIONER_TOLERATIONS",
 				Value: `
 - key: node.ocs.openshift.io/storage


### PR DESCRIPTION
Refers-https://issues.redhat.com/browse/RHSTOR-3269

**Add two new variables for Ceph-CSI to set as metadata on RBD & CephFS**
     
    CSI_ENABLE_METADATA variable is set directly & CSI_CLUSTER_NAME
    is set from a configmap named ocs-operator-config.
    Both of them can be overridden by editing the CM
    rook-ceph-operator-config to add these value & setting it to any
    required value.
    
**Add new configmap ocs-ocsoperator-config for pure ocs-operator use**
    
    This configmap is used only for configuration in the ocs-operator.
    Customer changes should not be made on this. This Can be useful in
    cases where we have to get something during the runtime and set
    that somewhere.