### PR TITLE
Bug 2119516:[release-4.7]expose option to force remove the OSD in osd

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -635,11 +635,22 @@ func (r *StorageClusterReconciler) ensureJobTemplates(sc *ocsv1.StorageCluster, 
 				DisplayName: "OSD IDs",
 				Required:    true,
 				Description: `
-The parameter OSD IDs needs a comma-separated list of numerical FAILED_OSD_IDs 
-when a single job removes multiple OSDs. 
-If the expected comma-separated format is not used, 
-or an ID cannot be converted to an int, 
+The parameter OSD IDs needs a comma-separated list of numerical FAILED_OSD_IDs
+when a single job removes multiple OSDs.
+If the expected comma-separated format is not used,
+or an ID cannot be converted to an int,
 or if an OSD ID is not found, errors will be generated in the log and no OSDs would be removed.`,
+			},
+			{
+				Name:        "FORCE_OSD_REMOVAL",
+				DisplayName: "Force OSD Removal",
+				Required:    false,
+				Value:       "false",
+				Description: `
+A flag indicating whether the OSD should be forcefully removed. Valid values are true or false.
+The default value is false. If an OSD is being removed that could lead to data loss, the OSD
+will not be removed by default. If you see the osd removal fails and you are sure the OSD
+should be removed, set this flag to true and run the job again.`,
 			},
 		}
 		return controllerutil.SetControllerReference(sc, osdCleanUpTemplate, r.Scheme)
@@ -696,6 +707,8 @@ func newCleanupJob(sc *ocsv1.StorageCluster) *batchv1.Job {
 								"osd",
 								"remove",
 								"--osd-ids=${FAILED_OSD_IDS}",
+								"--force-osd-removal",
+								"${FORCE_OSD_REMOVAL}",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -312,12 +312,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              metricsExporter:
-                description: MetricsExporter controls the configuration of resources for exposing StorageCluster metrics
-                properties:
-                  reconcileStrategy:
-                    type: string
-                type: object
               monDataDirHostPath:
                 type: string
               monPVCTemplate:
@@ -468,6 +462,12 @@ spec:
                         description: Phase represents the current phase of PersistentVolumeClaim.
                         type: string
                     type: object
+                type: object
+              monitoring:
+                description: Monitoring controls the configuration of resources for exposing OCS metrics
+                properties:
+                  reconcileStrategy:
+                    type: string
                 type: object
               multiCloudGateway:
                 description: MultiCloudGatewaySpec defines specific multi-cloud gateway configuration options

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -405,13 +405,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              metricsExporter:
-                description: MetricsExporter controls the configuration of resources
-                  for exposing StorageCluster metrics
-                properties:
-                  reconcileStrategy:
-                    type: string
-                type: object
               monDataDirHostPath:
                 type: string
               monPVCTemplate:
@@ -619,6 +612,13 @@ spec:
                         description: Phase represents the current phase of PersistentVolumeClaim.
                         type: string
                     type: object
+                type: object
+              monitoring:
+                description: Monitoring controls the configuration of resources for
+                  exposing OCS metrics
+                properties:
+                  reconcileStrategy:
+                    type: string
                 type: object
               multiCloudGateway:
                 description: MultiCloudGatewaySpec defines specific multi-cloud gateway

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -42,10 +42,10 @@ function dump_noobaa_csv() {
 
 	echo "Dumping Noobaa csv using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_csv_cmd"
 	# shellcheck disable=SC2086
-	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_csv_cmd) > $NOOBAA_CSV
+	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_csv_cmd) >$NOOBAA_CSV
 	echo "Dumping Noobaa crds using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_crds_cmd"
 	# shellcheck disable=SC2086
-	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_crds_cmd) > $noobaa_crds_outdir/noobaa-crd.yaml
+	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_crds_cmd) >$noobaa_crds_outdir/noobaa-crd.yaml
 }
 
 # ==== DUMP ROOK YAMLS ====
@@ -60,16 +60,16 @@ function dump_rook_csv() {
 
 	crd_list=$(mktemp)
 	echo "Dumping rook csv using command: $IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $rook_template_dir/$rook_csv_template"
-	$IMAGE_RUN_CMD --entrypoint=cat "$ROOK_IMAGE" $rook_template_dir/$rook_csv_template > $ROOK_CSV
+	$IMAGE_RUN_CMD --entrypoint=cat "$ROOK_IMAGE" $rook_template_dir/$rook_csv_template >$ROOK_CSV
 	echo "Listing rook crds using command: $IMAGE_RUN_CMD --entrypoint=ls $ROOK_IMAGE -1 $rook_crds_dir/"
-	$IMAGE_RUN_CMD --entrypoint=ls "$ROOK_IMAGE" -1 $rook_crds_dir/ > "$crd_list"
+	$IMAGE_RUN_CMD --entrypoint=ls "$ROOK_IMAGE" -1 $rook_crds_dir/ >"$crd_list"
 	# shellcheck disable=SC2013
 	for i in $(cat "$crd_list"); do
-	        # shellcheck disable=SC2059
+		# shellcheck disable=SC2059
 		crd_file=$(printf ${rook_crds_dir}/"$i" | tr -d '[:space:]')
 		echo "Dumping rook crd $crd_file using command: $IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $crd_file"
-		($IMAGE_RUN_CMD --entrypoint=cat "$ROOK_IMAGE" "$crd_file") > $rook_crds_outdir/"$(basename "$crd_file")"
-	done;
+		($IMAGE_RUN_CMD --entrypoint=cat "$ROOK_IMAGE" "$crd_file") >$rook_crds_outdir/"$(basename "$crd_file")"
+	done
 	rm -f "$crd_list"
 }
 
@@ -90,7 +90,7 @@ function gen_ocs_csv() {
 	$KUSTOMIZE edit set image ocs-dev/ocs-operator="$OCS_IMAGE"
 	popd
 	$KUSTOMIZE build config/manifests | $OPERATOR_SDK generate bundle -q --overwrite=false --version "$CSV_VERSION"
-	mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/manifests/*clusterserviceversion.yaml $OCS_CSV
+	mv bundle/manifests/*clusterserviceversion.yaml $OCS_CSV
 	cp config/crd/bases/* $ocs_crds_outdir
 }
 
@@ -103,8 +103,7 @@ gen_ocs_csv
 
 echo "Manifests sourced into $OUTDIR_TEMPLATES directory"
 
-
-mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/manifests $OCS_FINAL_DIR
-mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/metadata "$(dirname $OCS_FINAL_DIR)"/metadata
-rm -rf "$GOPATH"/src/github.com/openshift/ocs-operator/bundle
-rm "$GOPATH"/src/github.com/openshift/ocs-operator/bundle.Dockerfile
+mv bundle/manifests $OCS_FINAL_DIR
+mv bundle/metadata "$(dirname $OCS_FINAL_DIR)"/metadata
+rm -rf bundle
+rm bundle.Dockerfile


### PR DESCRIPTION
adding option to expose `--force-osd-removal` `<true/false>`.
It will help when Ceph indicates the OSD is not safe-to-destroy.

Signed-off-by: subhamkrai <srai@redhat.com>