### PR TITLE
Security fixes: privilege escalation control, run as non root, drop capabilities

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,19 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+              drop:
+                - all
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+              drop:
+                - all
+      securityContext:
+        runAsNonRoot: true

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -12,6 +12,11 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+              drop:
+                - all
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
@@ -21,3 +26,5 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      securityContext:
+        runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,4 +41,11 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+              drop:
+                - all
       terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2935,6 +2935,13 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - all
+              securityContext:
+                runAsNonRoot: true
               serviceAccountName: ocs-operator
               terminationGracePeriodSeconds: 10
               tolerations:

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -444,6 +444,13 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - all
+              securityContext:
+                runAsNonRoot: true
               serviceAccountName: ocs-operator
               terminationGracePeriodSeconds: 10
     strategy: deployment


### PR DESCRIPTION
run containers as allowPrivilegeEscalation:false
    resolves- https://bugzilla.redhat.com/show_bug.cgi?id=2114847

drop all default capabilities for containers
    resolves- https://bugzilla.redhat.com/show_bug.cgi?id=2114844

run pods as runAsNonRoot: true
    resolves- https://bugzilla.redhat.com/show_bug.cgi?id=2114840
