### PR TITLE
Fix StorageCluster is in error state for few minutes after installing

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -434,6 +434,12 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			statusutil.SetErrorCondition(&instance.Status.Conditions, reason, message)
 
 			if instance.Status.Phase != statusutil.PhaseOnboarding {
+				// if the error was due to skipped storage classes
+				// instead of error phase we will set it to progressing
+				if strings.Contains(returnErr.Error(), storageClassSkippedError) {
+					instance.Status.Phase = statusutil.PhaseProgressing
+					return reconcile.Result{Requeue: true}, nil
+				}
 				instance.Status.Phase = statusutil.PhaseError
 			}
 

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -18,6 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	storageClassSkippedError = "some StorageClasses were skipped while waiting for pre-requisites to be met"
+)
+
 // StorageClassConfiguration provides configuration options for a StorageClass.
 type StorageClassConfiguration struct {
 	storageClass      *storagev1.StorageClass
@@ -169,7 +173,7 @@ func (r *StorageClusterReconciler) createStorageClasses(sccs []StorageClassConfi
 		}
 	}
 	if len(skippedSC) > 0 {
-		return fmt.Errorf("some StorageClasses [%s] were skipped while waiting for pre-requisites to be met", strings.Join(skippedSC, ","))
+		return fmt.Errorf("%s: [%s]", storageClassSkippedError, strings.Join(skippedSC, ","))
 	}
 	return nil
 }


### PR DESCRIPTION
Resolve: https://bugzilla.redhat.com/show_bug.cgi?id=2004027

**Stop setting storagecluster to error phase just after creation**

    While storageclasses are being created it's waiting till underlying
    resources like cephBlockPool, cephFilesystem & NFS are created.
    In this phase, we are returning an error which results in the phase of the
    storagecluster to be in Error Phase creating confusion for the user.
    
    So henceforth this particular error would be caught, A requeue
    Reconcile result would be given and the storagecluster would be marked
    as in the Progressing Phase.