### PR TITLE
Integration with Thales enterprise key management

### DIFF
--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -525,6 +525,8 @@ func TestKMSConfigChanges(t *testing.T) {
 		// backward compatible test
 		{testLabel: "case 7", kmsProvider: VaultKMSProvider,
 			enabled: true, kmsAddress: "http://localhost:5678", authMethod: VaultSAAuthMethod},
+		{testLabel: "case 8", kmsProvider: ThalesKMSProvider,
+			clusterWideEncryption: true, kmsAddress: "http://localhost:5671"},
 	}
 	for _, kmsArgs := range validKMSArgs {
 		t.Run(kmsArgs.testLabel, func(t *testing.T) {
@@ -595,6 +597,8 @@ func assertCephClusterKMSConfiguration(t *testing.T, kmsArgs struct {
 		}
 		if kmsArgs.authMethod == VaultTokenAuthMethod {
 			assert.Equal(t, KMSTokenSecretName, cephCluster.Spec.Security.KeyManagementService.TokenSecretName, "Failed: %q. Expected the token-names tobe same", kmsArgs.testLabel)
+		} else if kmsArgs.kmsProvider == IbmKeyProtectKMSProvider || kmsArgs.kmsProvider == ThalesKMSProvider {
+			assert.Equal(t, kmsCM.Data[kmsProviderSecretKeyMap[kmsArgs.kmsProvider]], cephCluster.Spec.Security.KeyManagementService.TokenSecretName, "Failed: %q. Expected the token-names tobe same", kmsArgs.testLabel)
 		}
 	}
 }

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -204,8 +204,9 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 
 			// skip if KMS_PROVIDER is ibmkeyprotect or VAULT_AUTH_METHOD is kubernetes, not supported for RGW
 			if kmsConfigMap.Data["KMS_PROVIDER"] == IbmKeyProtectKMSProvider ||
+				kmsConfigMap.Data["KMS_PROVIDER"] == ThalesKMSProvider ||
 				kmsConfigMap.Data["VAULT_AUTH_METHOD"] == VaultSAAuthMethod {
-				r.Log.Info("IBMKeyProtect as KMS provider or Vault authentication via Service Account is unsupported configuration for RGW KMS, hence skipping")
+				r.Log.Info("IBMKeyProtect/Thales as KMS provider or Vault authentication via Service Account is unsupported configuration for RGW KMS, hence skipping")
 				continue
 			}
 			// Set default KMS_PROVIDER and VAULT_SECRET_ENGINE values, refer https://issues.redhat.com/browse/RHSTOR-1963

--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -33,12 +33,20 @@ const (
 	VaultSAAuthMethod = "kubernetes"
 	// IbmKeyProtectKMSProvider a constant to represent IBM hpcs KMS provider
 	IbmKeyProtectKMSProvider = "ibmkeyprotect"
+	// ThalesKMSProvider a constant to represent Thales (using KMIP) KMS provider
+	ThalesKMSProvider = "kmip"
 )
 
 var (
 	// currently supported KMS providers mapped to their address key
 	kmsProviderAddressKeyMap = map[string]string{
-		VaultKMSProvider: "VAULT_ADDR",
+		VaultKMSProvider:  "VAULT_ADDR",
+		ThalesKMSProvider: "KMIP_ENDPOINT",
+	}
+	// Mapping of KMS providers and key where corresponding Secret name is stored
+	kmsProviderSecretKeyMap = map[string]string{
+		IbmKeyProtectKMSProvider: "IBM_KP_SECRET_NAME",
+		ThalesKMSProvider:        "KMIP_SECRET_NAME",
 	}
 )
 

--- a/controllers/storagecluster/noobaa_system_reconciler_test.go
+++ b/controllers/storagecluster/noobaa_system_reconciler_test.go
@@ -447,6 +447,8 @@ func TestNoobaaKMSConfiguration(t *testing.T) {
 		// enabling only  cluster wide encryption and not kms
 		{testLabel: "case 10", kmsProvider: VaultKMSProvider, kmsDisabled: true,
 			clusterWideEncryption: true, kmsAddress: "http://localhost:5043", authMethod: VaultTokenAuthMethod},
+		{testLabel: "case 11", kmsProvider: ThalesKMSProvider,
+			clusterWideEncryption: true, kmsAddress: "http://localhost:5673"},
 	}
 	for _, kmsArgs := range allKMSArgs {
 		assertNoobaaKMSConfiguration(t, kmsArgs)
@@ -538,6 +540,8 @@ func assertNoobaaKMSConfiguration(t *testing.T, kmsArgs struct {
 			}
 			if kmsArgs.authMethod == VaultTokenAuthMethod {
 				assert.Equal(t, KMSTokenSecretName, nb.Spec.Security.KeyManagementService.TokenSecretName, fmt.Sprintf("Failed: %q. Expected the token-names tobe same", kmsArgs.testLabel))
+			} else if kmsArgs.kmsProvider == IbmKeyProtectKMSProvider || kmsArgs.kmsProvider == ThalesKMSProvider {
+				assert.Equal(t, kmsCM.Data[kmsProviderSecretKeyMap[kmsArgs.kmsProvider]], cephCluster.Spec.Security.KeyManagementService.TokenSecretName, "Failed: %q. Expected the token-names tobe same", kmsArgs.testLabel)
 			}
 		}
 	} else {


### PR DESCRIPTION
Adding new KMS (Thales), support added from UI, ceph-csi, rook and noobaa.

Signed-off-by: sanjalkatiyar <sanjaldhir@gmail.com>