### PR TITLE
Set CSI_ENABLE_METADATA by default false

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2986,7 +2986,7 @@ spec:
                 - name: ROOK_CSI_NFS_IMAGE
                   value: k8s.gcr.io/sig-storage/nfsplugin:v3.1.0
                 - name: CSI_ENABLE_METADATA
-                  value: "true"
+                  value: "false"
                 - name: CSI_CLUSTER_NAME
                   valueFrom:
                     configMapKeyRef:

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -246,7 +246,7 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 			},
 			{
 				Name:  "CSI_ENABLE_METADATA",
-				Value: "true",
+				Value: "false",
 			},
 			{
 				Name: "CSI_CLUSTER_NAME",


### PR DESCRIPTION
We don't want to enable metadata for CSI driver by default.
If a customer wants to enable metadata they can edit the
rook-ceph-operator-config cm to set CSI_ENABLE_METADATA to true.

oc patch cm rook-ceph-operator-config -p $'data:\n "CSI_ENABLE_METADATA":  "true"'

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>