### PR TITLE
must-gather: add ceph log last commands

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -75,6 +75,8 @@ ceph_commands+=("ceph service dump")
 ceph_commands+=("ceph status")
 ceph_commands+=("ceph time-sync-status")
 ceph_commands+=("ceph versions")
+ceph_commands+=("ceph log last 10000 debug cluster")
+ceph_commands+=("ceph log last 10000 debug audit")
 
 # Ceph volume commands
 ceph_volume_commands+=()


### PR DESCRIPTION
Add ceph log last commands to collect ceph cluster
logs to ease debugging from RADOS perspective. 

NOTE: Currently, the ceph log last command returns only
50 cluster log entries at max even if we specify 10000
(mon_log_max) log entries to be retrieved in the log
last command. This will be fixed with ceph PR#47873.

Signed-off-by: Prashant D <pdhange@redhat.com>