### PR TITLE
🧹hack scripts shebang cleanup

### DIFF
--- a/hack/build-appregistry.sh
+++ b/hack/build-appregistry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-container.sh
+++ b/hack/build-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-master-appregistry.sh
+++ b/hack/build-master-appregistry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-metrics-exporter.sh
+++ b/hack/build-metrics-exporter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-must-gather.sh
+++ b/hack/build-must-gather.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-operator-bundle.sh
+++ b/hack/build-operator-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-operator-index.sh
+++ b/hack/build-operator-index.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034
 # disable unused variable warnings

--- a/hack/docker-common.sh
+++ b/hack/docker-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034
 # disable unused variable warnings

--- a/hack/dump-debug-info.sh
+++ b/hack/dump-debug-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source hack/common.sh
 

--- a/hack/ensure-operator-sdk.sh
+++ b/hack/ensure-operator-sdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/ensure-opm.sh
+++ b/hack/ensure-opm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source hack/common.sh
 

--- a/hack/gen-deployment-yaml.sh
+++ b/hack/gen-deployment-yaml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/gen-protobuf.sh
+++ b/hack/gen-protobuf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 

--- a/hack/generate-appregistry.sh
+++ b/hack/generate-appregistry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/generate-master-appregistry.sh
+++ b/hack/generate-master-appregistry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/generate-master-bundle.sh
+++ b/hack/generate-master-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/generate-master-csv.sh
+++ b/hack/generate-master-csv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/generate-unified-csv.sh
+++ b/hack/generate-unified-csv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/golangci_lint.sh
+++ b/hack/golangci_lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source hack/common.sh
 

--- a/hack/operator-sdk-common.sh
+++ b/hack/operator-sdk-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034
 # don't fail on unused variables - this is for sourcing

--- a/hack/red-hat-storage-ocs-ci-tests.sh
+++ b/hack/red-hat-storage-ocs-ci-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # https://github.com/red-hat-storage/ocs-ci/blob/master/docs/getting_started.md
 set -e
 

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check for shell syntax & style.
 

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # example: ROOK_IMAGE=build-e858f56d/ceph-amd64:latest NOOBAA_IMAGE=noobaa/noobaa-operator:1.1.0 OCS_IMAGE=placeholder CSV_VERSION=1.1.1 hack/generate-manifests.sh
 

--- a/hack/ticketgen/ticketcheck.sh
+++ b/hack/ticketgen/ticketcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   cat << EOF

--- a/hack/ticketgen/ticketgen.sh
+++ b/hack/ticketgen/ticketgen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   cat << EOF

--- a/hack/verify-dependencies.sh
+++ b/hack/verify-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 paths=('go.mod' 'go.sum' 'vendor/')
 

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -n "$(git status --porcelain api config/crd/bases)" ]]; then
  	git diff -u api config/crd/bases 

--- a/hack/verify-latest-csv.sh
+++ b/hack/verify-latest-csv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source hack/common.sh
 

--- a/hack/verify-latest-deploy-yaml.sh
+++ b/hack/verify-latest-deploy-yaml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/verify-operator-bundle.sh
+++ b/hack/verify-operator-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
# Hack scripts shebang cleanup

Improve portability among platforms. Hack script code depends on bash version 5 syntax features. Replace '#!/bin/bash' with  '#!/usr/bin/env bash' as a shebang for hack scripts.

# Specifically enable 'make gen-latest-csv' on MacOS:

➜  hack git:(hack_cleanup) ✗ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin21) <--- insufficient version 3!
Copyright (C) 2007 Free Software Foundation, Inc.
➜  hack git:(hack_cleanup) ✗ /usr/local/bin/bash --version
GNU bash, version 5.1.16(1)-release (x86_64-apple-darwin21.1.0)
Copyright (C) 2020 Free Software Foundation, Inc.

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>