### PR TITLE
Give correct name for poolName in the non-resilient pool storageclass

### DIFF
--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -442,7 +442,7 @@ func getTopologyConstrainedPools(initData *ocsv1.StorageCluster) string {
 	var topologyConstrainedPools []topologyConstrainedPool
 	for _, failureDomainValue := range initData.Status.FailureDomainValues {
 		topologyConstrainedPools = append(topologyConstrainedPools, topologyConstrainedPool{
-			PoolName: generateNameForNonResilientCephBlockPool(initData, initData.Status.FailureDomain),
+			PoolName: generateNameForNonResilientCephBlockPool(initData, failureDomainValue),
 			DomainSegments: []topologySegment{
 				{
 					DomainLabel: initData.Status.FailureDomain,


### PR DESCRIPTION
Was using the failureDomain as the poolName in the non-resilient pool storageclass. This is incorrect. The poolName should be the name of the pool which is the failureDomainValue.

This was mistakenly left from this PR https://github.com/red-hat-storage/ocs-operator/pull/1782.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>