### PR TITLE
reduce cardinality for odf_system_bucket_count and odf_system_objects_total

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -68,13 +68,13 @@ spec:
         system_vendor: Red Hat
       record: odf_system_latency_seconds
     - expr: |
-        sum by (namespace, managedBy, job, service) (ocs_objectbucket_objects_total)
+        sum (ocs_objectbucket_objects_total)
       labels:
         system_type: OCS
         system_vendor: Red Hat
       record: odf_system_objects_total
     - expr: |
-        ocs_objectbucket_count_total
+        sum (ocs_objectbucket_count_total)
       labels:
         system_type: OCS
         system_vendor: Red Hat

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -115,7 +115,7 @@
           {
             record: 'odf_system_objects_total',
             expr: |||
-              sum by (namespace, managedBy, job, service) (ocs_objectbucket_objects_total)
+              sum (ocs_objectbucket_objects_total)
             ||| % $._config,
             labels: {
               system_vendor: 'Red Hat',
@@ -125,7 +125,7 @@
           {
             record: 'odf_system_bucket_count',
             expr: |||
-              ocs_objectbucket_count_total
+               sum (ocs_objectbucket_count_total)
             ||| % $._config,
             labels: {
               system_vendor: 'Red Hat',


### PR DESCRIPTION
Remove the labels to reduce the cardinality for the odf_system_bucket_count and odf_system_objects_total metrics.