### PR TITLE
update kmsProviderAddressKeyMap

### DIFF
--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -40,8 +40,7 @@ const (
 var (
 	// currently supported KMS providers mapped to their address key
 	kmsProviderAddressKeyMap = map[string]string{
-		VaultKMSProvider:  "VAULT_ADDR",
-		ThalesKMSProvider: "KMIP_ENDPOINT",
+		VaultKMSProvider: "VAULT_ADDR",
 	}
 	// Mapping of KMS providers and key where corresponding Secret name is stored
 	kmsProviderSecretKeyMap = map[string]string{


### PR DESCRIPTION
"kmsProviderAddressKeyMap" is an object/map containing KMS with http(s) endpoint address. For Thales user can pass IP address directly as well.

Signed-off-by: sanjalkatiyar <sanjaldhir@gmail.com>