### PR TITLE
Upgrade ocs metrics exporter & ocs operator to use golang 1.18 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /go/src/github.com/red-hat-storage/ocs-operator
 COPY . .


### PR DESCRIPTION
Signed-off-by: Malay Kumar Parida <mparida@redhat.com>