### PR TITLE
WaitForCacheSync in storageclassclaim Reconcile

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,6 +180,7 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&storageclassclaim.StorageClassClaimReconciler{
+		Cache:             mgr.GetCache(),
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		OperatorNamespace: operatorNamespace,


### PR DESCRIPTION
When a storageclassclaim CR is created, a Reconcile is triggered. We are using controller runtime client does GET operation which reads from the runtime cache. When a blockpool or subvolumegroup is created, a new reconcile request will be in the queue until the existing Reconcile completes. Once the existing Reconcile completes, we will get Reconcile request for the resource in the queue and try to get the storageclassclaim object here. We have a chance to get the object from the runtime cache instead of fetching it from the apiserver. Because of it, we get stale resources created for subvolumegroup and blockpool.

As a workaround for the above problem, wait for  Cache to be synced during start of Reconcile.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>