### PR TITLE
use go1.18 for metrics exporter development builds

### DIFF
--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /go/src/github.com/red-hat-storage/ocs-operator
 COPY . .


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>