### PR TITLE
Enable RBD mirroring debugging by default

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -161,6 +161,7 @@ func getRookCephConfig(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (s
 			return "", fmt.Errorf("failed to set network configuration for rook: %v", err)
 		}
 	}
+	// configure rbd mirroring debug features by default if mirroring is enabled
 	if sc.Spec.Mirroring.Enabled {
 		var err error
 		// [global] section
@@ -168,6 +169,20 @@ func getRookCephConfig(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (s
 		if err != nil {
 			return "", fmt.Errorf("failed to set rbd mirroring debug features for rook config: %v", err)
 		}
+
+		rbdMirrorDebug :=
+			`[client.rbd-mirror.a]
+debug_ms = 1
+debug_rbd = 20
+debug_rbd_mirror = 30
+log_file = /var/log/ceph/$cluster-$name.log
+[client.rbd-mirror-peer]
+debug_ms = 1
+debug_rbd = 20
+debug_rbd_mirror = 30
+log_file = /var/log/ceph/$cluster-$name.log
+`
+		rookConfigData = rookConfigData + rbdMirrorDebug
 	}
 	return rookConfigData, nil
 }

--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -29,7 +29,6 @@ const (
 var (
 	defaultRookConfigData = `
 [global]
-rbd_mirror_die_after_seconds = 3600
 bdev_flock_retry = 20
 mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8
@@ -160,6 +159,14 @@ func getRookCephConfig(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (s
 		rookConfigData, err = updateRookConfig(rookConfigData, globalSectionKey, publicNetworkKey, cidrName)
 		if err != nil {
 			return "", fmt.Errorf("failed to set network configuration for rook: %v", err)
+		}
+	}
+	if sc.Spec.Mirroring.Enabled {
+		var err error
+		// [global] section
+		rookConfigData, err = updateRookConfig(rookConfigData, globalSectionKey, "rbd_mirror_die_after_seconds", "3600")
+		if err != nil {
+			return "", fmt.Errorf("failed to set rbd mirroring debug features for rook config: %v", err)
 		}
 	}
 	return rookConfigData, nil


### PR DESCRIPTION
Resolves- https://bugzilla.redhat.com/show_bug.cgi?id=2127186

[Enable RBD mirroring debugging by default](https://github.com/red-hat-storage/ocs-operator/commit/d8a663103aed3e3a64ac74e9f63bf6e2521a8a53) 

This will help to debug issues during preview of regional DR.
For GA these settings would be removed.

[Apply rbd_mirror_die_after_seconds only when rbd_mirroring is enabled](https://github.com/red-hat-storage/ocs-operator/commit/0eb18f6ac92e6bf244343f0c34c892c67ff206f8) 

Avoiding setting the config even when rbd_mirroring is disabled, to
avoid any future inconsistencies.

[Fix ensureCreated() to update the found configMap](https://github.com/red-hat-storage/ocs-operator/pull/1816/commits/a27a8fbf57de1681ed33a03a702b60b07d87a4f3) 

Currently we are not updating the found configMap with the new values,
We are just updating the local configMap object.
This makes the getRookCephConfig() useless.
This commit fixes that.
