### PR TITLE
Various fixes to initial GitHub Actions

### DIFF
--- a/.github/workflows/ocs-operator-ci.yaml
+++ b/.github/workflows/ocs-operator-ci.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run shellcheck
-        run: make shellcheck
+        run: make shellcheck-test
 
   golangci-lint:
     name: golangci-lint
@@ -27,29 +27,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.17", "1.18"]
+        go: ["1.18","1.19"]
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-          go-version-file: go.mod
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      # TODO: Our code currently does not pass linting using Go 1.19, so
+      # avoiding it until we bump go.mod to 1.19 as well.
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.49.0
-          args: -E gosec --timeout=6m
+
+          # The weird NO_FUTURE thing is a workaround suggested here:
+          # # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
+          args: "--out-${NO_FUTURE}format=colored-line-number --timeout=6m ./..."
 
   go-test:
-    name: go-test unit tests
+    name: go test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.17", "1.18"]
+        go: ["1.18", "1.19"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -69,8 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.17", "1.18"]
-        make-target: ["verify-deps", "verify-generated", "verify-latest-csv", "verify-operator-bundle", "verify-latest-deploy-yaml"]
+        go: ["1.18", "1.19"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -80,5 +83,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run ${{ matrix.make-target }} make target
-        run: make ${{ matrix.make-target }}
+      - name: Verify go dependencies
+        run: make verify-deps
+
+      - name: Verify generated code and configd
+        run: make verify-generated
+
+      - name: Verify CSV changes
+        run: make verify-latest-csv
+
+      - name: Verify bundle changes
+        run: make verify-operator-bundle
+
+      - name: Verify deployment YAML
+        run: make verify-latest-deploy-yaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,14 +9,11 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - unused
-    - varcheck
     - gofmt
     - revive

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ verify-latest-csv: gen-latest-csv
 	@echo "Verifying latest CSV"
 	hack/verify-latest-csv.sh
 
-verify-operator-bundle:
+verify-operator-bundle: operator-sdk
 	@echo "Verifying operator bundle"
 	hack/verify-operator-bundle.sh
 

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the ocs v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=ocs.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=ocs.openshift.io
 package v1alpha1
 
 import (

--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -43,7 +43,7 @@ func InitNamespacedName() types.NamespacedName {
 }
 
 // OCSInitializationReconciler reconciles a OCSInitialization object
-//nolint
+// nolint:revive
 type OCSInitializationReconciler struct {
 	client.Client
 	Log            logr.Logger

--- a/controllers/ocsinitialization/ocsinitialization_controller_test.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller_test.go
@@ -140,7 +140,6 @@ func TestNonWatchedResourceNotFound(t *testing.T) {
 	}
 }
 
-//nolint //ignoring errcheck causing the failures
 func TestNonWatchedResourceFound(t *testing.T) {
 	testcases := []struct {
 		label     string
@@ -160,6 +159,7 @@ func TestNonWatchedResourceFound(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		ctx := context.TODO()
 		_, _, reconciler := getTestParams(true, t)
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -173,18 +173,17 @@ func TestNonWatchedResourceFound(t *testing.T) {
 				Namespace: tc.namespace,
 			},
 		}
-		err := reconciler.Client.Create(nil, &ocs)
+		err := reconciler.Client.Create(ctx, &ocs)
 		assert.NoErrorf(t, err, "[%s]: failed CREATE of non watched resource", tc.label)
 		_, err = reconciler.Reconcile(context.TODO(), request)
 		assert.NoErrorf(t, err, "[%s]: failed to reconcile with non watched resource", tc.label)
 		actual := &v1.OCSInitialization{}
-		err = reconciler.Client.Get(nil, request.NamespacedName, actual)
+		err = reconciler.Client.Get(ctx, request.NamespacedName, actual)
 		assert.NoErrorf(t, err, "[%s]: failed GET of actual resource", tc.label)
 		assert.Equalf(t, statusutil.PhaseIgnored, actual.Status.Phase, "[%s]: failed to update phase of non watched resource that already exists OCS:\n%v", tc.label, actual)
 	}
 }
 
-//nolint //ignoring errcheck as causing failures
 func TestCreateWatchedResource(t *testing.T) {
 	testcases := []struct {
 		label          string
@@ -201,20 +200,19 @@ func TestCreateWatchedResource(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		ctx := context.TODO()
 		ocs, request, reconciler := getTestParams(false, t)
-		if tc.alreadyCreated {
-			reconciler.Client.Create(nil, &ocs)
-		} else {
-			err := reconciler.Client.Delete(nil, &ocs)
+		if !tc.alreadyCreated {
+			err := reconciler.Client.Delete(ctx, &ocs)
 			assert.NoError(t, err)
 
-			err = reconciler.Client.Get(nil, request.NamespacedName, &ocs)
+			err = reconciler.Client.Get(ctx, request.NamespacedName, &ocs)
 			assert.Error(t, err)
 		}
-		_, err := reconciler.Reconcile(context.TODO(), request)
+		_, err := reconciler.Reconcile(ctx, request)
 		assert.NoError(t, err)
 		obj := v1.OCSInitialization{}
-		_ = reconciler.Client.Get(nil, request.NamespacedName, &obj)
+		_ = reconciler.Client.Get(ctx, request.NamespacedName, &obj)
 		assert.Equalf(t, obj.Name, request.Name, "[%s]: failed to create ocsInit resource with correct name", tc.label)
 		assert.Equalf(t, obj.Namespace, request.Namespace, "[%s]: failed to create ocsInit resource with correct namespace", tc.label)
 	}

--- a/controllers/storageclassclaim/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim/storageclassclaim_controller.go
@@ -58,7 +58,7 @@ const (
 )
 
 // StorageClassClaimReconciler reconciles a StorageClassClaim object
-// nolint
+// nolint:revive
 type StorageClassClaimReconciler struct {
 	client.Client
 	cache.Cache

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -79,7 +79,7 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placeme
 	return placement
 }
 
-//convertLabelToNodeSelectorRequirements returns a NodeSelectorRequirement list from a given LabelSelector
+// convertLabelToNodeSelectorRequirements returns a NodeSelectorRequirement list from a given LabelSelector
 func convertLabelToNodeSelectorRequirements(labelSelector metav1.LabelSelector) []corev1.NodeSelectorRequirement {
 	reqs := []corev1.NodeSelectorRequirement{}
 	for key, value := range labelSelector.MatchLabels {
@@ -122,7 +122,7 @@ type MatchingLabelsSelector struct {
 }
 
 // ApplyToList applies this configuration to the given list options.
-//This is implemented by MatchingLabelsSelector which implements ListOption interface.
+// This is implemented by MatchingLabelsSelector which implements ListOption interface.
 func (m MatchingLabelsSelector) ApplyToList(opts *client.ListOptions) {
 	opts.LabelSelector = m
 }

--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -344,7 +344,7 @@ func GetProviderAPIServerSecret(instance *ocsv1.StorageCluster) *corev1.Secret {
 	}
 }
 
-//RandomString - Generate a random string of A-Z chars with len = l
+// RandomString - Generate a random string of A-Z chars with len = l
 func RandomString(l int) string {
 
 	bytes := make([]byte, l)

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -74,7 +74,7 @@ type ImageMap struct {
 }
 
 // StorageClusterReconciler reconciles a StorageCluster object
-//nolint
+// nolint:revive
 type StorageClusterReconciler struct {
 	client.Client
 	ctx                context.Context

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1046,7 +1046,6 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
-//nolint //ignoring err checks as causing failures
 func TestMonCountChange(t *testing.T) {
 	for nodeCount := 0; nodeCount <= 10; nodeCount++ {
 		monCountExpected := defaults.DefaultMonCount

--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -41,8 +41,10 @@ const (
 	UninstallModeGraceful UninstallModeType = "graceful"
 )
 
-//nolint:unused // func deleteNodeAffinityKeyFromNodes is not used. For Future usuage func is created.
 // deleteNodeAffinityKeyFromNodes deletes the default NodeAffinityKey from the OCS nodes
+// This is not used, yet.
+//
+// nolint:unused
 func (r *StorageClusterReconciler) deleteNodeAffinityKeyFromNodes(sc *ocsv1.StorageCluster) (err error) {
 
 	// We should delete the label only when the StorageCluster is using the default NodeAffinityKey

--- a/controllers/storagecluster/uninstall_reconciler_test.go
+++ b/controllers/storagecluster/uninstall_reconciler_test.go
@@ -205,7 +205,8 @@ func TestDeleteSnapshotClasses(t *testing.T) {
 	}
 }
 
-//nolint // func assertTestDeleteSnapshotClasses is not used. For Future usuage func is created.
+// This function is not used, yet. It will be used in the future.
+// nolint:unused
 func assertTestDeleteSnapshotClasses(
 	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, SnapshotClassExists bool) {
 
@@ -545,7 +546,8 @@ func TestDeleteCephBlockPools(t *testing.T) {
 	}
 }
 
-//nolint // func assertTestDeleteCephBlockPools is not used. For Future usuage func is created.
+// This function is not used, yet. It will be used in the future.
+// nolint:unused
 func assertTestDeleteCephBlockPools(
 	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, cephBlockPoolsExist bool) {
 

--- a/functests/common.go
+++ b/functests/common.go
@@ -20,7 +20,7 @@ func debug(msg string, args ...interface{}) {
 	ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf(msg, args...)))
 }
 
-//RunMustGather runs the OCS must-gather container image
+// RunMustGather runs the OCS must-gather container image
 func RunMustGather() error {
 	gopath := os.Getenv("GOPATH")
 	cmd := exec.Command("/bin/bash", gopath+"/src/github.com/red-hat-storage/ocs-operator/hack/dump-debug-info.sh")

--- a/hack/golangci_lint.sh
+++ b/hack/golangci_lint.sh
@@ -6,7 +6,7 @@ source hack/common.sh
 
 mkdir -p ${OUTDIR_TOOLS}
 LINT_BIN="${OUTDIR_TOOLS}/golangci-lint"
-LINT_VER="1.47.3"
+LINT_VER="1.49.0"
 
 check_bin_exists() {
   which "${LINT_BIN}" >/dev/null 2>&1 && [[ "$(${LINT_BIN} --version)" == *"${LINT_VER}"* ]]

--- a/hack/verify-operator-bundle.sh
+++ b/hack/verify-operator-bundle.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-source hack/common.sh
+source hack/ensure-operator-sdk.sh
 source hack/docker-common.sh
-source hack/operator-sdk-common.sh
 
-./"${OPERATOR_SDK}" bundle validate "$(dirname $OCS_FINAL_DIR)" -b "$IMAGE_BUILD_CMD" --verbose
+./"${OPERATOR_SDK}" bundle validate "$(dirname $OCS_FINAL_DIR)" --verbose

--- a/metrics/internal/collectors/object-bucket_test.go
+++ b/metrics/internal/collectors/object-bucket_test.go
@@ -22,7 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-/*const (
+/*
+const (
 getUserJSON = )
 */
 var (

--- a/metrics/internal/exporter/registry.go
+++ b/metrics/internal/exporter/registry.go
@@ -10,6 +10,7 @@ import (
 //   - prometheus.NewProcessCollector
 //   - prometheus.NewGoCollector
 //   - collectors.NewExporterVersionCollector
+//
 // This is intended to be used to expose metrics about the exporter.
 func RegisterExporterCollectors(registry *prometheus.Registry) {
 	registry.MustRegister(

--- a/pkg/deploy-manager/common.go
+++ b/pkg/deploy-manager/common.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -50,7 +49,7 @@ func (t *DeployManager) RemoveAllFinalizers(namespace string) error {
 	}
 
 	for _, gv := range gvs {
-		kinds := scheme.Scheme.KnownTypes(gv)
+		kinds := scheme.KnownTypes(gv)
 		for kind := range kinds {
 			// For some reason, meta Kinds get added to each project's scheme. Skip
 			// those and Lists Kinds.

--- a/test/crd_validation_test.go
+++ b/test/crd_validation_test.go
@@ -45,7 +45,7 @@ func TestSampleCustomResources(t *testing.T) {
 	}
 }
 
-//nolint
+// nolint
 func validateCustomResources(t *testing.T, root string, crd string, prefix string) {
 	schema := getSchema(t, fmt.Sprintf("%s/%s", root, crd))
 	assert.NotNil(t, schema)
@@ -110,7 +110,7 @@ func TestCompleteCRD(t *testing.T) {
 	}
 }
 
-//nolint
+// nolint
 func getSchema(t *testing.T, crd string) validation.Schema {
 	bytes, err := ioutil.ReadFile(crd)
 	assert.NoError(t, err, "Error reading CRD yaml from %v", crd)

--- a/tools/cluster-deploy/cluster-deploy.go
+++ b/tools/cluster-deploy/cluster-deploy.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -33,7 +32,7 @@ func main() {
 
 	if *yamlOutputPath != "" {
 		yaml := t.DumpYAML(*ocsCatalogSourceImage, *ocsSubscriptionChannel)
-		err := ioutil.WriteFile(*yamlOutputPath, []byte(yaml), 0644)
+		err := os.WriteFile(*yamlOutputPath, []byte(yaml), 0644)
 		if err != nil {
 			panic(err)
 		}

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -809,7 +808,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(*outputDir, finalizedCsvFilename()), []byte(writer.String()), 0644)
+	err = os.WriteFile(filepath.Join(*outputDir, finalizedCsvFilename()), []byte(writer.String()), 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -897,7 +896,7 @@ func copyCrds(ocsCSV *csvv1.ClusterServiceVersion) {
 
 	for _, dir := range crdDirs {
 		crdDir := filepath.Join(*inputCrdsDir, dir)
-		files, err := ioutil.ReadDir(crdDir)
+		files, err := os.ReadDir(crdDir)
 		if err != nil {
 			panic(err)
 		}
@@ -912,7 +911,7 @@ func copyCrds(ocsCSV *csvv1.ClusterServiceVersion) {
 	}
 
 	for _, crdFile := range crdFiles {
-		crdBytes, err := ioutil.ReadFile(crdFile)
+		crdBytes, err := os.ReadFile(crdFile)
 		if err != nil {
 			panic(err)
 		}
@@ -946,7 +945,7 @@ func copyCrds(ocsCSV *csvv1.ClusterServiceVersion) {
 			if err != nil {
 				panic(err)
 			}
-			err = ioutil.WriteFile(outputFile, []byte(writer.String()), 0644)
+			err = os.WriteFile(outputFile, []byte(writer.String()), 0644)
 			if err != nil {
 				panic(err)
 			}
@@ -956,7 +955,7 @@ func copyCrds(ocsCSV *csvv1.ClusterServiceVersion) {
 }
 
 func copyManifests() {
-	manifests, err := ioutil.ReadDir(*inputManifestsDir)
+	manifests, err := os.ReadDir(*inputManifestsDir)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
...that merged too early in #1814 ;)

The golangci-lint changes were tricky, but basically it comes down to some weirdness in running it using Go 1.19 versus Go 1.18 for golangci-lint v1.49.0. Specifically, it was this change in 1.48.0 that was causing us so much pain: https://github.com/golangci/golangci-lint/pull/3002

In addition, the original configuration listed *both* `go-version` and `go-version-file` configuration options, and `go-version` was being taken as the preferred one. Unfortunately, our code still fails against Go 1.19 for some reason, so for the time being we're forcing the Action to target Go 1.18 across the job's config matrix. I kept the matrix at `["1.18","1.19"]` just so we don't have to change it later when we do start moving to 1.19. 

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>