### PR TITLE
FIx storagecluster deletion is stuck forever

### DIFF
--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -344,10 +344,10 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) (re
 		&ocsCephNFSService{},
 		&ocsCephFilesystems{},
 		&ocsCephBlockPools{},
-		&ocsSnapshotClass{},
 		&ocsStorageQuota{},
-		&ocsStorageClass{},
 		&ocsCephCluster{},
+		&ocsSnapshotClass{},
+		&ocsStorageClass{},
 		&ocsClusterClaim{},
 		&backingStorageClasses{},
 	}


### PR DESCRIPTION
Resolves-https://bugzilla.redhat.com/show_bug.cgi?id=2060897

Currently, during deletion of a storagecluster, the storageclasses are being deleted before the cephcluster. The PVs are not getting deleted as they need the storageclasses for that. And the PVs in turn are blocking the deletion of PVCs, Cephblockpool/cephfilesystem and finally the cephcluster. This PR moves the deletions of storageclasses to after the cephcluster deletion.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>