### PR TITLE
🧹Verify the CI index db is up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ all: ocs-operator ocs-registry ocs-must-gather
 	gen-latest-prometheus-rules-yamls \
 	verify-latest-deploy-yaml \
 	verify-latest-csv \
+	verify-latest-ci-index-db \
 	source-manifests \
 	cluster-deploy \
 	cluster-clean \
@@ -112,6 +113,10 @@ gen-release-csv: operator-sdk manifests kustomize
 verify-latest-csv: gen-latest-csv
 	@echo "Verifying latest CSV"
 	hack/verify-latest-csv.sh
+
+verify-latest-ci-index-db:
+	@echo "Verifying latest CI index db"
+	hack/verify-latest-ci-index-db.sh
 
 verify-operator-bundle: operator-sdk
 	@echo "Verifying operator bundle"

--- a/hack/verify-latest-ci-index-db.sh
+++ b/hack/verify-latest-ci-index-db.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Verify the CI index db of the current commit
+# is up to date.
+#
+
+source hack/common.sh
+
+set -e
+
+INDEXDB="./openshift-ci/database/index.db"
+BUILDINDEXDB="./openshift-ci/build-operator-index-ci.sh"
+
+#
+# Check the original CI index db exists
+#
+if [ ! -f ${INDEXDB} ]; then
+	echo "Latest ${INDEXDB} has not been generated"
+        echo "Run"
+        echo "    ${BUILDINDEXDB}"
+        echo "to generate CI index database. Then commit results."
+	exit 1
+fi
+
+#
+# Verify the CI index db is commited
+#
+if [[ -n "$(git status --porcelain ${INDEXDB} )" ]]; then
+	echo "Uncommitted CI index db changes. Commit your results."
+	exit 1
+fi
+
+#
+# Dump the original CI index db
+#
+ORIGSQL=$(mktemp)
+if ! sqlite3 ${INDEXDB} .dump | grep -v schema_migrations | uniq | sort > ${ORIGSQL}; then
+	echo "Failed to dump original CI index db"
+	exit 1
+fi
+
+#
+# Update the CI index db
+#
+if ! ${BUILDINDEXDB};  then
+	echo "Failed to run ${BUILDINDEXDB}"
+	exit 1
+fi
+
+#
+# Dump the generated CI index db
+#
+NEWSQL=$(mktemp)
+if ! sqlite3 ${INDEXDB} .dump | grep -v schema_migrations | uniq | sort > ${NEWSQL}; then
+	echo "Failed to dump new CI index db"
+	exit 1
+fi
+
+#
+# Poor's man compare of the database content
+#
+if ! diff -u ${ORIGSQL} ${NEWSQL}; then
+	echo "uncommitted CI index database. run ${BUILDINDEXDB} and commit results."
+	exit 1
+fi
+
+#
+# Clean up
+#
+rm -rf ${ORIGSQL} ${NEWSQL}
+git checkout ${INDEXDB}
+
+echo "Success: ${INDEXDB} is up to date"


### PR DESCRIPTION
Add a hack script to verify the CI index database of the commit is up to date. To be added to CI operator main workflow
    https://github.com/openshift/release/blob/master/ci-operator/config/red-hat-storage/ocs-operator/red-hat-storage-ocs-operator-main.yaml
Similar to verify-latest-csv

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>