### PR TITLE
[WIP] Pass a common set of SharedIndexInformer objects to collectors

### DIFF
--- a/metrics/internal/collectors/ceph-block-pool.go
+++ b/metrics/internal/collectors/ceph-block-pool.go
@@ -33,6 +33,7 @@ func NewCephBlockPoolCollector(opts *options.Options) *CephBlockPoolCollector {
 	client, err := rookclient.NewForConfig(opts.Kubeconfig)
 	if err != nil {
 		klog.Error(err)
+		return nil
 	}
 
 	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephblockpools", metav1.NamespaceAll, fields.Everything())

--- a/metrics/internal/collectors/ceph-block-pool.go
+++ b/metrics/internal/collectors/ceph-block-pool.go
@@ -6,8 +6,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	cephv1listers "github.com/rook/rook/pkg/client/listers/ceph.rook.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
@@ -29,16 +27,14 @@ type CephBlockPoolCollector struct {
 }
 
 // NewCephBlockPoolCollector constructs a collector
-func NewCephBlockPoolCollector(opts *options.Options) *CephBlockPoolCollector {
-	client, err := rookclient.NewForConfig(opts.Kubeconfig)
-	if err != nil {
-		klog.Error(err)
-		return nil
+func NewCephBlockPoolCollector(opts *options.Options, sharedIndexInformers ...cache.SharedIndexInformer) *CephBlockPoolCollector {
+	var sharedIndexInformer cache.SharedIndexInformer
+	if len(sharedIndexInformers) > 0 {
+		sharedIndexInformer = sharedIndexInformers[0]
+	} else {
+		rookClient := rookclient.NewForConfigOrDie(opts.Kubeconfig)
+		sharedIndexInformer = CephBlockPoolSIIAI.SharedIndexInformer(rookClient.CephV1())
 	}
-
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephblockpools", metav1.NamespaceAll, fields.Everything())
-	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &cephv1.CephBlockPool{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
 	return &CephBlockPoolCollector{
 		MirroringImageHealth: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, poolMirroringSubsystem, "image_health"),
@@ -55,11 +51,6 @@ func NewCephBlockPoolCollector(opts *options.Options) *CephBlockPoolCollector {
 		Informer:          sharedIndexInformer,
 		AllowedNamespaces: opts.AllowedNamespaces,
 	}
-}
-
-// Run starts CephBlockPool informer
-func (c *CephBlockPoolCollector) Run(stopCh <-chan struct{}) {
-	go c.Informer.Run(stopCh)
 }
 
 // Describe implements prometheus.Collector interface

--- a/metrics/internal/collectors/ceph-cluster.go
+++ b/metrics/internal/collectors/ceph-cluster.go
@@ -32,6 +32,7 @@ func NewCephClusterCollector(opts *options.Options) *CephClusterCollector {
 	client, err := rookclient.NewForConfig(opts.Kubeconfig)
 	if err != nil {
 		klog.Error(err)
+		return nil
 	}
 
 	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephclusters", metav1.NamespaceAll, fields.Everything())

--- a/metrics/internal/collectors/object-bucket.go
+++ b/metrics/internal/collectors/object-bucket.go
@@ -48,6 +48,9 @@ type ObjectBucketCollector struct {
 // NewObjectBucketCollector constructs a collector
 func NewObjectBucketCollector(opts *options.Options) *ObjectBucketCollector {
 	sharedIndexInformer := CephObjectStoreInformer(opts)
+	if sharedIndexInformer == nil {
+		return nil
+	}
 
 	return &ObjectBucketCollector{
 		OBSizeTotal: prometheus.NewDesc(

--- a/metrics/internal/collectors/rbd-mirror.go
+++ b/metrics/internal/collectors/rbd-mirror.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/red-hat-storage/ocs-operator/metrics/internal/cache"
 	internalcache "github.com/red-hat-storage/ocs-operator/metrics/internal/cache"
 	"github.com/red-hat-storage/ocs-operator/metrics/internal/options"
 	"k8s.io/klog"
@@ -173,7 +172,7 @@ func (c *RBDMirrorCollector) Collect(ch chan<- prometheus.Metric) {
 						continue
 					}
 					description := siteDescription[1]
-					desc := cache.RBDMirrorPeerSiteDescription{}
+					desc := internalcache.RBDMirrorPeerSiteDescription{}
 					err := json.Unmarshal([]byte(description), &desc)
 					if err != nil {
 						klog.Errorf("Failed to unmarshal description of image %q from site %q: %v", image.Name, site.SiteName, err)

--- a/metrics/internal/collectors/shared-index-informers.go
+++ b/metrics/internal/collectors/shared-index-informers.go
@@ -1,0 +1,72 @@
+package collectors
+
+import (
+	"github.com/red-hat-storage/ocs-operator/metrics/internal/options"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+type RESTClientInterface interface {
+	RESTClient() restclient.Interface
+}
+
+type SharedIndexInformerArrayIndex int
+
+const (
+	CephClusterSIIAI SharedIndexInformerArrayIndex = iota
+	CephObjectStoreSIIAI
+	StorageClassSIIAI
+	CephRBDMirrorSIIAI
+	CephBlockPoolSIIAI
+)
+
+func (si SharedIndexInformerArrayIndex) Resource() string {
+	resourceArr := []string{
+		"cephclusters",
+		"cephobjectstores",
+		"storageclasses",
+		"cephrbdmirrors",
+		"cephblockpools",
+	}
+	return resourceArr[si]
+}
+
+func (si SharedIndexInformerArrayIndex) RuntimeObject() runtime.Object {
+	runtimeObjectArr := []runtime.Object{
+		&cephv1.CephCluster{},
+		&cephv1.CephObjectStore{},
+		&storagev1.StorageClass{},
+		&cephv1.CephRBDMirror{},
+		&cephv1.CephBlockPool{},
+	}
+	return runtimeObjectArr[si]
+}
+
+func (si SharedIndexInformerArrayIndex) SharedIndexInformer(restClient RESTClientInterface) cache.SharedIndexInformer {
+	return getSharedIndexInformer(restClient, si.Resource(), si.RuntimeObject())
+}
+
+func getSharedIndexInformer(restClient RESTClientInterface, resource string, sampleObject runtime.Object) cache.SharedIndexInformer {
+	lw := cache.NewListWatchFromClient(restClient.RESTClient(), resource, metav1.NamespaceAll, fields.Everything())
+	return cache.NewSharedIndexInformer(lw, sampleObject, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+}
+
+func listAllSharedIndexInformers(opts *options.Options) (siiArr []cache.SharedIndexInformer) {
+	k8sClient := clientset.NewForConfigOrDie(opts.Kubeconfig)
+	rookClient := rookclient.NewForConfigOrDie(opts.Kubeconfig)
+	siiArr = []cache.SharedIndexInformer{
+		CephClusterSIIAI.SharedIndexInformer(rookClient.CephV1()),
+		CephObjectStoreSIIAI.SharedIndexInformer(rookClient.CephV1()),
+		StorageClassSIIAI.SharedIndexInformer(k8sClient),
+		CephRBDMirrorSIIAI.SharedIndexInformer(rookClient.CephV1()),
+		CephBlockPoolSIIAI.SharedIndexInformer(rookClient.CephV1()),
+	}
+	return
+}

--- a/metrics/internal/collectors/shared-index-informers_test.go
+++ b/metrics/internal/collectors/shared-index-informers_test.go
@@ -1,0 +1,45 @@
+package collectors
+
+import (
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestSharedIndexInformers(t *testing.T) {
+	resourceStrArr := []string{
+		"cephclusters",
+		"cephblockpools",
+		"cephrbdmirrors",
+		"cephobjectstores",
+		"storageclasses",
+	}
+
+	runtimeObjs := []runtime.Object{
+		&cephv1.CephCluster{},
+		&cephv1.CephBlockPool{},
+		&cephv1.CephRBDMirror{},
+		&cephv1.CephObjectStore{},
+		&storagev1.StorageClass{},
+	}
+
+	sharedIndexInformerAIArr := []SharedIndexInformerArrayIndex{
+		CephClusterSIIAI,
+		CephBlockPoolSIIAI,
+		CephRBDMirrorSIIAI,
+		CephObjectStoreSIIAI,
+		StorageClassSIIAI,
+	}
+
+	for idx, sharedIndexInformerAI := range sharedIndexInformerAIArr {
+		assert.Equal(t, resourceStrArr[idx], sharedIndexInformerAI.Resource())
+		assert.Equal(t, runtimeObjs[idx], sharedIndexInformerAI.RuntimeObject())
+	}
+
+	setKubeConfig(t)
+	siiList := listAllSharedIndexInformers(mockOpts)
+	assert.Equal(t, len(sharedIndexInformerAIArr), len(siiList))
+}


### PR DESCRIPTION
Instead of creating it's own 'SharedIndexInformer' and running them in separate go routines, Collectors can share & re-use a common set of SharedIndexInformer objects.
Added needed tests for common SharedIndexInformer changes.

This PR is on top of existing PR: https://github.com/red-hat-storage/ocs-operator/pull/1795