### PR TITLE
Added new metric for consumers connected to provider

### DIFF
--- a/deploy/bundle/manifests/exporter-role.yaml
+++ b/deploy/bundle/manifests/exporter-role.yaml
@@ -53,3 +53,11 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageconsumers
+  verbs:
+    - get
+    - list
+    - watch

--- a/metrics/deploy/rbac.yaml
+++ b/metrics/deploy/rbac.yaml
@@ -61,6 +61,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageconsumers
+  verbs:
+    - get
+    - list
+    - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/metrics/internal/collectors/ocs-client.go
+++ b/metrics/internal/collectors/ocs-client.go
@@ -1,0 +1,54 @@
+package collectors
+
+import (
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
+	"github.com/red-hat-storage/ocs-operator/metrics/internal/options"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func GetOcsClient(opts *options.Options) (*rest.RESTClient, error) {
+	ocsConfig, err := clientcmd.BuildConfigFromFlags("", opts.KubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	scheme := runtime.NewScheme()
+	utilruntime.Must(ocsv1alpha1.AddToScheme(scheme))
+	codecs := serializer.NewCodecFactory(scheme)
+	ocsConfig.GroupVersion = &ocsv1alpha1.GroupVersion
+	ocsConfig.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: codecs}
+	ocsConfig.APIPath = "/apis"
+	ocsConfig.ContentType = runtime.ContentTypeJSON
+	if ocsConfig.UserAgent == "" {
+		ocsConfig.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	ocsClient, err := rest.RESTClientFor(ocsConfig)
+	if err != nil {
+		return nil, err
+	}
+	return ocsClient, nil
+}
+
+type StorageConsumerLister interface {
+	List(selector labels.Selector) (ret []*ocsv1alpha1.StorageConsumer, err error)
+}
+
+type storageConsumerLister struct {
+	indexer cache.Indexer
+}
+
+func NewStorageConsumerLister(indexer cache.Indexer) StorageConsumerLister {
+	return &storageConsumerLister{indexer: indexer}
+}
+
+func (s *storageConsumerLister) List(selector labels.Selector) (ret []*ocsv1alpha1.StorageConsumer, err error) {
+	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*ocsv1alpha1.StorageConsumer))
+	})
+	return ret, err
+}

--- a/metrics/internal/collectors/registry.go
+++ b/metrics/internal/collectors/registry.go
@@ -27,6 +27,7 @@ func RegisterCustomResourceCollectors(registry *prometheus.Registry, opts *optio
 	cephClusterCollector := NewCephClusterCollector(opts)
 	OBMetricsCollector := NewObjectBucketCollector(opts)
 	clusterAdvanceFeatureCollector := NewClusterAdvancedFeatureCollector(opts)
+	storageConsumerCollector := NewStorageConsumerCollector(opts)
 	cephObjectStoreCollector.Run(opts.StopCh)
 	cephBlockPoolCollector.Run(opts.StopCh)
 	cephClusterCollector.Run(opts.StopCh)
@@ -40,6 +41,10 @@ func RegisterCustomResourceCollectors(registry *prometheus.Registry, opts *optio
 	if clusterAdvanceFeatureCollector != nil {
 		clusterAdvanceFeatureCollector.Run(opts.StopCh)
 		registry.MustRegister(clusterAdvanceFeatureCollector)
+	}
+	if storageConsumerCollector != nil {
+		storageConsumerCollector.Run(opts.StopCh)
+		registry.MustRegister(storageConsumerCollector)
 	}
 }
 

--- a/metrics/internal/collectors/storageconsumer.go
+++ b/metrics/internal/collectors/storageconsumer.go
@@ -1,0 +1,80 @@
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
+	"github.com/red-hat-storage/ocs-operator/metrics/internal/options"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+var _ prometheus.Collector = &StorageConsumerCollector{}
+
+type StorageConsumerCollector struct {
+	Informer                cache.SharedIndexInformer
+	StorageConsumerMetadata *prometheus.Desc
+	AllowedNamespace        string
+}
+
+func NewStorageConsumerCollector(opts *options.Options) *StorageConsumerCollector {
+	ocsClient, err := GetOcsClient(opts)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+	lw := cache.NewListWatchFromClient(ocsClient, "storageconsumers", metav1.NamespaceAll, fields.Everything())
+	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &ocsv1alpha1.StorageConsumer{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	return &StorageConsumerCollector{
+		StorageConsumerMetadata: prometheus.NewDesc(
+			prometheus.BuildFQName("ocs", "storage_consumer", "metadata"),
+			`Attributes of OCS Storage Consumers`,
+			[]string{"storage_consumer_name", "capacity", "state", "granted_capacity"},
+			nil,
+		),
+		Informer: sharedIndexInformer,
+	}
+}
+
+func (c *StorageConsumerCollector) Collect(ch chan<- prometheus.Metric) {
+	storageConsumerLister := NewStorageConsumerLister(c.Informer.GetIndexer())
+	storageConsumers := getAllStorageConsumers(storageConsumerLister, c.AllowedNamespace)
+	if len(storageConsumers) > 0 {
+		c.collectStorageConsumersMetadata(storageConsumers, ch)
+	}
+}
+
+func (c *StorageConsumerCollector) Describe(ch chan<- *prometheus.Desc) {
+	ds := []*prometheus.Desc{
+		c.StorageConsumerMetadata,
+	}
+	for _, d := range ds {
+		ch <- d
+	}
+}
+
+func (c *StorageConsumerCollector) Run(stopCh <-chan struct{}) {
+	go c.Informer.Run(stopCh)
+}
+
+func (c *StorageConsumerCollector) collectStorageConsumersMetadata(storageConsumers []*ocsv1alpha1.StorageConsumer, ch chan<- prometheus.Metric) {
+	for _, storageConsumer := range storageConsumers {
+		ch <- prometheus.MustNewConstMetric(c.StorageConsumerMetadata,
+			prometheus.GaugeValue, 1,
+			storageConsumer.Name,
+			storageConsumer.Spec.Capacity.String(),
+			string(storageConsumer.Status.State),
+			storageConsumer.Status.GrantedCapacity.String())
+	}
+}
+
+func getAllStorageConsumers(lister StorageConsumerLister, namespace string) (storageConsumers []*ocsv1alpha1.StorageConsumer) {
+	storageConsumers, err := lister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("couldn't list StorageConsumer. %v", err)
+		return nil
+	}
+	return
+}

--- a/rbac/exporter-role.yaml
+++ b/rbac/exporter-role.yaml
@@ -53,3 +53,11 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageconsumers
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
This PR creates a new metrics for  all the consumers connected to the   provider with additional metadata.
sample metric:
`ocs_storage_consumer_metadata{capacity="500",granted_capacity="500",state="Ready",storage_consumer_name="ocs-storageconsumer"} 1`

JIRA: [ODFMS-58](https://issues.redhat.com/browse/ODFMS-58)

Signed-off-by: Kaustav Majumder [kmajumde@redhat.com](mailto:kmajumde@redhat.com)