### PR TITLE
add "noobaa-standalone" daemonplacement for MCG standalone deployment

### DIFF
--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -115,6 +115,12 @@ var (
 			},
 		},
 
+		"noobaa-standalone": {
+			Tolerations: []corev1.Toleration{
+				getOcsToleration(),
+			},
+		},
+
 		"rbd-mirror": {
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),

--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -141,6 +141,9 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 		placement := getPlacement(sc, "noobaa-core")
 		nb.Spec.Tolerations = placement.Tolerations
 		nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
+	} else {
+		placement := getPlacement(sc, "noobaa-standalone")
+		nb.Spec.Tolerations = placement.Tolerations
 	}
 	nb.Spec.DBVolumeResources = &dBVolumeResources
 	nb.Spec.Image = &r.images.NooBaaCore


### PR DESCRIPTION
This PR adds a "noobaa-standalone" daemonplacement for MCG standalone deployment. This is required so that the user can set tolerations to the MCG pods in standalone mode as well via the storagecluster.

Associated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2115613

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>