### PR TITLE
add nil pointer check to ObjectStore collector

### DIFF
--- a/metrics/internal/collectors/cluster-advance-feature-use.go
+++ b/metrics/internal/collectors/cluster-advance-feature-use.go
@@ -54,6 +54,9 @@ func (c *CephObjectStoreAdvancedFeatureProvider) AdvancedFeature(namespaces ...s
 	cephObjectStoreLister := cephv1listers.NewCephObjectStoreLister(c.GetIndexer())
 	cephObjectStores := getAllObjectStores(cephObjectStoreLister, namespaces)
 	for _, cephObjectStore := range cephObjectStores {
+		if cephObjectStore.Spec.Security == nil {
+			return 0
+		}
 		if cephObjectStore.Spec.Security.KeyManagementService.IsEnabled() {
 			return 1
 		}


### PR DESCRIPTION
Add nil pointer check on ObjectStore collector to prevent crash when SecuritySpec is empty in CephObjectStore.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>