### PR TITLE
remove rbd mirror daemon restart config

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -29,7 +29,6 @@ const (
 var (
 	defaultRookConfigData = `
 [global]
-rbd_mirror_die_after_seconds = 3600
 bdev_flock_retry = 20
 mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8


### PR DESCRIPTION
Removed rbd_mirror_die_after_seconds from the rook configmap which got introduced in #1740 as this is fixed in ceph.

Ref BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2132366

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

/assign @idryomov 
/assing @ShyamsundarR 
/assing @malayparida2000