### PR TITLE
Add labels to the namespace to bypass security context requirements in e2e-test

### DIFF
--- a/pkg/deploy-manager/common.go
+++ b/pkg/deploy-manager/common.go
@@ -26,6 +26,11 @@ func (t *DeployManager) CreateNamespace(namespace string) error {
 	label := make(map[string]string)
 	// Label required for monitoring this namespace
 	label["openshift.io/cluster-monitoring"] = "true"
+	// These labels are added to bypass the security context requirements
+	label["security.openshift.io/scc.podSecurityLabelSync"] = "false"
+	label["pod-security.kubernetes.io/enforce"] = "privileged"
+	label["pod-security.kubernetes.io/warn"] = "baseline"
+	label["pod-security.kubernetes.io/audit"] = "baseline"
 	ns := &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,


### PR DESCRIPTION
With ocp 4.12 secuirty contexts are strict requirements now. But we still need privileged containers like rook to run our operator. So we need to add labels to the namespace to bypass security context requirements during the e2e-test.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>