### PR TITLE
Change to use gp2-csi storageclass instead of gp2 from 4.12 onwards

### DIFF
--- a/config/samples/ocs_v1_storagecluster.yaml
+++ b/config/samples/ocs_v1_storagecluster.yaml
@@ -7,7 +7,7 @@ spec:
   manageNodes: false
   monPVCTemplate:
     spec:
-      storageClassName: gp2
+      storageClassName: gp2-csi
       accessModes:
       - ReadWriteOnce
       resources:
@@ -20,7 +20,7 @@ spec:
     placement: {}
     dataPVCTemplate:
       spec:
-        storageClassName: gp2
+        storageClassName: gp2-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -56,7 +56,7 @@ type knownDiskType struct {
 // This list allows to specify disks from which storage classes to tune for fast
 // or slow disk optimization.
 var knownDiskTypes = []knownDiskType{
-	{diskSpeedSlow, EBS, "gp2"},
+	{diskSpeedSlow, EBS, "gp2-csi"},
 	{diskSpeedSlow, EBS, "io1"},
 	{diskSpeedFast, AzureDisk, "managed-premium"},
 }

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -104,7 +104,7 @@ var mockCephClusterNamespacedName = types.NamespacedName{
 	Namespace: mockStorageCluster.Namespace,
 }
 
-var storageClassName = "gp2"
+var storageClassName = "gp2-csi"
 var storageClassName2 = "managed-premium"
 var fakeStorageClassName = "st1"
 var volMode = corev1.PersistentVolumeBlock
@@ -328,14 +328,14 @@ func TestThrottleStorageDevices(t *testing.T) {
 		platform       *Platform
 	}{
 		{
-			label: "Case 1", // storageclass is gp2 or io1
+			label: "Case 1", // storageclass is gp2-csi or io1
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gp2",
+					Name: "gp2-csi",
 				},
 				Provisioner: string(EBS),
 				Parameters: map[string]string{
-					"type": "gp2",
+					"type": "gp2-csi",
 				},
 			},
 			deviceSets: []api.StorageDeviceSet{
@@ -354,7 +354,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 			expectedSpeed:  diskSpeedSlow,
 		},
 		{
-			label: "Case 2", // storageclass is neither gp2 nor io1
+			label: "Case 2", // storageclass is neither gp2-csi nor io1
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "st1",
@@ -433,14 +433,14 @@ func TestThrottleStorageDevices(t *testing.T) {
 			expectedSpeed:  diskSpeedSlow,
 		},
 		{
-			label: "Case 5", // storageclass is gp2 but deviceType ssd
+			label: "Case 5", // storageclass is gp2-csi but deviceType ssd
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gp2",
+					Name: "gp2-csi",
 				},
 				Provisioner: string(EBS),
 				Parameters: map[string]string{
-					"type": "gp2",
+					"type": "gp2-csi",
 				},
 			},
 			deviceSets: []api.StorageDeviceSet{
@@ -460,7 +460,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 			expectedSpeed:  diskSpeedFast,
 		},
 		{
-			label: "Case 6", // storageclass is neither gp2 nor io1 but deviceType nvme
+			label: "Case 6", // storageclass is neither gp2-csi nor io1 but deviceType nvme
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "st1",
@@ -487,7 +487,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 			expectedSpeed:  diskSpeedFast,
 		},
 		{
-			label: "Case 7", // storageclass is neither gp2 nor io1 but platform is Azure
+			label: "Case 7", // storageclass is neither gp2-csi nor io1 but platform is Azure
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "st1",
@@ -697,11 +697,11 @@ func TestStorageDeviceSets(t *testing.T) {
 	walScName := ""
 	storageClassEBS := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gp2",
+			Name: "gp2-csi",
 		},
 		Provisioner: string(EBS),
 		Parameters: map[string]string{
-			"type": "gp2",
+			"type": "gp2-csi",
 		},
 	}
 

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
                                   "storage": "10Gi"
                               }
                           },
-                          "storageClassName": "gp2"
+                          "storageClassName": "gp2-csi"
                       }
                   },
                   "storageDeviceSets": [
@@ -41,7 +41,7 @@ metadata:
                                           "storage": "1Ti"
                                       }
                                   },
-                                  "storageClassName": "gp2",
+                                  "storageClassName": "gp2-csi",
                                   "volumeMode": "Block"
                               }
                           },
@@ -1405,14 +1405,14 @@ metadata:
       [\n                        \"ReadWriteOnce\"\n                    ],\n                    \"resources\":
       {\n                        \"requests\": {\n                            \"storage\":
       \"10Gi\"\n                        }\n                    },\n                    \"storageClassName\":
-      \"gp2\"\n                }\n            },\n            \"storageDeviceSets\":
+      \"gp2-csi\"\n                }\n            },\n            \"storageDeviceSets\":
       [\n                {\n                    \"count\": 3,\n                    \"dataPVCTemplate\":
       {\n                        \"spec\": {\n                            \"accessModes\":
       [\n                                \"ReadWriteOnce\"\n                            ],\n
       \                           \"resources\": {\n                                \"requests\":
       {\n                                    \"storage\": \"1Ti\"\n                                }\n
       \                           },\n                            \"storageClassName\":
-      \"gp2\",\n                            \"volumeMode\": \"Block\"\n                        }\n
+      \"gp2-csi\",\n                            \"volumeMode\": \"Block\"\n                        }\n
       \                   },\n                    \"name\": \"example-deviceset\",\n
       \                   \"placement\": {},\n                    \"portable\": true,\n
       \                   \"resources\": {}\n                }\n            ]\n        }\n

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -31,7 +31,7 @@ metadata:
                     "storage": "10Gi"
                   }
                 },
-                "storageClassName": "gp2"
+                "storageClassName": "gp2-csi"
               }
             },
             "storageDeviceSets": [
@@ -47,7 +47,7 @@ metadata:
                         "storage": "1Ti"
                       }
                     },
-                    "storageClassName": "gp2",
+                    "storageClassName": "gp2-csi",
                     "volumeMode": "Block"
                   }
                 },

--- a/docs/multus.md
+++ b/docs/multus.md
@@ -16,7 +16,7 @@ spec:
   manageNodes: false
   monPVCTemplate:
     spec:
-      storageClassName: gp2
+      storageClassName: gp2-csi
       accessModes:
       - ReadWriteOnce
       resources:
@@ -29,7 +29,7 @@ spec:
     placement: {}
     dataPVCTemplate:
       spec:
-        storageClassName: gp2
+        storageClassName: gp2-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/pkg/deploy-manager/storagecluster.go
+++ b/pkg/deploy-manager/storagecluster.go
@@ -70,7 +70,7 @@ func (t *DeployManager) DefaultStorageCluster() (*ocsv1.StorageCluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	storageClassName := "gp2"
+	storageClassName := "gp2-csi"
 	blockVolumeMode := k8sv1.PersistentVolumeBlock
 	storageCluster := &ocsv1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -719,7 +719,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
                             "storage": "10Gi"
                         }
                     },
-                    "storageClassName": "gp2"
+                    "storageClassName": "gp2-csi"
                 }
             },
             "storageDeviceSets": [
@@ -735,7 +735,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
                                     "storage": "1Ti"
                                 }
                             },
-                            "storageClassName": "gp2",
+                            "storageClassName": "gp2-csi",
                             "volumeMode": "Block"
                         }
                     },
@@ -772,7 +772,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
                             "storage": "10Gi"
                         }
                     },
-                    "storageClassName": "gp2"
+                    "storageClassName": "gp2-csi"
                 }
             },
             "storageDeviceSets": [
@@ -788,7 +788,7 @@ The OpenShift Container Storage operator is the primary operator for OpenShift C
                                     "storage": "1Ti"
                                 }
                             },
-                            "storageClassName": "gp2",
+                            "storageClassName": "gp2-csi",
                             "volumeMode": "Block"
                         }
                     },


### PR DESCRIPTION
[Change to use gp2-csi storageclass instead of gp2](https://github.com/red-hat-storage/ocs-operator/pull/1845/commits/65a2cd821bb930fd4909757d9042256d6ffa7faa) 

Starting with ocp 4.12 the gp2 storageclass is no longer available.
So we need to use gp2-csi storageclass instead.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>