### PR TITLE
Add ShouldNot to codespell ignore list as it's a function name in ginkgo

### DIFF
--- a/.github/workflows/ocs-operator-ci.yaml
+++ b/.github/workflows/ocs-operator-ci.yaml
@@ -110,4 +110,4 @@ jobs:
           check_filenames: true
           check_hidden: true
           skip: vendor
-          ignore_words_list: xdescribe,contails
+          ignore_words_list: xdescribe,contails,shouldnot


### PR DESCRIPTION
The code spell is failing due to the function name ShouldNot, used with ginkgo.
So adding it to ignore list.
Signed-off-by: Malay Kumar Parida <mparida@redhat.com>