### PR TITLE
Don't use rook master tag in Job

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -163,7 +163,7 @@ func newExtendClusterJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephC
 					InitContainers: []corev1.Container{
 						{
 							Name:            "config-init",
-							Image:           "rook/ceph:master",
+							Image:           os.Getenv("ROOK_CEPH_IMAGE"),
 							Command:         []string{"/usr/local/bin/toolbox.sh"},
 							Args:            []string{"--skip-watch"},
 							ImagePullPolicy: "IfNotPresent",


### PR DESCRIPTION
we should not be using rook master tag in init container in product deployments
instead, we should be using rook version from env var.

Signed-off-by: subhamkrai <srai@redhat.com>