### PR TITLE
Deploy two mgr pods in a cephcluster

### DIFF
--- a/controllers/defaults/defaults.go
+++ b/controllers/defaults/defaults.go
@@ -20,6 +20,8 @@ const (
 )
 
 var (
+	// DefaultMgrCount is the default number of Ceph Manager Pods
+	DefaultMgrCount = 2
 	// DefaultMonCount is the number of monitors to be configured for the CephCluster
 	DefaultMonCount = 3
 	// ArbiterModeMonCount is the number of monitors to be configured for the CephCluster in arbiter mode

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -630,6 +630,10 @@ func getMinimumNodes(sc *ocsv1.StorageCluster) int {
 	return maxReplica
 }
 
+func getMgrCount() int {
+	return defaults.DefaultMgrCount
+}
+
 func getMonCount(nodeCount int, arbiter bool) int {
 	// return static value if overridden
 	override := os.Getenv(monCountOverrideEnvVar)
@@ -1001,14 +1005,11 @@ func generateMonSpec(sc *ocsv1.StorageCluster, nodeCount int) rookCephv1.MonSpec
 
 func generateMgrSpec(sc *ocsv1.StorageCluster) rookCephv1.MgrSpec {
 	spec := rookCephv1.MgrSpec{
+		Count: getMgrCount(),
 		Modules: []rookCephv1.Module{
 			{Name: "pg_autoscaler", Enabled: true},
 			{Name: "balancer", Enabled: true},
 		},
-	}
-
-	if arbiterEnabled(sc) {
-		spec.Count = 2
 	}
 
 	return spec


### PR DESCRIPTION
Recently in upstream Rook we did make 2 mgrs the default, and it has been very stable so we need the OCS operator to make that the default as well.

Resolves-https://bugzilla.redhat.com/show_bug.cgi?id=2130266