### PR TITLE
Update NooBaa core and endpoint default CPU resource values

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -81,11 +81,11 @@ var (
 		},
 		"noobaa-core": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceCPU:    resource.MustParse("999m"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceCPU:    resource.MustParse("999m"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
@@ -106,11 +106,11 @@ var (
 		},
 		"noobaa-endpoint": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceCPU:    resource.MustParse("999m"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceCPU:    resource.MustParse("999m"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},


### PR DESCRIPTION
## Update NooBaa core and endpoint default CPU resource values

Limit/request for the NooBaa Endpoint and Core pods is expected to be a fraction number, like 999m.
    
See
       - https://bugzilla.redhat.com/show_bug.cgi?id=2123133
       - https://github.com/noobaa/noobaa-operator/pull/830

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>