### PR TITLE
Enable verbose logging when rbd mirroing is enabled for debugging

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,8 +28,10 @@ rules:
   - batch
   resources:
   - cronjobs
+  - jobs
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/controllers/storagecluster/cephrbdmirrors.go
+++ b/controllers/storagecluster/cephrbdmirrors.go
@@ -3,19 +3,28 @@ package storagecluster
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	"github.com/red-hat-storage/ocs-operator/controllers/defaults"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type ocsCephRbdMirrors struct{}
+
+var (
+	rbdMirrorDebugLoggingEnabled = false
+)
 
 func (r *StorageClusterReconciler) fetchCephRbdMirrorInstance(cephRbdMirror *cephv1.CephRBDMirror) (cephv1.CephRBDMirror, error) {
 	existing := cephv1.CephRBDMirror{}
@@ -123,4 +132,209 @@ func (obj *ocsCephRbdMirrors) ensureDeleted(r *StorageClusterReconciler, sc *ocs
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, r.deleteCephRbdMirrorInstance(cephRbdMirrors)
+}
+
+func (r *StorageClusterReconciler) ensureRbdMirrorDebugLogging(sc *ocsv1.StorageCluster) (reconcile.Result, error) {
+	enableRbdMirrorDebugLoggingJobName := "enable-rbd-mirror-debug-logging"
+	disableRbdMirrorDebugLoggingJobName := "disable-rbd-mirror-debug-logging"
+	enableRbdMirrorDebugLoggingCommands :=
+		`echo "starting configuration of mirror logging"
+ceph config set client.rbd-mirror.a debug_ms 1
+ceph config set client.rbd-mirror.a debug_rbd 15
+ceph config set client.rbd-mirror.a debug_rbd_mirror 30
+ceph config set client.rbd-mirror.a log_file /var/log/ceph/\$cluster-\$name.log
+ceph config set client.rbd-mirror-peer debug_ms 1
+ceph config set client.rbd-mirror-peer debug_rbd 15
+ceph config set client.rbd-mirror-peer debug_rbd_mirror 30
+ceph config set client.rbd-mirror-peer log_file /var/log/ceph/\$cluster-\$name.log
+ceph config set mgr mgr/rbd_support/log_level debug
+		echo "completed"`
+	disableRbdMirrorDebugLoggingCommands :=
+		`echo "Removing configuration of mirror logging"
+ceph config rm client.rbd-mirror.a debug_ms
+ceph config rm client.rbd-mirror.a debug_rbd
+ceph config rm client.rbd-mirror.a debug_rbd_mirror
+ceph config rm client.rbd-mirror.a log_file
+ceph config rm client.rbd-mirror-peer debug_ms
+ceph config rm client.rbd-mirror-peer debug_rbd
+ceph config rm client.rbd-mirror-peer debug_rbd_mirror
+ceph config rm client.rbd-mirror-peer log_file
+ceph config rm mgr mgr/rbd_support/log_level
+		echo "completed"`
+
+	// Mirroring is enabled but the debug logging is disabled
+	if sc.Spec.Mirroring.Enabled && !rbdMirrorDebugLoggingEnabled {
+
+		err := r.Client.Create(r.ctx, getRbdMirrorDebugLoggingJob(sc, enableRbdMirrorDebugLoggingJobName, enableRbdMirrorDebugLoggingCommands))
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return reconcile.Result{}, err
+		}
+		// Check if the job has succeeded
+		job := &batchv1.Job{}
+		err = r.Client.Get(r.ctx, types.NamespacedName{Name: enableRbdMirrorDebugLoggingJobName, Namespace: sc.Namespace}, job)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if job.Status.Succeeded == 0 {
+			// Job has not succeeded yet, so requeue a reconcile request after 10 sec to check again
+			r.Log.Info("Waiting for enable-rbd-mirror-debug-logging job to complete")
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
+		r.Log.Info("Successfully enabled rbd mirror debug logging")
+		rbdMirrorDebugLoggingEnabled = true
+	}
+	// Mirroring is disabled but the debug logging is enabled
+	if !sc.Spec.Mirroring.Enabled && rbdMirrorDebugLoggingEnabled {
+		err := r.Client.Create(r.ctx, getRbdMirrorDebugLoggingJob(sc, disableRbdMirrorDebugLoggingJobName, disableRbdMirrorDebugLoggingCommands))
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return reconcile.Result{}, err
+		}
+		// Check if the job has succeeded
+		job := &batchv1.Job{}
+		err = r.Client.Get(r.ctx, types.NamespacedName{Name: disableRbdMirrorDebugLoggingJobName, Namespace: sc.Namespace}, job)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if job.Status.Succeeded == 0 {
+			// Job has not succeeded yet, so requeue a reconcile request after 10 sec to check again
+			r.Log.Info("Waiting for disable-rbd-mirror-debug-logging job to complete")
+			return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		}
+
+		// Delete both the enable & disable jobs
+		err = r.Client.Delete(r.ctx, &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      enableRbdMirrorDebugLoggingJobName,
+				Namespace: sc.Namespace,
+			}})
+		if err != nil && !errors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		err = r.Client.Delete(r.ctx, &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      disableRbdMirrorDebugLoggingJobName,
+				Namespace: sc.Namespace,
+			}})
+		if err != nil && !errors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		r.Log.Info("Successfully disabled rbd mirror debug logging")
+		rbdMirrorDebugLoggingEnabled = false
+	}
+	return reconcile.Result{}, nil
+}
+
+func getRbdMirrorDebugLoggingJob(sc *ocsv1.StorageCluster, jobName string, configCommands string) *batchv1.Job {
+	rookImage := os.Getenv("ROOK_CEPH_IMAGE")
+	debugJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: sc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: sc.APIVersion,
+					Kind:       sc.Kind,
+					Name:       sc.Name,
+					UID:        sc.UID,
+				},
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            "config-init",
+							Image:           rookImage,
+							Command:         []string{"/usr/local/bin/toolbox.sh"},
+							Args:            []string{"--skip-watch"},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name: "ROOK_CEPH_USERNAME",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon"},
+											Key:                  "ceph-username",
+										},
+									},
+								},
+								{
+									Name: "ROOK_CEPH_SECRET",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon"},
+											Key:                  "ceph-secret",
+										},
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "ceph-config", MountPath: "/etc/ceph"},
+								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.BoolPtr(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "script",
+							Image: rookImage,
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "ceph-config", MountPath: "/etc/ceph", ReadOnly: true},
+							},
+							Command: []string{
+								"bash",
+								"-c",
+								configCommands,
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.BoolPtr(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{Name: "ceph-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "mon-endpoint-volume", VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon-endpoints"},
+								Items:                []corev1.KeyToPath{{Key: "data", Path: "mon-endpoints"}},
+							},
+						},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: pointer.BoolPtr(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      defaults.NodeTolerationKey,
+							Operator: corev1.TolerationOpEqual,
+							Value:    "true",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+	return debugJob
 }

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -125,7 +125,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=operatorconditions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=*
-// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;create;update;watch
+// +kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;create;update;watch;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;list;watch
 
@@ -530,6 +530,14 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			r.Log.Error(err, "Failed to reconcile prometheus rules.")
 			return reconcile.Result{}, err
 		}
+	}
+
+	// Ensure that verbose logging is enabled when RBD mirroring is enabled
+	// TODO: This is a temporary arrangement, this is to be removed when RDR goes to GA
+	result, err := r.ensureRbdMirrorDebugLogging(instance)
+	if !result.IsZero() || err != nil {
+		r.Log.Error(err, "Failed to ensure RBD mirror debug logging.")
+		return result, err
 	}
 
 	return reconcile.Result{}, nil

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -20,6 +20,7 @@ import (
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -985,6 +986,10 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 	scheme, err := api.SchemeBuilder.Build()
 	if err != nil {
 		assert.Fail(t, "unable to build scheme")
+	}
+	err = batchv1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "unable to add batchv1 to scheme")
 	}
 	err = corev1.AddToScheme(scheme)
 	if err != nil {

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1807,8 +1807,10 @@ spec:
           - batch
           resources:
           - cronjobs
+          - jobs
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -129,8 +129,10 @@ spec:
           - batch
           resources:
           - cronjobs
+          - jobs
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/main.go
+++ b/main.go
@@ -42,8 +42,7 @@ import (
 	controllers "github.com/red-hat-storage/ocs-operator/controllers/storageconsumer"
 	"github.com/red-hat-storage/ocs-operator/controllers/util"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -55,6 +54,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/util/retry"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	apiclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,6 +76,7 @@ func init() {
 	utilruntime.Must(storagev1.AddToScheme(scheme))
 	utilruntime.Must(nbapis.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(openshiftv1.AddToScheme(scheme))
 	utilruntime.Must(snapapi.AddToScheme(scheme))


### PR DESCRIPTION
When mirroring is enabled it creates a enable job which runs the
required ceph config set commands to enable verbose logging.
When mirroring is disabled it creates a disable job which runs the
required ceph config rm commands to disable verbose logging and deletes
both the enable and disable jobs.
RBD team needs by default verbose logging when rbd-mirroing is enabled,
to debug issues properly. This would be reverted once RDR goes to GA.

Resolves-https://bugzilla.redhat.com/show_bug.cgi?id=2127186