### PR TITLE
[release-4.10] Stop using Topology Spread Constraints when Arbiter is enabled

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -666,7 +666,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			preparePlacement := rookCephv1.Placement{}
 
 			if noPlacement {
-				if supportTSC {
+				if supportTSC && !sc.Spec.Arbiter.Enable {
 					in := getPlacement(sc, "osd-tsc")
 					(&in).DeepCopyInto(&placement)
 


### PR DESCRIPTION
Using Topology Spread Constraints with Arbiter creates problems. As we use the maxskew as 1 and arbiter zone never has any pods, so after 1 pod each is scheduled in the data zones, the maxskew is violated and the other pods(osd prepare pods) stay in pending state.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>