### PR TITLE
delete Secret for external RHCS

### DIFF
--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -371,6 +371,11 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) (re
 		return reconcile.Result{}, err
 	}
 
+	err = r.deleteExternalSecret(sc)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// TODO: skip the deletion of these labels till we figure out a way to wait
 	// for the cleanup jobs
 	//err = r.deleteNodeAffinityKeyFromNodes(sc)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2089446
delete rook-ceph-external-cluster-details Secret as a part of SS deletion.

Signed-off-by: sanjalkatiyar <sanjaldhir@gmail.com>