### PR TITLE
Bug 2154165: disable webhook for rook

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2828,6 +2828,8 @@ spec:
                   value: "true"
                 - name: ROOK_CSI_ALLOW_UNSUPPORTED_VERSION
                   value: "true"
+                - name: ROOK_DISABLE_ADMISSION_CONTROLLER
+                  value: "true"
                 - name: ROOK_CSIADDONS_IMAGE
                   value: quay.io/csiaddons/k8s-sidecar:v0.5.0
                 - name: CSI_ENABLE_METADATA

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -230,6 +230,10 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				Value: "true",
 			},
 			{
+				Name:  "ROOK_DISABLE_ADMISSION_CONTROLLER",
+				Value: "true",
+			},
+			{
 				Name:  "ROOK_CSIADDONS_IMAGE",
 				Value: *rookCsiAddonsImage,
 			},


### PR DESCRIPTION
disabling webhook for rook untill is officially supported

Signed-off-by: subhamkrai <srai@redhat.com>

Backport of https://github.com/red-hat-storage/ocs-operator/pull/1895