### PR TITLE
Change failure domain value to hostname from host

### DIFF
--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -443,11 +443,15 @@ func getTopologyConstrainedPools(initData *ocsv1.StorageCluster) string {
 
 	var topologyConstrainedPools []topologyConstrainedPool
 	for _, failureDomainValue := range initData.Status.FailureDomainValues {
+		failureDomain := initData.Status.FailureDomain
+		if failureDomain == "host" {
+			failureDomain = "hostname"
+		}
 		topologyConstrainedPools = append(topologyConstrainedPools, topologyConstrainedPool{
 			PoolName: generateNameForNonResilientCephBlockPool(initData, failureDomainValue),
 			DomainSegments: []topologySegment{
 				{
-					DomainLabel: initData.Status.FailureDomain,
+					DomainLabel: failureDomain,
 					DomainValue: failureDomainValue,
 				},
 			},


### PR DESCRIPTION
This is to align the failure domain standards with K8s.
This is also to solve the problem of provisioning with replica 1
topology aware provisioning.