### PR TITLE
set domainLabel to "hostname" instead of "host" in topology constrained pool

### DIFF
--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -443,11 +443,18 @@ func getTopologyConstrainedPools(initData *ocsv1.StorageCluster) string {
 
 	var topologyConstrainedPools []topologyConstrainedPool
 	for _, failureDomainValue := range initData.Status.FailureDomainValues {
+		failureDomain := initData.Status.FailureDomain
+		// Normally the label on the nodes is of the form kubernetes.io/hostname=<hostname>
+		// and the same is passed to ceph-csi through rook-ceph-opeartor-config cm.
+		// Hence, the ceph-non-resilient-rbd storageclass needs to have domainLabel set as hostname for topology constrained pools.
+		if failureDomain == "host" {
+			failureDomain = "hostname"
+		}
 		topologyConstrainedPools = append(topologyConstrainedPools, topologyConstrainedPool{
 			PoolName: generateNameForNonResilientCephBlockPool(initData, failureDomainValue),
 			DomainSegments: []topologySegment{
 				{
-					DomainLabel: initData.Status.FailureDomain,
+					DomainLabel: failureDomain,
 					DomainValue: failureDomainValue,
 				},
 			},


### PR DESCRIPTION
Normally the label on the nodes is of the form
kubernetes.io/hostname=<hostname> and the same is passed to ceph-csi
through rook-ceph-opeartor-config cm.
Hence, the domainLabel should be set as "hostname" instead of "host"
for topology constrained pools.

Resolves-https://bugzilla.redhat.com/show_bug.cgi?id=2155402