### PR TITLE
fix io/ioutil deprecation warning from golangci-lint run

### DIFF
--- a/controllers/storagecluster/prometheus.go
+++ b/controllers/storagecluster/prometheus.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -75,7 +74,7 @@ func getPrometheusRuleSpecFrom(filePath string) (*monitoringv1.PrometheusRuleSpe
 	if err := CheckFileExists(filePath); err != nil {
 		return nil, err
 	}
-	fileContent, err := ioutil.ReadFile(filepath.Clean(filePath))
+	fileContent, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, fmt.Errorf("'%s' not readable", filePath)
 	}

--- a/metrics/internal/collectors/object-bucket_test.go
+++ b/metrics/internal/collectors/object-bucket_test.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -164,14 +164,14 @@ func TestCollectObjectBucketMetrics(t *testing.T) {
 				return nil, err
 			}
 			defer userJSONFile.Close()
-			byteValue, err := ioutil.ReadAll(userJSONFile)
+			byteValue, err := io.ReadAll(userJSONFile)
 			if err != nil {
 				return nil, err
 			}
 			if req.URL.RawQuery == "format=json&stats=true&uid=mock-ceph-user" && req.Method == http.MethodGet && req.URL.Path == "/admin/user" {
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewReader(byteValue)),
+					Body:       io.NopCloser(bytes.NewReader(byteValue)),
 				}, nil
 			}
 			return nil, fmt.Errorf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path)

--- a/test/crd_validation_test.go
+++ b/test/crd_validation_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +54,7 @@ func validateCustomResources(t *testing.T, root string, crd string, prefix strin
 			return nil
 		}
 		if strings.HasPrefix(info.Name(), prefix) {
-			bytes, err := ioutil.ReadFile(path)
+			bytes, err := os.ReadFile(path)
 			assert.NoError(t, err, "Error reading CR yaml from %v", path)
 			var input map[string]interface{}
 			assert.NoError(t, yaml.Unmarshal(bytes, &input))
@@ -112,7 +111,7 @@ func TestCompleteCRD(t *testing.T) {
 
 // nolint
 func getSchema(t *testing.T, crd string) validation.Schema {
-	bytes, err := ioutil.ReadFile(crd)
+	bytes, err := os.ReadFile(crd)
 	assert.NoError(t, err, "Error reading CRD yaml from %v", crd)
 	schema, err := validation.New(bytes)
 	assert.NoError(t, err)


### PR DESCRIPTION
io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.

Signed-off-by: Malay Kumar Parida <mparida@redhat.com>