### PR TITLE
fix OCS Dockerfile path in bundle build script

### DIFF
--- a/hack/build-operator-bundle.sh
+++ b/hack/build-operator-bundle.sh
@@ -26,5 +26,5 @@ if [ "$FUSION" == true ]; then
     build_operator_bundle fcs.Dockerfile
 else
     echo "Building Red Hat OpenShift Container Storage Operator Bundle"
-    build_operator_bundle ocs.Dockerfile
+    build_operator_bundle Dockerfile
 fi


### PR DESCRIPTION
Fixes the Dockerfile path in the bundle build script which was broken after commit 50dcce2d5 (#1917 )