### PR TITLE
update the labels while updating the servicemonitor and prometheusrules

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -192,6 +192,12 @@ func CreateOrUpdateServiceMonitor(r *StorageClusterReconciler, instance *ocsv1.S
 		return nil, fmt.Errorf("failed to retrieve metrics exporter servicemonitor %v. %v", namespacedName, err)
 	}
 	oldSm.Spec = serviceMonitor.Spec
+
+	err = mergo.Merge(&oldSm.Labels, serviceMonitor.Labels, mergo.WithOverride)
+	if err != nil {
+		return nil, err
+	}
+
 	err = r.Client.Update(context.TODO(), oldSm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update metrics exporter servicemonitor %v. %v", namespacedName, err)

--- a/controllers/storagecluster/prometheus.go
+++ b/controllers/storagecluster/prometheus.go
@@ -109,6 +109,12 @@ func (r *StorageClusterReconciler) CreateOrUpdatePrometheusRules(rule *monitorin
 				return fmt.Errorf("failed while fetching PrometheusRule: %v", err)
 			}
 			oldRule.Spec = rule.Spec
+
+			err = mergo.Merge(&oldRule.Labels, rule.Labels, mergo.WithOverride)
+			if err != nil {
+				return err
+			}
+
 			err := r.Client.Update(context.TODO(), oldRule)
 			if err != nil {
 				return fmt.Errorf("failed while updating PrometheusRule: %v", err)


### PR DESCRIPTION
labels were not getting updated while updating the servicemonitor and prometheusrules. Only Spec is the one which was getting updated. With the fix labels will also get updated along with the spec.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>