### PR TITLE
Add new metric for monitoring blocklisted RBD clients

### DIFF
--- a/config/rbac/exporter-role.yaml
+++ b/config/rbac/exporter-role.yaml
@@ -41,6 +41,8 @@ rules:
   - ""
   resources:
   - persistentvolumes
+  - persistentvolumeclaims
+  - pods
   verbs:
     - get
     - list

--- a/deploy/csv-templates/ics-operator.csv.yaml.in
+++ b/deploy/csv-templates/ics-operator.csv.yaml.in
@@ -181,6 +181,8 @@ spec:
           - ""
           resources:
           - persistentvolumes
+          - persistentvolumeclaims
+          - pods
           verbs:
           - get
           - list

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -181,6 +181,8 @@ spec:
           - ""
           resources:
           - persistentvolumes
+          - persistentvolumeclaims
+          - pods
           verbs:
           - get
           - list

--- a/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1719,6 +1719,8 @@ spec:
           - ""
           resources:
           - persistentvolumes
+          - persistentvolumeclaims
+          - pods
           verbs:
           - get
           - list

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1719,6 +1719,8 @@ spec:
           - ""
           resources:
           - persistentvolumes
+          - persistentvolumeclaims
+          - pods
           verbs:
           - get
           - list

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.90.0
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 	open-cluster-management.io/api v0.10.0
@@ -141,7 +142,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
-	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-aggregator v0.26.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230217203603-ff9a8e8fa21d // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -190,3 +190,15 @@ spec:
       for: 15s
       labels:
         severity: critical
+  - name: ceph-blocklist-alerts.rules
+    rules:
+    - alert: ODFRBDClientBlocked
+      annotations:
+        description: A kernel RBD client on node {{ $labels.node_name }} is blocklisted by Ceph for more than 10s. Please check Ceph logs.
+        message: A kernel RBD client on node {{ $labels.node_name }} is blocklisted by Ceph.
+        severity_level: error
+      expr: |
+        ocs_rbd_client_blocklisted{job="ocs-metrics-exporter"} > 0
+      for: 10s
+      labels:
+        severity: critical

--- a/metrics/deploy/rbac.yaml
+++ b/metrics/deploy/rbac.yaml
@@ -14,6 +14,8 @@ rules:
   - ""
   resources:
   - persistentvolumes
+  - persistentvolumeclaims
+  - pods
   - configmaps
   - secrets
   verbs:

--- a/metrics/internal/cache/ceph-blocklist.go
+++ b/metrics/internal/cache/ceph-blocklist.go
@@ -1,0 +1,171 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/red-hat-storage/ocs-operator/metrics/internal/options"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+type CephBlocklistLs struct {
+	IP    string    `json:"ip"`
+	Port  int       `json:"port"`
+	Nonce int       `json:"nonce"`
+	Until time.Time `json:"until"`
+}
+
+func (c *CephBlocklistLs) UnmarshalJSON(data []byte) error {
+	var blocklistData struct {
+		Addr  string `json:"addr"`
+		Until string `json:"until"`
+	}
+	if err := json.Unmarshal(data, &blocklistData); err != nil {
+		return fmt.Errorf("failed to unmarshal CephBlocklistLs: %v", err)
+	}
+	c.Until, _ = time.Parse(time.RFC3339Nano, blocklistData.Until)
+	re := regexp.MustCompile(`^(\d+\.\d+\.\d+\.\d+):(\d+)/(\d+)$`)
+	match := re.FindStringSubmatch(blocklistData.Addr)
+	if len(match) != 4 {
+		return fmt.Errorf("failed to extract IP, port, and nonce from address %s, expected format <IP>:<port>/<nonce>", blocklistData.Addr)
+	}
+	c.IP = match[1]
+	port, err := strconv.Atoi(match[2])
+	if err != nil {
+		return fmt.Errorf("failed to convert port to integer: %v", err)
+	}
+	c.Port = port
+	nonce, err := strconv.Atoi(match[3])
+	if err != nil {
+		return fmt.Errorf("failed to convert nonce to integer: %v", err)
+	}
+	c.Nonce = nonce
+	return nil
+}
+
+type CephBlocklistStore struct {
+	Mutex         sync.RWMutex
+	Store         []CephBlocklistLs
+	monitorConfig cephMonitorConfig
+	kubeClient    clientset.Interface
+}
+
+var _ cache.Store = &CephBlocklistStore{}
+
+func NewCephBlocklistStore(opts *options.Options) *CephBlocklistStore {
+	return &CephBlocklistStore{
+		Store:         []CephBlocklistLs{},
+		kubeClient:    clientset.NewForConfigOrDie(opts.Kubeconfig),
+		monitorConfig: cephMonitorConfig{},
+	}
+}
+
+func (c *CephBlocklistStore) Add(obj interface{}) error {
+	return c.Resync()
+}
+
+func (c *CephBlocklistStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+func (c *CephBlocklistStore) List() []interface{} {
+	c.Mutex.RLock()
+	defer c.Mutex.RUnlock()
+
+	list := make([]interface{}, len(c.Store))
+	for i, blocklist := range c.Store {
+		list[i] = blocklist
+	}
+
+	return list
+}
+
+func (c *CephBlocklistStore) ListKeys() []string {
+	return nil
+}
+
+func (c *CephBlocklistStore) Replace(list []interface{}, _ string) error {
+	return nil
+}
+
+func (c *CephBlocklistStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+func (c *CephBlocklistStore) Resync() error {
+	klog.Infof("Blocklist store sync started %v", time.Now())
+
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
+
+	if (c.monitorConfig == cephMonitorConfig{}) {
+		var err error
+		c.monitorConfig, err = initCeph(c.kubeClient, "openshift-storage")
+		if err != nil {
+			return fmt.Errorf("failed to initialize ceph: %v", err)
+		}
+	}
+
+	blockList, err := runCephOSDBlocklist(&c.monitorConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get blocklist data: %v", err)
+	}
+
+	c.Store = blockList
+
+	klog.Infof("Blocklist store sync completed at %v", time.Now())
+
+	return nil
+}
+
+func (c *CephBlocklistStore) Delete(obj interface{}) error {
+	return nil
+}
+
+func (c *CephBlocklistStore) Update(obj interface{}) error {
+	return c.Add(obj)
+}
+
+func (c *CephBlocklistStore) IsBlocked(ip string, port, nonce int) bool {
+	// Check if the RBD client for this node is blocklisted
+	blocklisted := false
+	for _, blocklist := range c.Store {
+		if blocklist.IP == ip && blocklist.Port == port && (blocklist.Nonce == 0 || blocklist.Nonce == nonce) {
+			blocklisted = true
+			break
+		}
+	}
+	return blocklisted
+}
+
+func runCephOSDBlocklist(config *cephMonitorConfig) ([]CephBlocklistLs, error) {
+	var blocklistSlice []CephBlocklistLs
+	if config.monitor == "" && config.id == "" && config.key == "" {
+		return blocklistSlice, errors.New("unable to get blocklist data. monitor config missing")
+	}
+
+	args := []string{"osd", "blocklist", "ls", "--format", "json", "-m", config.monitor, "--id", config.id, "--key", config.key}
+	cmd, err := execCommand("ceph", args)
+	if err != nil {
+		return blocklistSlice, err
+	}
+
+	re := regexp.MustCompile(`\[[^\[\]]+\]`)
+	match := re.Find(cmd)
+	if len(match) == 0 && err != nil {
+		return blocklistSlice, fmt.Errorf("failed to extract JSON from input: %v", err)
+	}
+
+	err = json.Unmarshal(match, &blocklistSlice)
+	if err != nil {
+		return blocklistSlice, fmt.Errorf("failed to extract JSON from command output: %v", err)
+	}
+	return blocklistSlice, nil
+}

--- a/metrics/internal/cache/rbd-mirror.go
+++ b/metrics/internal/cache/rbd-mirror.go
@@ -111,7 +111,7 @@ type RBDMirrorStore struct {
 	Store map[types.UID]RBDMirrorPoolStatusVerbose
 	// rbdCommandInput is a struct that contains the input for the rbd command
 	// for each AllowdNamespaces
-	rbdCommandInput   map[string]*rbdCommandInput
+	rbdCommandInput   map[string]*cephMonitorConfig
 	kubeclient        clientset.Interface
 	allowedNamespaces []string
 }
@@ -119,7 +119,7 @@ type RBDMirrorStore struct {
 func NewRBDMirrorStore(opts *options.Options) *RBDMirrorStore {
 	return &RBDMirrorStore{
 		Store:             map[types.UID]RBDMirrorPoolStatusVerbose{},
-		rbdCommandInput:   map[string]*rbdCommandInput{},
+		rbdCommandInput:   map[string]*cephMonitorConfig{},
 		kubeclient:        clientset.NewForConfigOrDie(opts.Kubeconfig),
 		allowedNamespaces: opts.AllowedNamespaces,
 	}
@@ -137,46 +137,55 @@ func (s *RBDMirrorStore) WithRBDCommandInput(namespace string) error {
 		return fmt.Errorf("rbd-mirror metrics collection from namespace %q is not allowed", namespace)
 	}
 
-	secret, err := s.kubeclient.CoreV1().Secrets(namespace).Get(context.TODO(), "rook-ceph-mon", v1.GetOptions{})
+	input, err := initCeph(s.kubeclient, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to get secret in namespace %q: %v", namespace, err)
+		return err
+	}
+
+	s.rbdCommandInput[namespace] = &input
+
+	return nil
+}
+
+func initCeph(kubeclient clientset.Interface, namespace string) (cephMonitorConfig, error) {
+	secret, err := kubeclient.CoreV1().Secrets(namespace).Get(context.TODO(), "rook-ceph-mon", v1.GetOptions{})
+	if err != nil {
+		return cephMonitorConfig{}, fmt.Errorf("failed to get secret in namespace %q: %v", namespace, err)
 	}
 	key, ok := secret.Data["ceph-secret"]
 	if !ok {
-		return fmt.Errorf("failed to get client key from secret in namespace %q", namespace)
+		return cephMonitorConfig{}, fmt.Errorf("failed to get client key from secret in namespace %q", namespace)
 	}
 	id := "admin"
 
-	configmap, err := s.kubeclient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "rook-ceph-csi-config", v1.GetOptions{})
+	configmap, err := kubeclient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "rook-ceph-csi-config", v1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get configmap in namespace %q: %v", namespace, err)
+		return cephMonitorConfig{}, fmt.Errorf("failed to get configmap in namespace %q: %v", namespace, err)
 	}
 
 	data, ok := configmap.Data["csi-cluster-config-json"]
 	if !ok {
-		return fmt.Errorf("failed to get CSI cluster config from configmap in namespace %q", namespace)
+		return cephMonitorConfig{}, fmt.Errorf("failed to get CSI cluster config from configmap in namespace %q", namespace)
 	}
 
 	var clusterConfig []csiClusterConfig
 	err = json.Unmarshal([]byte(data), &clusterConfig)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal csi-cluster-config-json in namespace %q: %v", namespace, err)
+		return cephMonitorConfig{}, fmt.Errorf("failed to unmarshal csi-cluster-config-json in namespace %q: %v", namespace, err)
 	}
 
 	if len(clusterConfig) == 0 {
-		return fmt.Errorf("expected 1 or more CSI cluster config but found 0 from configmap in namespace %q", namespace)
+		return cephMonitorConfig{}, fmt.Errorf("expected 1 or more CSI cluster config but found 0 from configmap in namespace %q", namespace)
 	}
 	if len(clusterConfig[0].Monitors) == 0 {
-		return fmt.Errorf("expected 1 or more monitors but found 0 from configmap in namespace %q", namespace)
+		return cephMonitorConfig{}, fmt.Errorf("expected 1 or more monitors but found 0 from configmap in namespace %q", namespace)
 	}
 
-	input := rbdCommandInput{}
+	input := cephMonitorConfig{}
 	input.monitor = clusterConfig[0].Monitors[0]
 	input.id = id
 	input.key = string(key)
-	s.rbdCommandInput[namespace] = &input
-
-	return nil
+	return input, nil
 }
 
 func (s *RBDMirrorStore) Add(obj interface{}) error {
@@ -203,7 +212,7 @@ func (s *RBDMirrorStore) Add(obj interface{}) error {
 		}
 	}
 
-	mirrorStatus, err := s.rbdCommandInput[pool.Namespace].rbdImageStatus(pool.Name)
+	mirrorStatus, err := rbdImageStatus(s.rbdCommandInput[pool.Namespace], pool.Name)
 	if err != nil {
 		return fmt.Errorf("rbd command error: %v", err)
 	}
@@ -283,7 +292,7 @@ func (s *RBDMirrorStore) Resync() error {
 			}
 		}
 
-		mirrorStatus, err := s.rbdCommandInput[poolStatusVerbose.PoolNamespace].rbdImageStatus(poolStatusVerbose.PoolName)
+		mirrorStatus, err := rbdImageStatus(s.rbdCommandInput[poolStatusVerbose.PoolNamespace], poolStatusVerbose.PoolName)
 		if err != nil {
 			klog.Errorf("rbd command error: %v", err)
 			continue
@@ -314,19 +323,19 @@ func CreateCephBlockPoolListWatch(cephClient rookclient.Interface, namespace, fi
 
 /* RBD CLI Commands */
 
-type rbdCommandInput struct {
+type cephMonitorConfig struct {
 	monitor, id, key string
 }
 
-func (in *rbdCommandInput) rbdImageStatus(poolName string) (RBDMirrorStatusVerbose, error) {
+func rbdImageStatus(config *cephMonitorConfig, poolName string) (RBDMirrorStatusVerbose, error) {
 	var cmd []byte
 	var rbdMirrorStatusVerbose RBDMirrorStatusVerbose
 
-	if in.monitor == "" && in.id == "" && in.key == "" {
+	if config.monitor == "" && config.id == "" && config.key == "" {
 		return rbdMirrorStatusVerbose, errors.New("unable to get RBD mirror data. RBD command input not specified")
 	}
 
-	args := []string{"mirror", "pool", "status", poolName, "--verbose", "--format", "json", "-m", in.monitor, "--id", in.id, "--key", in.key, "--debug-rbd", "0"}
+	args := []string{"mirror", "pool", "status", poolName, "--verbose", "--format", "json", "-m", config.monitor, "--id", config.id, "--key", config.key, "--debug-rbd", "0"}
 	cmd, err := execCommand("rbd", args)
 	if err != nil {
 		return rbdMirrorStatusVerbose, err

--- a/metrics/internal/collectors/ceph-blocklist.go
+++ b/metrics/internal/collectors/ceph-blocklist.go
@@ -1,0 +1,87 @@
+package collectors
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	internalcache "github.com/red-hat-storage/ocs-operator/metrics/internal/cache"
+	"k8s.io/klog"
+)
+
+var _ prometheus.Collector = &CephBlocklistCollector{}
+
+type CephBlocklistCollector struct {
+	CephBlocklistStore    *internalcache.CephBlocklistStore
+	PersistentVolumeStore *internalcache.PersistentVolumeStore
+	// Metrics Descriptors
+	NodeRBDBlocklist *prometheus.Desc
+}
+
+func NewCephBlocklistCollector(blocklistStore *internalcache.CephBlocklistStore, pvStore *internalcache.PersistentVolumeStore) *CephBlocklistCollector {
+	return &CephBlocklistCollector{
+		CephBlocklistStore:    blocklistStore,
+		PersistentVolumeStore: pvStore,
+		NodeRBDBlocklist: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "rbd_client_blocklisted"),
+			"State of the rbd client on a node, 0 = Unblocked, 1 = Blocked", []string{"node_name"}, nil),
+	}
+}
+
+func (c *CephBlocklistCollector) Describe(ch chan<- *prometheus.Desc) {
+	ds := []*prometheus.Desc{
+		c.NodeRBDBlocklist,
+	}
+
+	for _, d := range ds {
+		ch <- d
+	}
+}
+
+func (c *CephBlocklistCollector) Collect(ch chan<- prometheus.Metric) {
+	c.CephBlocklistStore.Mutex.RLock()
+	defer c.CephBlocklistStore.Mutex.RUnlock()
+
+	c.PersistentVolumeStore.Mutex.RLock()
+	defer c.PersistentVolumeStore.Mutex.RUnlock()
+
+	for node, clients := range c.PersistentVolumeStore.RBDClientMap {
+		for _, watcher := range clients.Watchers {
+			ip, port, nonce := parseAddress(watcher.Address)
+			if ip == "" {
+				klog.Errorf("error parsing address %s", watcher.Address)
+				continue
+			}
+
+			if c.CephBlocklistStore.IsBlocked(ip, port, nonce) {
+				ch <- prometheus.MustNewConstMetric(c.NodeRBDBlocklist, prometheus.GaugeValue, 1, node)
+			} else {
+				ch <- prometheus.MustNewConstMetric(c.NodeRBDBlocklist, prometheus.GaugeValue, 0, node)
+			}
+		}
+	}
+}
+
+func parseAddress(address string) (string, int, int) {
+	// Separate IP address, port and nonce from input string
+	// IP address can contain square brackets if it's an IPv6 address
+	re := regexp.MustCompile(`\[(.+)\]:(\d+)/(\d+)`)
+	matches := re.FindStringSubmatch(address)
+	if len(matches) == 4 {
+		ip := matches[1]
+		port, _ := strconv.Atoi(matches[2])
+		nonce, _ := strconv.Atoi(matches[3])
+		return ip, port, nonce
+	}
+
+	re = regexp.MustCompile(`(.+):(\d+)/(\d+)`)
+	matches = re.FindStringSubmatch(address)
+	if len(matches) == 4 {
+		ip := matches[1]
+		port, _ := strconv.Atoi(matches[2])
+		nonce, _ := strconv.Atoi(matches[3])
+		return ip, port, nonce
+	}
+
+	return "", 0, 0
+}

--- a/metrics/internal/collectors/rbd-mirror.go
+++ b/metrics/internal/collectors/rbd-mirror.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/red-hat-storage/ocs-operator/metrics/internal/cache"
 	internalcache "github.com/red-hat-storage/ocs-operator/metrics/internal/cache"
 	"github.com/red-hat-storage/ocs-operator/metrics/internal/options"
 	"k8s.io/klog/v2"
@@ -173,7 +172,7 @@ func (c *RBDMirrorCollector) Collect(ch chan<- prometheus.Metric) {
 						continue
 					}
 					description := siteDescription[1]
-					desc := cache.RBDMirrorPeerSiteDescription{}
+					desc := internalcache.RBDMirrorPeerSiteDescription{}
 					err := json.Unmarshal([]byte(description), &desc)
 					if err != nil {
 						klog.Errorf("Failed to unmarshal description of image %q from site %q: %v", image.Name, site.SiteName, err)

--- a/metrics/internal/collectors/registry.go
+++ b/metrics/internal/collectors/registry.go
@@ -49,12 +49,13 @@ func RegisterCustomResourceCollectors(registry *prometheus.Registry, opts *optio
 }
 
 var pvStoreEnabled bool
-var pvStore = internalcache.NewPersistentVolumeStore()
+var pvStore *internalcache.PersistentVolumeStore
 
 func enablePVStore(opts *options.Options) {
+	pvStore = internalcache.NewPersistentVolumeStore(opts)
 	client := clientset.NewForConfigOrDie(opts.Kubeconfig)
 	lw := internalcache.CreatePersistentVolumeListWatch(client, "")
-	reflector := cache.NewReflector(lw, &corev1.PersistentVolume{}, pvStore, 0)
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolume{}, pvStore, 2*time.Minute)
 	go reflector.Run(opts.StopCh)
 	pvStoreEnabled = true
 }
@@ -69,6 +70,16 @@ func enableRBDMirrorStore(opts *options.Options) {
 	reflector := cache.NewReflector(lw, &cephv1.CephBlockPool{}, rbdMirrorStore, 30*time.Second)
 	go reflector.Run(opts.StopCh)
 	rbdMirrorStoreEnabled = true
+}
+
+var cephBlocklistStore *internalcache.CephBlocklistStore
+
+func enableCephBlocklistMirrorStore(opts *options.Options) {
+	cephBlocklistStore = internalcache.NewCephBlocklistStore(opts)
+	rookClient := rookclient.NewForConfigOrDie(opts.Kubeconfig)
+	lw := internalcache.CreateCephBlockPoolListWatch(rookClient, corev1.NamespaceAll, "")
+	reflector := cache.NewReflector(lw, &cephv1.CephBlockPool{}, cephBlocklistStore, 30*time.Second)
+	go reflector.Run(opts.StopCh)
 }
 
 // RegisterPersistentVolumeAttributesCollector registers PV attribute colletor to registry
@@ -90,4 +101,10 @@ func RegisterRBDMirrorCollector(registry *prometheus.Registry, opts *options.Opt
 	}
 	rbdMirrorCollector := NewRBDMirrorCollector(rbdMirrorStore, pvStore, opts)
 	registry.MustRegister(rbdMirrorCollector)
+}
+
+func RegisterCephBlocklistCollector(registry *prometheus.Registry, opts *options.Options) {
+	enableCephBlocklistMirrorStore(opts)
+	blocklistCollector := NewCephBlocklistCollector(cephBlocklistStore, pvStore)
+	registry.MustRegister(blocklistCollector)
 }

--- a/metrics/main.go
+++ b/metrics/main.go
@@ -52,6 +52,9 @@ func main() {
 	// Add persistent volume attributes collector to the registry.
 	collectors.RegisterPersistentVolumeAttributesCollector(customResourceRegistry, opts)
 
+	// Add blocklist collector to the registry
+	collectors.RegisterCephBlocklistCollector(customResourceRegistry, opts)
+
 	// serves custom resources metrics
 	customResourceMux := http.NewServeMux()
 	handler.RegisterCustomResourceMuxHandlers(customResourceMux, customResourceRegistry, exporterRegistry)

--- a/metrics/mixin/alerts/alerts.libsonnet
+++ b/metrics/mixin/alerts/alerts.libsonnet
@@ -1,3 +1,4 @@
 (import 'mirroring.libsonnet') +
 (import 'obc.libsonnet') +
-(import 'services.libsonnet')
+(import 'services.libsonnet') +
+(import 'blocklist.libsonnet')

--- a/metrics/mixin/alerts/blocklist.libsonnet
+++ b/metrics/mixin/alerts/blocklist.libsonnet
@@ -1,0 +1,26 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'ceph-blocklist-alerts.rules',
+        rules: [
+          {
+            alert: 'ODFRBDClientBlocked',
+            expr: |||
+              ocs_rbd_client_blocklisted{%(ocsExporterSelector)s} > 0
+            ||| % $._config,
+            'for': $._config.blockedRBDClientAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'A kernel RBD client on node {{ $labels.node_name }} is blocklisted by Ceph.',
+              description: 'A kernel RBD client on node {{ $labels.node_name }} is blocklisted by Ceph for more than %s. Please check Ceph logs.' % $._config.blockedRBDClientAlertTime,
+              severity_level: 'error',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/metrics/mixin/config.libsonnet
+++ b/metrics/mixin/config.libsonnet
@@ -11,6 +11,7 @@
     odfObcQuotaCriticalAlertTime: '0s',
     odfPoolMirroringImageHealthWarningAlertTime: '1m',
     odfPoolMirroringImageHealthCriticalAlertTime: '10s',
+    blockedRBDClientAlertTime: '10s',
 
     // Constants
     objectStorageType: 'RGW',

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -124,7 +124,7 @@
           {
             record: 'odf_system_bucket_count',
             expr: |||
-               sum (ocs_objectbucket_count_total)
+              sum (ocs_objectbucket_count_total)
             ||| % $._config,
             labels: {
               system_vendor: 'Red Hat',


### PR DESCRIPTION
In this PR, we are adding a new metric called ocs_rbd_client_blocklisted with the label node_name. This metric lists the nodes that are blocklisted in Ceph OSD blocklist ls.

The purpose of this metric is to check if the clients used for images being provisioned using rbd are blocklisted. If the kernel rbd client is blocklisted, the images can go into read-only mount. By monitoring this metric, we can identify which nodes are blocklisted and take appropriate actions to resolve the issue.

This PR aims to improve the monitoring and alerting capabilities of the Ceph cluster by adding this new metric.

Metrics example: 
```
# HELP ocs_rbd_client_blocksited State of the rbd client on a node, 0 = Unblocked, 1 = Blocked
# TYPE ocs_rbd_client_blocksited gauge
ocs_rbd_client_blocksited{node_name="ip-10-0-138-1.ec2.internal"} 1
ocs_rbd_client_blocksited{node_name="ip-10-0-179-220.ec2.internal"} 0
```

Fixes: https://issues.redhat.com/browse/RHSTOR-4105
Fixes: https://issues.redhat.com/browse/RHSTOR-4106
