### PR TITLE
cephcluster: add support for read affinity for RBD volumes

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -46,6 +46,7 @@ func InitNamespacedName() types.NamespacedName {
 // nolint:revive
 type OCSInitializationReconciler struct {
 	client.Client
+	ctx            context.Context
 	Log            logr.Logger
 	Scheme         *runtime.Scheme
 	SecurityClient secv1client.SecurityV1Interface
@@ -64,6 +65,7 @@ func (r *OCSInitializationReconciler) Reconcile(ctx context.Context, request rec
 	prevLogger := r.Log
 	defer func() { r.Log = prevLogger }()
 	r.Log = r.Log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	r.ctx = ctx
 
 	r.Log.Info("Reconciling OCSInitialization.", "OCSInitialization", klog.KRef(request.Namespace, request.Name))
 
@@ -190,7 +192,7 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		})).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ocsOperatorConfigName,
+				Name:      util.OcsOperatorConfigName,
 				Namespace: watchNamespace,
 			},
 		}}, &handler.EnqueueRequestForOwner{

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -19,6 +19,7 @@ import (
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	"github.com/red-hat-storage/ocs-operator/controllers/defaults"
+	"github.com/red-hat-storage/ocs-operator/controllers/util"
 	statusutil "github.com/red-hat-storage/ocs-operator/controllers/util"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -94,13 +96,24 @@ func arbiterEnabled(sc *ocsv1.StorageCluster) bool {
 // ensureCreated ensures that a CephCluster resource exists with its Spec in
 // the desired state.
 func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
-	reconcileStrategy := ReconcileStrategy(sc.Spec.ManagedResources.CephCluster.ReconcileStrategy)
+	var (
+		cephCluster       *rookCephv1.CephCluster
+		err               error
+		reconcileStrategy = ReconcileStrategy(sc.Spec.ManagedResources.CephCluster.ReconcileStrategy)
+	)
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return reconcile.Result{}, nil
 	}
 
 	if sc.Spec.ExternalStorage.Enable && len(sc.Spec.StorageDeviceSets) != 0 {
 		return reconcile.Result{}, fmt.Errorf("'StorageDeviceSets' should not be initialized in an external CephCluster")
+	}
+
+	err = r.setReadAffinity(sc)
+	if err != nil {
+		r.Log.Error(err, fmt.Sprintf("Failed to set Read Affinity to %t", !sc.Spec.ExternalStorage.Enable),
+			"StorageCluster", klog.KRef(sc.Namespace, sc.Name))
+		return reconcile.Result{}, err
 	}
 
 	for i, ds := range sc.Spec.StorageDeviceSets {
@@ -128,8 +141,6 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		}
 	}
 
-	var cephCluster *rookCephv1.CephCluster
-	var err error
 	// Define a new CephCluster object
 	if sc.Spec.ExternalStorage.Enable {
 		extRArr, ok := externalOCSResources[sc.UID]
@@ -1127,6 +1138,49 @@ func createOrUpdatePrometheusRule(r *StorageClusterReconciler, sc *ocsv1.Storage
 			return err
 		}
 	}
+	return nil
+}
+
+// setReadAffinity sets read affinity by setting "CSI_ENABLE_READ_AFFINITY"
+// in ocs-operator-config configmap.
+func (r *StorageClusterReconciler) setReadAffinity(sc *ocsv1.StorageCluster) error {
+	var (
+		readAffinityVarKey = "CSI_ENABLE_READ_AFFINITY"
+		readAffinityVarVal = strconv.FormatBool(!sc.Spec.ExternalStorage.Enable)
+		cm                 = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.OcsOperatorConfigName,
+				Namespace: sc.Namespace,
+			},
+			Data: map[string]string{
+				readAffinityVarKey: readAffinityVarVal,
+			},
+		}
+		needsRestart = false
+	)
+
+	_, err := ctrl.CreateOrUpdate(r.ctx, r.Client, cm, func() error {
+		if cm.Data[readAffinityVarKey] != readAffinityVarVal {
+			cm.Data[readAffinityVarKey] = readAffinityVarVal
+			needsRestart = true
+		}
+		return nil
+	})
+	if err != nil {
+		r.Log.Error(err, fmt.Sprintf("failed to update %q configmap", util.OcsOperatorConfigName),
+			"storageCluster", klog.KRef(sc.Namespace, sc.Name))
+		return err
+	}
+	if needsRestart {
+		// restart the rook-ceph-operator pod to pick up the new change
+		util.RestartRookOperatorPod(r.ctx, r.Client, &r.Log, sc.Namespace)
+		r.Log.Info(fmt.Sprintf("successfully set %q to %q", readAffinityVarKey, readAffinityVarVal),
+			"storageCluster", klog.KRef(sc.Namespace, sc.Name))
+	} else {
+		r.Log.Info(fmt.Sprintf("%q is already set to %q", readAffinityVarKey, readAffinityVarVal),
+			"storageCluster", klog.KRef(sc.Namespace, sc.Name))
+	}
+
 	return nil
 }
 

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -1,14 +1,24 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"os"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
-// which is the namespace where the watch activity happens.
-// this value is empty if the operator is running with clusterScope.
-const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+const (
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which is the namespace where the watch activity happens.
+	// this value is empty if the operator is running with clusterScope.
+	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+
+	// This configmap is purely for the OCS operator to use.
+	OcsOperatorConfigName = "ocs-operator-config"
+)
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes
 func GetWatchNamespace() (string, error) {
@@ -30,4 +40,21 @@ func GetOperatorNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", OperatorNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+// RestartRookOperatorPod restarts the rook-operator pod in the OCP cluster
+func RestartRookOperatorPod(ctx context.Context, kubeClient client.Client, logger *logr.Logger, namespace string) {
+	podList := &corev1.PodList{}
+	err := kubeClient.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{"app": "rook-ceph-operator"})
+	if err != nil {
+		logger.Error(err, "Failed to list rook-ceph-operator pod")
+		return
+	}
+	for _, pod := range podList.Items {
+		err := kubeClient.Delete(ctx, &pod)
+		if err != nil {
+			logger.Error(err, "Failed to delete rook-ceph-operator pod")
+			return
+		}
+	}
 }

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2899,6 +2899,11 @@ spec:
                     configMapKeyRef:
                       key: CSI_CLUSTER_NAME
                       name: ocs-operator-config
+                - name: CSI_ENABLE_READ_AFFINITY
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_ENABLE_READ_AFFINITY
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -249,6 +249,17 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				},
 			},
 			{
+				Name: "CSI_ENABLE_READ_AFFINITY",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "CSI_ENABLE_READ_AFFINITY",
+					},
+				},
+			},
+			{
 				Name: "CSI_PROVISIONER_TOLERATIONS",
 				Value: `
 - key: node.ocs.openshift.io/storage


### PR DESCRIPTION
This commit enables read affinity for RBD volumes by setting the "CSI_ENABLE_READ_AFFINITY" environment variable to "true". If it is an external cluster, and the "CSI_ENABLE_READ_AFFINITY" variable is not present in rook-ceph-operator-config ConfigMap, only then it is set to false. This provides flexibility to use the configmap enable and modify this feature for external cluster.

refer: https://issues.redhat.com/browse/RHSTOR-4371