### PR TITLE
Alwasy enable ceph msgrv2 port & pass kernel mount options to rook-ceph operator

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -234,8 +234,9 @@ func (r *OCSInitializationReconciler) ensureRookCephOperatorConfigExists(initial
 // When any value in the configmap is updated, the rook-ceph-operator pod is restarted to pick up the new values.
 func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData *ocsv1.OCSInitialization) error {
 	const (
-		clusterNameKey        = "CSI_CLUSTER_NAME"
-		enableReadAffinityKey = "CSI_ENABLE_READ_AFFINITY"
+		clusterNameKey              = "CSI_CLUSTER_NAME"
+		enableReadAffinityKey       = "CSI_ENABLE_READ_AFFINITY"
+		cephFSKernelMountOptionsKey = "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS"
 	)
 	ocsOperatorConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -244,8 +245,9 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 		},
 		// Default or placeholder values for the configmap
 		Data: map[string]string{
-			clusterNameKey:        "",
-			enableReadAffinityKey: "true",
+			clusterNameKey:              "",
+			enableReadAffinityKey:       "true",
+			cephFSKernelMountOptionsKey: "ms_mode=prefer-crc",
 		},
 	}
 	err := r.Client.Create(r.ctx, ocsOperatorConfig)

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -531,6 +531,16 @@ func getNetworkSpec(sc ocsv1.StorageCluster) rookCephv1.NetworkSpec {
 	}
 	// respect both the old way and the new way for enabling HostNetwork
 	networkSpec.HostNetwork = networkSpec.HostNetwork || sc.Spec.HostNetwork
+
+	// Enable the msgr2 port always
+	if networkSpec.Connections == nil {
+		networkSpec.Connections = &rookCephv1.ConnectionsSpec{
+			RequireMsgr2: true,
+		}
+	} else {
+		networkSpec.Connections.RequireMsgr2 = true
+	}
+
 	return networkSpec
 }
 

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -824,6 +824,9 @@ func TestGetNetworkSpec(t *testing.T) {
 			},
 			expected: cephv1.NetworkSpec{
 				HostNetwork: true,
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
 			},
 		},
 		{
@@ -833,6 +836,9 @@ func TestGetNetworkSpec(t *testing.T) {
 			},
 			expected: cephv1.NetworkSpec{
 				HostNetwork: false,
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
 			},
 		},
 		{
@@ -847,6 +853,9 @@ func TestGetNetworkSpec(t *testing.T) {
 			expected: cephv1.NetworkSpec{
 				HostNetwork: true,
 				IPFamily:    cephv1.IPv6,
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
 			},
 		},
 		{
@@ -863,6 +872,9 @@ func TestGetNetworkSpec(t *testing.T) {
 				HostNetwork: true,
 				IPFamily:    cephv1.IPv6,
 				DualStack:   true,
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
 			},
 		},
 		{
@@ -877,12 +889,19 @@ func TestGetNetworkSpec(t *testing.T) {
 			expected: cephv1.NetworkSpec{
 				HostNetwork: false,
 				IPFamily:    cephv1.IPv4,
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
 			},
 		},
 		{
-			desc:     "hostNetwork unspecified, network unspecified",
-			scSpec:   ocsv1.StorageClusterSpec{},
-			expected: cephv1.NetworkSpec{},
+			desc:   "hostNetwork unspecified, network unspecified",
+			scSpec: ocsv1.StorageClusterSpec{},
+			expected: cephv1.NetworkSpec{
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
+			},
 		},
 		{
 			desc: "hostNetwork unspecified, network specified",
@@ -895,6 +914,9 @@ func TestGetNetworkSpec(t *testing.T) {
 			expected: cephv1.NetworkSpec{
 				HostNetwork: true,
 				IPFamily:    cephv1.IPv4,
+				Connections: &cephv1.ConnectionsSpec{
+					RequireMsgr2: true,
+				},
 			},
 		},
 	}

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1141,8 +1141,6 @@ func assertCephClusterNetwork(t assert.TestingT, reconciler StorageClusterReconc
 	if cr.Spec.Network == nil {
 		assert.Equal(t, "", cephCluster.Spec.Network.Provider)
 		assert.Nil(t, cephCluster.Spec.Network.Selectors)
-	} else {
-		assert.Equal(t, *cr.Spec.Network, cephCluster.Spec.Network)
 	}
 }
 

--- a/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2923,6 +2923,11 @@ spec:
                     configMapKeyRef:
                       key: CSI_ENABLE_READ_AFFINITY
                       name: ocs-operator-config
+                - name: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2923,6 +2923,11 @@ spec:
                     configMapKeyRef:
                       key: CSI_ENABLE_READ_AFFINITY
                       name: ocs-operator-config
+                - name: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -260,6 +260,17 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				},
 			},
 			{
+				Name: "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS",
+					},
+				},
+			},
+			{
 				Name: "CSI_PROVISIONER_TOLERATIONS",
 				Value: `
 - key: node.ocs.openshift.io/storage


### PR DESCRIPTION
Jira-https://issues.redhat.com/browse/RHSTOR-2516

For easier enablement of new features like in-transit encryption &
compression we need the ceph msgr v2 port. So we will use the msgrv2
port instead of the old v1 port by default.

The cephFS kernel mount option is set as a key in the ocsoperator
configmap. The value of the key is passed to rook as a env variable.
The default is "ms_mode=prefer-crc" and if in transit encryption is
enabled, the value is set to "ms_mode=secure". The rook operator
pod is restarted if the value of the key is changed.