### PR TITLE
Update golangci-lint version to 1.51.1 & fix the BoolPtr deprecation warning

### DIFF
--- a/.github/workflows/ocs-operator-ci.yaml
+++ b/.github/workflows/ocs-operator-ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.51.1
 
           # The weird NO_FUTURE thing is a workaround suggested here:
           # # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

--- a/controllers/storagecluster/cephrbdmirrors.go
+++ b/controllers/storagecluster/cephrbdmirrors.go
@@ -276,7 +276,7 @@ func getRbdMirrorDebugLoggingJob(sc *ocsv1.StorageCluster, jobName string, confi
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: pointer.BoolPtr(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",
@@ -298,7 +298,7 @@ func getRbdMirrorDebugLoggingJob(sc *ocsv1.StorageCluster, jobName string, confi
 								configCommands,
 							},
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: pointer.BoolPtr(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",
@@ -319,7 +319,7 @@ func getRbdMirrorDebugLoggingJob(sc *ocsv1.StorageCluster, jobName string, confi
 					},
 					RestartPolicy: corev1.RestartPolicyNever,
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: pointer.BoolPtr(true),
+						RunAsNonRoot: pointer.Bool(true),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},

--- a/hack/golangci_lint.sh
+++ b/hack/golangci_lint.sh
@@ -6,7 +6,7 @@ source hack/common.sh
 
 mkdir -p ${OUTDIR_TOOLS}
 LINT_BIN="${OUTDIR_TOOLS}/golangci-lint"
-LINT_VER="1.49.0"
+LINT_VER="1.51.1"
 
 check_bin_exists() {
   which "${LINT_BIN}" >/dev/null 2>&1 && [[ "$(${LINT_BIN} --version)" == *"${LINT_VER}"* ]]

--- a/services/provider/server/storageclaim.go
+++ b/services/provider/server/storageclaim.go
@@ -94,7 +94,7 @@ func (s *storageClassClaimManager) Create(
 			Kind:               gvk.Kind,
 			UID:                consumer.GetUID(),
 			Name:               consumer.GetName(),
-			BlockOwnerDeletion: pointer.BoolPtr(true),
+			BlockOwnerDeletion: pointer.Bool(true),
 		},
 	})
 


### PR DESCRIPTION
Update golangci-lint to version to 1.51.1 & fix the deprecation warning "BoolPtr is deprecated: Use Bool instead"