### PR TITLE
change the conditions when cephcluster is in connected state

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -462,6 +462,10 @@ func (r *StorageClusterReconciler) reconcilePhases(
 		message := ocsv1.ReconcileCompletedMessage
 		statusutil.SetCompleteCondition(&instance.Status.Conditions, reason, message)
 
+		if instance.Spec.ExternalStorage.Enable {
+			statusutil.RemoveExternalCephClusterNegativeConditions(&instance.Status.Conditions)
+		}
+
 		// If no operator whose conditions we are watching reports an error, then it is safe
 		// to set upgradeable to true.
 		if instance.Status.Phase != statusutil.PhaseClusterExpanding {

--- a/controllers/util/status.go
+++ b/controllers/util/status.go
@@ -204,6 +204,16 @@ func MapExternalCephClusterNegativeConditions(conditions *[]conditionsv1.Conditi
 	}
 }
 
+// RemoveExternalCephClusterNegativeConditions removes the External cluster negative conditions
+func RemoveExternalCephClusterNegativeConditions(conditions *[]conditionsv1.Condition) {
+	if conditionsv1.FindStatusCondition(*conditions, ocsv1.ConditionExternalClusterConnecting) != nil {
+		conditionsv1.RemoveStatusCondition(conditions, ocsv1.ConditionExternalClusterConnecting)
+	}
+	if conditionsv1.FindStatusCondition(*conditions, ocsv1.ConditionExternalClusterConnected) != nil {
+		conditionsv1.RemoveStatusCondition(conditions, ocsv1.ConditionExternalClusterConnected)
+	}
+}
+
 // MapCephClusterNoConditions sets status conditions to progressing. Used when component operator isn't
 // reporting any status, and we have to assume progress.
 func MapCephClusterNoConditions(conditions *[]conditionsv1.Condition, reason string, message string) {


### PR DESCRIPTION
we are changing the conditions when cephcluster is in connecting state or error state and reflecting the ceph cluster state in the storagecluster conditions accordingly. But once ceph cluster is in connected state we are not changing the conditions at all. Which makes storagecluster conditions out of sync with the cephcluster when it is in connected state. updating the conditions when cephcluster is connected will reflect the actual state.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2172189