### PR TITLE
remove OCSInitialization controller ref from ocs-operator-config cm

### DIFF
--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -41,6 +41,14 @@ func (r *StorageClusterReconciler) ensureOCSOperatorConfig(sc *ocsv1.StorageClus
 	}
 
 	opResult, err := ctrl.CreateOrUpdate(r.ctx, r.Client, cm, func() error {
+
+		// This configmap was created and controlled by the OCSInitialization earlier.
+		// We are required to remove OCSInitialization as a controller before adding storageCluster as controller.
+		if existing := metav1.GetControllerOfNoCopy(cm); existing != nil && existing.Kind == "OCSInitialization" {
+			existing.BlockOwnerDeletion = nil
+			existing.Controller = nil
+		}
+
 		if cm.Data[clusterNameKey] != clusterNameVal {
 			cm.Data[clusterNameKey] = clusterNameVal
 		}


### PR DESCRIPTION
We are upgrading the ocs-operator configmap by adding a storage cluster as an controller, which breaks the upgrade because ocsinitialization is already a controller to it. Before we can add the storagecluster as an controller, we must first remove ocsinitialization as a controller from the owner references.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>