### PR TITLE
Bug 2176357: [release-4.9] Moving the defaults for rookceph operator from configmap to csv

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -44,7 +44,7 @@ func InitNamespacedName() types.NamespacedName {
 }
 
 // OCSInitializationReconciler reconciles a OCSInitialization object
-//nolint
+// nolint
 type OCSInitializationReconciler struct {
 	client.Client
 	Log            logr.Logger
@@ -322,23 +322,12 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // returns a ConfigMap with default settings for rook-ceph operator
 func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
-	var defaultCSIToleration = `
-- key: ` + defaults.NodeTolerationKey + `
-  operator: Equal
-  value: "true"
-  effect: NoSchedule`
-
 	config := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rookCephOperatorConfigName,
 			Namespace: namespace,
 		},
 	}
-	data := make(map[string]string)
-	data["CSI_PROVISIONER_TOLERATIONS"] = defaultCSIToleration
-	data["CSI_PLUGIN_TOLERATIONS"] = defaultCSIToleration
-	data["CSI_LOG_LEVEL"] = "5"
-	config.Data = data
 
 	return config
 }

--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2395,6 +2395,8 @@ spec:
                       operator: Equal
                       value: "true"
                       effect: NoSchedule
+                - name: CSI_LOG_LEVEL
+                  value: "5"
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -237,6 +237,10 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
   effect: NoSchedule`,
 			},
 			{
+				Name:  "CSI_LOG_LEVEL",
+				Value: "5",
+			},
+			{
 				Name: "NODE_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{


### PR DESCRIPTION
This is an modified cherry-pick of #1648, where we are only backporting the CSI_LOG_LEVEL changes in the csv.

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>