### PR TITLE
Reconcile the job templates so it is in sync with the latest changes

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -49,6 +49,7 @@ func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1
 	for _, tempFunc := range tempFuncs {
 		template := tempFunc(sc)
 		_, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, template, func() error {
+			template := tempFunc(sc)
 			return controllerutil.SetControllerReference(sc, template, r.Scheme)
 		})
 


### PR DESCRIPTION
Previously once the template existed we were not reconciling it. This resulted in the template using very old rook-ceph images and not having the newly added parameters. We want the template to be updated to use new parameters, any new ceph commands, latest rook-ceph image, etc.

Fixes- https://bugzilla.redhat.com/show_bug.cgi?id=2143944