### PR TITLE
ms: add subvolumegroupname to GetStorageClassClaimConfig RPC

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -648,8 +648,9 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 				Name: "cephfs",
 				Kind: "StorageClass",
 				Data: mustMarshal(map[string]string{
-					"clusterID": getSubVolumeGroupClusterID(subVolumeGroup),
-					"fsName":    subVolumeGroup.Spec.FilesystemName,
+					"clusterID":          getSubVolumeGroupClusterID(subVolumeGroup),
+					"subvolumegroupname": subVolumeGroup.Name,
+					"fsName":             subVolumeGroup.Spec.FilesystemName,
 					"csi.storage.k8s.io/provisioner-secret-name":       provisionerCephClientSecret,
 					"csi.storage.k8s.io/node-stage-secret-name":        nodeCephClientSecret,
 					"csi.storage.k8s.io/controller-expand-secret-name": provisionerCephClientSecret,

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -533,9 +533,10 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 				Name: "cephfs",
 				Kind: "StorageClass",
 				Data: map[string]string{
-					"clusterID": "8d26c7378c1b0ec9c2455d1c3601c4cd",
-					"fsName":    "myfs",
-					"pool":      "",
+					"clusterID":          "8d26c7378c1b0ec9c2455d1c3601c4cd",
+					"fsName":             "myfs",
+					"subvolumegroupname": "cephFilesystemSubVolumeGroup",
+					"pool":               "",
 					"csi.storage.k8s.io/provisioner-secret-name":       "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",
 					"csi.storage.k8s.io/node-stage-secret-name":        "rook-ceph-client-1b042fcc8812fe4203689eec38fdfbfa",
 					"csi.storage.k8s.io/controller-expand-secret-name": "rook-ceph-client-4ffcb503ff8044c8699dac415f82d604",


### PR DESCRIPTION
To use ocs-client-operator with ODF, the subvolumegroup needs to be sent back in the GetStorageClassClaimConfig RPC call as the csi configmap needs to point to the right subvolumegroup for the user to use.