### PR TITLE
4.8 - ginkgo e2e ci fix

### DIFF
--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -9,14 +9,8 @@ GOBIN="${GOBIN:-$GOPATH/bin}"
 GINKGO=$GOBIN/ginkgo
 
 if ! [ -x "$GINKGO" ]; then
-	echo "Retrieving ginkgo and gomega build dependencies"
-	# TODO: Move to `go install` while upgrading to Go 1.16
-	# Currently, `go install` is unable to install ginkgo which
-	# causes build failures during E2E tests. The workaround is
-	# to install ginkgo and gomega using `go get` and turn off
-	# the modules so that it doesn't update go.mod and go.sum files
-	GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
-	GO111MODULE=off go get github.com/onsi/gomega/...
+	echo "Installing GINKGO"
+	go install -v github.com/onsi/ginkgo/v2/ginkgo@latest
 else
 	echo "GINKO binary found at $GINKGO"
 fi


### PR DESCRIPTION
Use go install for ginkgo instead of go get to fix failing functests