### PR TITLE
[release-4.11] Fix ginko errors in the openshift-ci

### DIFF
--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -10,13 +10,7 @@ GINKGO=$GOBIN/ginkgo
 
 if ! [ -x "$GINKGO" ]; then
 	echo "Retrieving ginkgo and gomega build dependencies"
-	# TODO: Move to `go install` while upgrading to Go 1.16
-	# Currently, `go install` is unable to install ginkgo which
-	# causes build failures during E2E tests. The workaround is
-	# to install ginkgo and gomega using `go get` and turn off
-	# the modules so that it doesn't update go.mod and go.sum files
-	GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
-	GO111MODULE=off go get github.com/onsi/gomega/...
+	go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 else
 	echo "GINKO binary found at $GINKGO"
 fi


### PR DESCRIPTION
openshift-ci is failing for quite a long time on the older branches due to the ginko v2.

We were installing the Ginko binary without the version, which was installing Ginko V2 and making it incompatible with our older code and Golang. Fix it by sticking it to the v1 version.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>