### PR TITLE
Reconcile the clusterClaim spec values to keep the values in sync

### DIFF
--- a/controllers/storagecluster/clusterclaims.go
+++ b/controllers/storagecluster/clusterclaims.go
@@ -114,6 +114,7 @@ func (c *ClusterClaimCreator) create() error {
 		}
 
 		_, err := controllerutil.CreateOrUpdate(c.Context, c.Client, &cc, func() error {
+			cc.Spec.Value = value
 			return nil
 		})
 


### PR DESCRIPTION
Earlier the clusterClaim spec was not reconciled once created. This resulted in the clusterClaim spec value to be out of sync with the current odf version.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2182703