### PR TITLE
Don't require msgr2 port for provider/consumer clusters

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -528,8 +528,8 @@ func getNetworkSpec(sc ocsv1.StorageCluster) rookCephv1.NetworkSpec {
 	// respect both the old way and the new way for enabling HostNetwork
 	networkSpec.HostNetwork = networkSpec.HostNetwork || sc.Spec.HostNetwork
 
-	// Enable the msgr2 port always if it's not an external cluster
-	if !sc.Spec.ExternalStorage.Enable {
+	// Don't require the msgr2 port if it's an provider or external/consumer cluster
+	if !sc.Spec.AllowRemoteStorageConsumers && !sc.Spec.ExternalStorage.Enable {
 		if networkSpec.Connections == nil {
 			networkSpec.Connections = &rookCephv1.ConnectionsSpec{}
 		}

--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -104,7 +104,8 @@ func (r *StorageClusterReconciler) getClusterID() string {
 
 // getCephFSKernelMountOptions returns the kernel mount options for cephfs
 func getCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
-	if sc.Spec.ExternalStorage.Enable {
+	// If it is an provider or consumer/external cluster, we don't need to set any mount options
+	if sc.Spec.ExternalStorage.Enable || sc.Spec.AllowRemoteStorageConsumers {
 		return ""
 	}
 	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil && sc.Spec.Network.Connections.Encryption != nil && sc.Spec.Network.Connections.Encryption.Enabled {


### PR DESCRIPTION
For consumer/provider MS mode we cannot set global configuration at the csi level as a single consumer will be connected to the multiple provider clusters.

resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2184068#c10