### PR TITLE
Refactor GetNetworkSpec to handle different network connection & Pass appropriate options for all the cases of Network Spec

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -528,17 +528,12 @@ func getNetworkSpec(sc ocsv1.StorageCluster) rookCephv1.NetworkSpec {
 	// respect both the old way and the new way for enabling HostNetwork
 	networkSpec.HostNetwork = networkSpec.HostNetwork || sc.Spec.HostNetwork
 
-	if networkSpec.Connections == nil {
-		networkSpec.Connections = &rookCephv1.ConnectionsSpec{}
-	}
-	networkSpec.Connections.RequireMsgr2 = true
-
-	// If it's an provider or external/consumer cluster don't require msgr2
-	// And don't allow encryption or compression to be enabled
-	if sc.Spec.AllowRemoteStorageConsumers || sc.Spec.ExternalStorage.Enable {
-		networkSpec.Connections.RequireMsgr2 = false
-		networkSpec.Connections.Encryption = nil
-		networkSpec.Connections.Compression = nil
+	// If it's not an external and not a provider cluster always require msgr2
+	if !sc.Spec.AllowRemoteStorageConsumers && !sc.Spec.ExternalStorage.Enable {
+		if networkSpec.Connections == nil {
+			networkSpec.Connections = &rookCephv1.ConnectionsSpec{}
+		}
+		networkSpec.Connections.RequireMsgr2 = true
 	}
 
 	return networkSpec

--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -102,14 +102,29 @@ func (r *StorageClusterReconciler) getClusterID() string {
 	return fmt.Sprint(clusterVersion.Spec.ClusterID)
 }
 
-// getCephFSKernelMountOptions returns the kernel mount options for cephfs
+// getCephFSKernelMountOptions returns the kernel mount options for CephFS based on the spec on the StorageCluster
 func getCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
-	// If it is an provider or consumer/external cluster, we don't need to set any mount options
+	// If Encryption is enabled, Always use secure mode
+	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
+		sc.Spec.Network.Connections.Encryption.Enabled {
+		return "ms_mode=secure"
+	}
+
+	// If Encryption is not enabled, but Compression or RequireMsgr2 is enabled, use prefer-crc mode
+	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
+		((sc.Spec.Network.Connections.Compression != nil && sc.Spec.Network.Connections.Compression.Enabled) ||
+			sc.Spec.Network.Connections.RequireMsgr2) {
+		return "ms_mode=prefer-crc"
+	}
+
+	// Network spec always has higher precedence even in the External or Provider cluster. so they are checked first above
+
+	// None of Encryption, Compression, RequireMsgr2 are enabled on the StorageCluster
+	// If it's an External or Provider cluster, We don't require msgr2 by default so no mount options are needed
 	if sc.Spec.ExternalStorage.Enable || sc.Spec.AllowRemoteStorageConsumers {
 		return ""
 	}
-	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil && sc.Spec.Network.Connections.Encryption != nil && sc.Spec.Network.Connections.Encryption.Enabled {
-		return "ms_mode=secure"
-	}
+	// If none of the above cases apply, We set RequireMsgr2 true by default on the cephcluster
+	// so we need to set the mount options to prefer-crc
 	return "ms_mode=prefer-crc"
 }


### PR DESCRIPTION
Refactor GetNetworkSpec to handle different network connection specs 

    RequireMsgr2 will be set by default if it's not an external cluster
    or a provider cluster, so v2 port will be the default port.
    For a new cluster, The mons will have only the v2 port.
    For an upgraded cluster mons will have both v1 and v2 ports. But csi
    will use the v2 port for any new volume mounts.
    
    For external cluster or provider cluster, v1 port will be used by
    default. In this case for both new cluster and for an upgraded cluster
    mons will have both v1 and v2 ports. But csi will use the v1 port. If
    the user wants to use Encryption, compression or v2 port, they can
    specify it in the network spec. In that case csi will switch to v2 port.

Pass appropriate options for  all the cases of Network Spec combination

    We have mainly 4 cases.
    1. Encryption is enabled
    2. Encryption is not enabled, but Either Compression is enabled or
        RequireMsgr2 is true
    3. Non of Encryption, Compression, RequireMsgr2 is enabled, And it is
        an external or provider cluster
    4. None of the above cases are true, By default we will require Msgr2
    
    For all options, appropriate options are passed for cephfs mounting.