### PR TITLE
Bug 2185725:[release-4.12] do not watch noobaa CRs if SKIP_NOOBAA_CRD_WATCH is set to true

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -154,13 +154,17 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	)
 
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&ocsv1.StorageCluster{}, builder.WithPredicates(scPredicate)).
 		Owns(&cephv1.CephCluster{}).
-		Owns(&nbv1.NooBaa{}).
 		Owns(&corev1.PersistentVolumeClaim{}, builder.WithPredicates(pvcPredicate)).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&source.Kind{Type: &ocsv1.OCSInitialization{}}, enqueueStorageClusterRequest).
-		Complete(r)
+		Watches(&source.Kind{Type: &ocsv1.OCSInitialization{}}, enqueueStorageClusterRequest)
+
+	if os.Getenv("SKIP_NOOBAA_CRD_WATCH") != "true" {
+		builder.Owns(&nbv1.NooBaa{})
+	}
+
+	return builder.Complete(r)
 }


### PR DESCRIPTION
If the CRD is not present, it can prevent the ocs-operator from
starting which can cause problems for MS. Since MS is not going
to install the noobaa CSV anymore, it is better to only watch the
noobaa CRs if the SKIP_NOOBAA_CRD_WATCH is set to false.

MS will set SKIP_NOOBAA_CRD_WATCH env in the sub which will be
populated to the ocs-operator via OLM.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
(cherry picked from commit 0f62acc68e0295d2a8c9f1c35b8fef64a99e60c1)

Manual backport of #1972