### PR TITLE
Fix the OBC alert labels

### DIFF
--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -122,7 +122,7 @@ spec:
     rules:
     - alert: CephOSDCriticallyFull
       annotations:
-        description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class type {{$labels.device_class}} has crossed 80% on host {{ $labels.hostname }}. Immediately free up some space or add capacity of type {{$labels.device_class}}.
+        description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class type {{ $labels.device_class }} has crossed 80% on host {{ $labels.hostname }}. Immediately free up some space or add capacity of type {{ $labels.device_class }}.
         message: Back-end storage device is critically full.
         severity_level: error
         storage_type: ceph
@@ -144,7 +144,7 @@ spec:
         severity: critical
     - alert: CephOSDNearFull
       annotations:
-        description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class type {{$labels.device_class}} has crossed 75% on host {{ $labels.hostname }}. Immediately free up some space or add capacity of type {{$labels.device_class}}.
+        description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class type {{ $labels.device_class }} has crossed 75% on host {{ $labels.hostname }}. Immediately free up some space or add capacity of type {{ $labels.device_class }}.
         message: Back-end storage device is nearing full.
         severity_level: warning
         storage_type: ceph

--- a/metrics/mixin/alerts/obc.libsonnet
+++ b/metrics/mixin/alerts/obc.libsonnet
@@ -15,7 +15,7 @@
             },
             annotations: {
               message: 'OBC has crossed 80% of the quota(bytes).',
-              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
               storage_type: $._config.objectStorageType,
               severity_level: 'warning',
             },
@@ -31,7 +31,7 @@
             },
             annotations: {
               message: 'OBC has crossed 80% of the quota(object).',
-              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
               storage_type: $._config.objectStorageType,
               severity_level: 'warning',
             },
@@ -47,7 +47,7 @@
             },
             annotations: {
               message: 'OBC reached quota(bytes) limit.',
-              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
             },
@@ -63,7 +63,7 @@
             },
             annotations: {
               message: 'OBC reached quota(object) limit.',
-              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
             },


### PR DESCRIPTION
ObjectBucketClaim alerts had wrong label format

Wrong format: `{{$labels.objectbucketclaim}}`
Correct format:  `{{ $labels.objectbucketclaim }}`
