### PR TITLE
Use ms_mode=legacy instead of blank value, add network spec to external mode ceph cluster, add unit tests

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -580,6 +580,7 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage, monitoringIP, m
 				ManageMachineDisruptionBudgets: false,
 			},
 			Monitoring: monitoringSpec,
+			Network:    getNetworkSpec(*sc),
 			Labels: rookCephv1.LabelsSpec{
 				rookCephv1.KeyMonitoring: getCephClusterMonitoringLabels(*sc),
 			},

--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -122,7 +122,7 @@ func getCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
 	// None of Encryption, Compression, RequireMsgr2 are enabled on the StorageCluster
 	// If it's an External or Provider cluster, We don't require msgr2 by default so no mount options are needed
 	if sc.Spec.ExternalStorage.Enable || sc.Spec.AllowRemoteStorageConsumers {
-		return ""
+		return "ms_mode=legacy"
 	}
 	// If none of the above cases apply, We set RequireMsgr2 true by default on the cephcluster
 	// so we need to set the mount options to prefer-crc


### PR DESCRIPTION
In the case when for external mode upgrade happens from 4.12 to 4.13, getCephFSKernelMountOptions returns a blank value for external mode. It compares this with the current value of the key. But the configmap in this case also gives a blank value for the non-existent key. So it thinks the configmap is already in the correct state, skips adding the key to the cm. Which results in rook-ceph-operator pod being in CreateContainerConfigError state with the error message. So instead of the blank value, we return the ms_mode=legacy value which has the same effect as the blank value.

Reference-https://docs.ceph.com/en/latest/man/8/mount.ceph/#basic

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2188427

Add network spec to external cephcluster 

    This was a big miss with all the previous changes. In external mode,
    the cephcluster created by the operator should have the network spec
    set using the same getNetworkSpec() function as the internal mode.