### PR TITLE
enable single node cluster deployment

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -587,6 +587,9 @@ func getMinDeviceSetReplica(sc *ocsv1.StorageCluster) int {
 	if arbiterEnabled(sc) {
 		return defaults.ArbiterModeDeviceSetReplica
 	}
+	if statusutil.IsSingleNodeDeployment() {
+		return 1
+	}
 	return defaults.DeviceSetReplica
 }
 
@@ -903,7 +906,6 @@ func countAndReplicaOf(ds *ocsv1.StorageDeviceSet) (int, int) {
 }
 
 func newCephDaemonResources(sc *ocsv1.StorageCluster) map[string]corev1.ResourceRequirements {
-
 	custom := sc.Spec.Resources
 	resources := map[string]corev1.ResourceRequirements{
 		"mon": defaults.DaemonResources["mon"],
@@ -1011,7 +1013,7 @@ func generateMonSpec(sc *ocsv1.StorageCluster, nodeCount int) rookCephv1.MonSpec
 
 	return rookCephv1.MonSpec{
 		Count:                getMonCount(nodeCount, false),
-		AllowMultiplePerNode: false,
+		AllowMultiplePerNode: statusutil.IsSingleNodeDeployment(),
 	}
 }
 
@@ -1025,7 +1027,7 @@ func generateMgrSpec(sc *ocsv1.StorageCluster) rookCephv1.MgrSpec {
 	}
 	if sc.Spec.Mgr != nil && sc.Spec.Mgr.EnableActivePassive {
 		spec.Count = 2
-		spec.AllowMultiplePerNode = false
+		spec.AllowMultiplePerNode = statusutil.IsSingleNodeDeployment()
 	}
 
 	return spec

--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/red-hat-storage/ocs-operator/controllers/defaults"
+	statusutil "github.com/red-hat-storage/ocs-operator/controllers/util"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -79,6 +80,13 @@ func setFailureDomain(sc *ocsv1.StorageCluster) {
 
 	// default is rack
 	failureDomain := "rack"
+
+	if statusutil.IsSingleNodeDeployment() {
+		sc.Status.FailureDomain = "osd"
+		// Since nodes do not have a label for "osd" as a failure domain, setting it to "host".
+		sc.Status.FailureDomainKey, sc.Status.FailureDomainValues = sc.Status.NodeTopologies.GetKeyValues("host")
+		return
+	}
 
 	// But if FlexiableScaling is enabled then we select host as failure domain
 	// as we need +1 scaling

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 const (
@@ -10,6 +11,9 @@ const (
 	// which is the namespace where the watch activity happens.
 	// this value is empty if the operator is running with clusterScope.
 	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+
+	// SingleNodeEnvVar is set if StorageCluster needs to be deployed on a single node
+	SingleNodeEnvVar = "SINGLE_NODE"
 
 	// This configmap is purely for the OCS operator to use.
 	OcsOperatorConfigName = "ocs-operator-config"
@@ -38,4 +42,10 @@ func GetOperatorNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", OperatorNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+// IsSingleNodeDeployment returns true if StorageCluster needs to be deployed on a single node.
+func IsSingleNodeDeployment() bool {
+	isSingleNode := os.Getenv(SingleNodeEnvVar)
+	return strings.ToLower(strings.TrimSpace(isSingleNode)) == "true"
 }

--- a/deploy/single-node-storagecluster.yaml
+++ b/deploy/single-node-storagecluster.yaml
@@ -1,0 +1,92 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: sno-storagecluster
+  namespace: openshift-storage
+spec:
+  flexibleScaling: true
+  managedResources: {}
+  manageNodes: false
+  # monDataDirHostPath: /var/lib/rook
+  monPVCTemplate:
+    spec:
+      storageClassName: localblock
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+  placement:
+    mon: {}
+    mds: {}
+    mgr: {}
+    rbd-mirror: {}
+    rgw: {}
+    nfs: {}
+    noobaa-core: {}
+    noobaa-standalone: {}
+    osd: {}
+    osd-prepare: {}
+  resources:
+    mon:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    mds:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    mgr:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    mgr-sidecar:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    nfs:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    noobaa-core:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    noobaa-db:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    noobaa-db-vol:
+      requests:
+        storage: 10Gi
+    noobaa-endpoint:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    rbd-mirror:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    rgw:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+  storageDeviceSets:
+    - count: 3
+      dataPVCTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1
+          storageClassName: localblock
+          volumeMode: Block
+      name: ocs-deviceset
+      placement: {}
+      portable: false
+      replica: 1
+      resources:
+        requests:
+          cpu: 125m
+          memory: 128Mi


### PR DESCRIPTION
For development and demonstration purposes, StorageCluster can be deployed on a single node OpenShift cluster by setting environment variable "SINGLE_NODE" to true in ocs-operator pod.

Single node deployment for StorageCluster allows all pods to be deployed on a single node. This is not supported on a production cluster.

```
$ oc edit subscription ocs-operator
...
spec:
  config:
    env:
    - name: SINGLE_NODE
      value: "true"
...
```