### PR TITLE
nfs: servicemonitor for nfs-metrics

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -159,6 +159,7 @@ rules:
   - servicemonitors
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -28,6 +28,10 @@ func generateNameForNFSService(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-service", generateNameForCephNFS(initData))
 }
 
+func generateNameForNFSServiceMonitor(initData *ocsv1.StorageCluster) string {
+	return fmt.Sprintf("%s-servicemonitor", generateNameForCephNFS(initData))
+}
+
 func generateNameForCephNFSBlockPool(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-builtin-pool", generateNameForCephNFS(initData))
 }

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -114,7 +114,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=core,resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=*
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;networks,verbs=get;list;watch

--- a/deploy/csv-templates/ics-operator.csv.yaml.in
+++ b/deploy/csv-templates/ics-operator.csv.yaml.in
@@ -362,6 +362,7 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -362,6 +362,7 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1940,6 +1940,7 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1940,6 +1940,7 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
           - get
           - list
           - update


### PR DESCRIPTION
Create ServiceMonitor for nfs-metrics service (scrape NFS-ganesha's Prometheus metrics server endpoint).

NFS-Ganesha (as of V5-dev.2 [1]) supports Prometheus monitoring from within the NFS server itself. It provides metrics for both connected clients and active exports, via TCP port 9587.

Rook-ceph [2] uses NFS-Ganesha with metrics turned-on to enable NFS on top of cephfs.

This patch provides the missing binding piece between the NFS-Ganesha metrics the Prometheus scraping on ODF system.

Refs BZ-2190241

[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/b6c59df5a0b8a3ae5b2a87446f8906cb321ee026
[2] https://github.com/rook/rook/commit/7b28f1de05b2c00731bee4f09a3a69c5acfc7607