### PR TITLE
Sort values of topologymap labels to avoid frequent updates to CR

### DIFF
--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -306,6 +306,7 @@ func (r *StorageClusterReconciler) reconcileNodeTopologyMap(sc *ocsv1.StorageClu
 	}
 
 	filterDuplicateLabels(sc, nodes, topologyMap)
+	sortTopologyMapLabelValues(topologyMap)
 	sc.Status.NodeTopologies = topologyMap
 	setFailureDomain(sc)
 
@@ -317,6 +318,14 @@ func (r *StorageClusterReconciler) reconcileNodeTopologyMap(sc *ocsv1.StorageClu
 	}
 
 	return nil
+}
+
+// A function to sort the values of a label in the topology map
+func sortTopologyMapLabelValues(topologyMap *ocsv1.NodeTopologyMap) {
+	for label, values := range topologyMap.Labels {
+		sort.Strings(values)
+		topologyMap.Labels[label] = values
+	}
 }
 
 // nodesHaveIdenticalValuesForKeys will return true only if


### PR DESCRIPTION
As we construct the topologymap in each reconcile, the order of the label values are not consistent. This results in the nodetopologies to be updated frequently. This was causing reconcile to be cancelled in-between causing issues with rook-ceph-operator in stretched cluster.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2193220#c8