### PR TITLE
BZ2139037 : Use strings ports in service in routes

### DIFF
--- a/controllers/storagecluster/routes.go
+++ b/controllers/storagecluster/routes.go
@@ -150,13 +150,12 @@ func (r *StorageClusterReconciler) newCephRGWRoutes(initData *ocsv1.StorageClust
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: int32(80),
-						StrVal: "80",
+						Type:   intstr.String,
+						StrVal: "http",
 					},
 				},
 				TLS: &routev1.TLSConfig{
-					Termination:                   routev1.TLSTerminationReencrypt,
+					Termination:                   routev1.TLSTerminationEdge,
 					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 				},
 			},
@@ -173,9 +172,8 @@ func (r *StorageClusterReconciler) newCephRGWRoutes(initData *ocsv1.StorageClust
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: int32(443),
-						StrVal: "443",
+						Type:   intstr.String,
+						StrVal: "https",
 					},
 				},
 				TLS: &routev1.TLSConfig{

--- a/controllers/storagecluster/routes_test.go
+++ b/controllers/storagecluster/routes_test.go
@@ -61,13 +61,12 @@ func assertCephRGWRoutes(t *testing.T, reconciler StorageClusterReconciler, cr *
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: int32(80),
-						StrVal: "80",
+						Type:   intstr.String,
+						StrVal: "http",
 					},
 				},
 				TLS: &routev1.TLSConfig{
-					Termination:                   routev1.TLSTerminationReencrypt,
+					Termination:                   routev1.TLSTerminationEdge,
 					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 				},
 			},
@@ -83,9 +82,8 @@ func assertCephRGWRoutes(t *testing.T, reconciler StorageClusterReconciler, cr *
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: int32(443),
-						StrVal: "443",
+						Type:   intstr.String,
+						StrVal: "https",
 					},
 				},
 				TLS: &routev1.TLSConfig{


### PR DESCRIPTION
The BZ2139037 planned to expose differet routes for RGW service for TLS and non TLS ports. But current code uses the integer value for the ports. Since port in mentioned in RGW service for non-secure is different than one rgw internally uses in the pod. Hence the non-secure RGW route was not accessible. Also changed the termination policy to edge for the non-secure RGW route.