### PR TITLE
Use `IfNotPresent` pull policy for images pulled by digest

### DIFF
--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -72,6 +73,10 @@ var (
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
+
+	// Regular expression used to decide if an image reference is using a digest instead of a
+	// tag. For that kind of image references we want to use the `IfNotPresent` pull policy.
+	digestImageReferenceRE = regexp.MustCompile("^.+@.+:.+$")
 )
 
 type templateData struct {
@@ -696,6 +701,12 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
     }
 ]`
 
+	// Ensure that all deployments that pull images by digest use the `IfNotPresent` image pull
+	// policy. That is convenient because images that have already been pulled by digest can't
+	// change, and using the `Always` pull policy introduces an additional round trip to the
+	// registry server that isn't really necessary and can fail.
+	setDeploymentsImagePullPolicy(ocsCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs)
+
 	// write unified CSV to out dir
 	writer := strings.Builder{}
 	err = marshallObject(ocsCSV, &writer, injectCSVRelatedImages)
@@ -711,6 +722,29 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
 
 	fmt.Printf("CSV written to %s\n", filepath.Join(*outputDir, finalizedCsvFilename))
 	return ocsCSV
+}
+
+func setDeploymentsImagePullPolicy(deploymentSpecs []csvv1.StrategyDeploymentSpec) {
+	for i := range deploymentSpecs {
+		setDeploymentImagePullPolicy(&deploymentSpecs[i].Spec)
+	}
+}
+
+func setDeploymentImagePullPolicy(deploymentSpec *appsv1.DeploymentSpec) {
+	setContainersImagePullPolicy(deploymentSpec.Template.Spec.InitContainers)
+	setContainersImagePullPolicy(deploymentSpec.Template.Spec.Containers)
+}
+
+func setContainersImagePullPolicy(containers []corev1.Container) {
+	for i := range containers {
+		setContainerImagePullPolicy(&containers[i])
+	}
+}
+
+func setContainerImagePullPolicy(container *corev1.Container) {
+	if digestImageReferenceRE.MatchString(container.Image) {
+		container.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 }
 
 func injectCSVRelatedImages(r *unstructured.Unstructured) error {


### PR DESCRIPTION
Currently some of the images use the `Always` image pull policy. That isn't really necessary when the images are pulled by digest instead of by tag, and it introduces an additional network round trip to the image registry server that takes time and may fail. To avoid that this patch changes the `csv-merger` tool so that in addition to merging the CSVs it also changes the `imagePullPolicy` to `IfNotPresent` for images that are pulled by digest.

By default this doesn't produce any change in the merged CSV, because all the images are pulled by tag, but running the following:

```
$ export OCS_IMAGE=quay.io/ocs-dev/ocs-operator@sha256:b22c334a530dc194e758b0e9974376fe75ac1ea5044d079252aeb17081be8e0e
$ make gen-latest-csv
```

Will generate the following diff:

```diff
diff --git a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
index 91e1f483..4a87e74a 100644
--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2891,13 +2891,13 @@ spec:
                 - name: NOOBAA_DB_IMAGE
                   value: centos/postgresql-12-centos7
                 - name: PROVIDER_API_SERVER_IMAGE
-                  value: quay.io/ocs-dev/ocs-operator:latest
+                  value: quay.io/ocs-dev/ocs-operator@sha256:b22c334a530dc194e758b0e9974376fe75ac1ea5044d079252aeb17081be8e0e
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/ocs-dev/ocs-operator:latest
-                imagePullPolicy: Always
+                image: quay.io/ocs-dev/ocs-operator@sha256:b22c334a530dc194e758b0e9974376fe75ac1ea5044d079252aeb17081be8e0e
+                imagePullPolicy: IfNotPresent
                 name: ocs-operator
                 readinessProbe:
                   httpGet:
```

Note how that changed the image pull policy from `Always` to `IfNotPresent`.

Related: https://issues.redhat.com/browse/MGMT-13733
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2208563