### PR TITLE
Check Connections.Encryption is not nil to avoid panic

### DIFF
--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -106,7 +106,7 @@ func (r *StorageClusterReconciler) getClusterID() string {
 func getCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
 	// If Encryption is enabled, Always use secure mode
 	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
-		sc.Spec.Network.Connections.Encryption.Enabled {
+		sc.Spec.Network.Connections.Encryption != nil && sc.Spec.Network.Connections.Encryption.Enabled {
 		return "ms_mode=secure"
 	}
 


### PR DESCRIPTION
If Network.Connections is not null, we should check Connections.Encryption is not nill before checking Encryption.Enabled. This issue was found when we try to create a storage cluster with Network.Connections.Compression.Enabled set to true & Connections.Encryption is nil.

https://issues.redhat.com/browse/RHSTOR-4218