### PR TITLE
Replica 1-Tech Preview- Pass appropriate value to rook via the csv for ceph non-resilient pools

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -237,6 +237,8 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 		clusterNameKey              = "CSI_CLUSTER_NAME"
 		enableReadAffinityKey       = "CSI_ENABLE_READ_AFFINITY"
 		cephFSKernelMountOptionsKey = "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS"
+		enableTopologyKey           = "CSI_ENABLE_TOPOLOGY"
+		topologyDomainLabelsKey     = "CSI_TOPOLOGY_DOMAIN_LABELS"
 	)
 	ocsOperatorConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -248,6 +250,8 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 			clusterNameKey:              "",
 			enableReadAffinityKey:       "true",
 			cephFSKernelMountOptionsKey: "ms_mode=prefer-crc",
+			enableTopologyKey:           "false",
+			topologyDomainLabelsKey:     "",
 		},
 	}
 	err := r.Client.Create(r.ctx, ocsOperatorConfig)

--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -22,11 +22,15 @@ func (r *StorageClusterReconciler) ensureOCSOperatorConfig(sc *ocsv1.StorageClus
 		clusterNameKey              = "CSI_CLUSTER_NAME"
 		enableReadAffinityKey       = "CSI_ENABLE_READ_AFFINITY"
 		cephFSKernelMountOptionsKey = "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS"
+		enableTopologyKey           = "CSI_ENABLE_TOPOLOGY"
+		topologyDomainLabelsKey     = "CSI_TOPOLOGY_DOMAIN_LABELS"
 	)
 	var (
 		clusterNameVal             = r.getClusterID()
 		enableReadAffinityVal      = strconv.FormatBool(!sc.Spec.ExternalStorage.Enable)
 		cephFSKernelMountOptionVal = getCephFSKernelMountOptions(sc)
+		enableTopologyVal          = strconv.FormatBool(sc.Spec.ManagedResources.CephNonResilientPools.Enable)
+		topologyDomainLabelsVal    = getFailureDomainKey(sc)
 	)
 
 	cm := &corev1.ConfigMap{
@@ -35,8 +39,11 @@ func (r *StorageClusterReconciler) ensureOCSOperatorConfig(sc *ocsv1.StorageClus
 			Namespace: sc.Namespace,
 		},
 		Data: map[string]string{
-			clusterNameKey:        clusterNameVal,
-			enableReadAffinityKey: enableReadAffinityVal,
+			clusterNameKey:              clusterNameVal,
+			enableReadAffinityKey:       enableReadAffinityVal,
+			cephFSKernelMountOptionsKey: cephFSKernelMountOptionVal,
+			enableTopologyKey:           enableTopologyVal,
+			topologyDomainLabelsKey:     topologyDomainLabelsVal,
 		},
 	}
 
@@ -57,6 +64,12 @@ func (r *StorageClusterReconciler) ensureOCSOperatorConfig(sc *ocsv1.StorageClus
 		}
 		if cm.Data[cephFSKernelMountOptionsKey] != cephFSKernelMountOptionVal {
 			cm.Data[cephFSKernelMountOptionsKey] = cephFSKernelMountOptionVal
+		}
+		if cm.Data[enableTopologyKey] != enableTopologyVal {
+			cm.Data[enableTopologyKey] = enableTopologyVal
+		}
+		if cm.Data[topologyDomainLabelsKey] != topologyDomainLabelsVal {
+			cm.Data[topologyDomainLabelsKey] = topologyDomainLabelsVal
 		}
 		return ctrl.SetControllerReference(sc, cm, r.Scheme)
 	})

--- a/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2996,6 +2996,16 @@ spec:
                     configMapKeyRef:
                       key: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
                       name: ocs-operator-config
+                - name: CSI_ENABLE_TOPOLOGY
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_ENABLE_TOPOLOGY
+                      name: ocs-operator-config
+                - name: CSI_TOPOLOGY_DOMAIN_LABELS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_TOPOLOGY_DOMAIN_LABELS
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2996,6 +2996,16 @@ spec:
                     configMapKeyRef:
                       key: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
                       name: ocs-operator-config
+                - name: CSI_ENABLE_TOPOLOGY
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_ENABLE_TOPOLOGY
+                      name: ocs-operator-config
+                - name: CSI_TOPOLOGY_DOMAIN_LABELS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: CSI_TOPOLOGY_DOMAIN_LABELS
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -271,6 +271,28 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				},
 			},
 			{
+				Name: "CSI_ENABLE_TOPOLOGY",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "CSI_ENABLE_TOPOLOGY",
+					},
+				},
+			},
+			{
+				Name: "CSI_TOPOLOGY_DOMAIN_LABELS",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "CSI_TOPOLOGY_DOMAIN_LABELS",
+					},
+				},
+			},
+			{
 				Name: "CSI_PROVISIONER_TOLERATIONS",
 				Value: `
 - key: node.ocs.openshift.io/storage


### PR DESCRIPTION
When enabling non-resilient/replica-1 pools, it is necessary to
configure CSI by setting the CSI_ENABLE_TOPOLOGY variable to true and
specifying the value of the failure domain key using the
CSI_TOPOLOGY_DOMAIN_LABELS variable.

Previously, users had to manually modify the rook-ceph-operator-config
configmap. Now, the required values are passed automatically as ENV
variables via the CSV from the ocs-operator-config configmap.