### PR TITLE
Allow changing default storageclass names

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -184,11 +184,24 @@ type ManageCephBlockPools struct {
 	ReconcileStrategy    string `json:"reconcileStrategy,omitempty"`
 	DisableStorageClass  bool   `json:"disableStorageClass,omitempty"`
 	DisableSnapshotClass bool   `json:"disableSnapshotClass,omitempty"`
+	// StorageClassName specifies the name of the storage class created for ceph block pools
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	StorageClassName string `json:"storageClassName,omitempty"`
+	// VirtualizationStorageClassName specifies the name of the storage class created for ceph block pools
+	// for virtualization environment
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	VirtualizationStorageClassName string `json:"virtualizationStorageClassName,omitempty"`
 }
 
 // ManageCephNonResilientPools defines how to reconcile ceph non-resilient pools
 type ManageCephNonResilientPools struct {
 	Enable bool `json:"enable,omitempty"`
+	// StorageClassName specifies the name of the storage class created for ceph non-resilient pools
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	StorageClassName string `json:"storageClassName,omitempty"`
 	// ReconcileStrategy and other related fields are not used for now
 	// They can be added once the feature goes to GA
 }
@@ -198,6 +211,10 @@ type ManageCephFilesystems struct {
 	ReconcileStrategy    string `json:"reconcileStrategy,omitempty"`
 	DisableStorageClass  bool   `json:"disableStorageClass,omitempty"`
 	DisableSnapshotClass bool   `json:"disableSnapshotClass,omitempty"`
+	// StorageClassName specifies the name of the storage class created for cephfs
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // ManageCephObjectStores defines how to reconcile CephObjectStores
@@ -206,6 +223,10 @@ type ManageCephObjectStores struct {
 	DisableStorageClass bool   `json:"disableStorageClass,omitempty"`
 	GatewayInstances    int32  `json:"gatewayInstances,omitempty"`
 	DisableRoute        bool   `json:"disableRoute,omitempty"`
+	// StorageClassName specifies the name of the storage class created for ceph obc's
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // ManageCephObjectStoreUsers defines how to reconcile CephObjectStoreUsers
@@ -351,6 +372,10 @@ type NFSSpec struct {
 	// Enable specifies whether to enable NFS.
 	// +optional
 	Enable bool `json:"enable,omitempty"`
+	// StorageClassName specifies the name of the storage class created for NFS
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // MonitoringSpec controls the configuration of resources for exposing OCS metrics
@@ -371,7 +396,11 @@ type EncryptionSpec struct {
 	// +optional
 	ClusterWide bool `json:"clusterWide,omitempty"`
 	// +optional
-	StorageClass         bool                     `json:"storageClass,omitempty"`
+	StorageClass bool `json:"storageClass,omitempty"`
+	// StorageClassName specifies the name of the storage class created for ceph encrypted block pools
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	StorageClassName     string                   `json:"storageClassName,omitempty"`
 	KeyManagementService KeyManagementServiceSpec `json:"kms,omitempty"`
 }
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -480,6 +480,12 @@ spec:
                     type: object
                   storageClass:
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for ceph encrypted block pools
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When
@@ -580,6 +586,19 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph block pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      virtualizationStorageClassName:
+                        description: VirtualizationStorageClassName specifies the
+                          name of the storage class created for ceph block pools for
+                          virtualization environment
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephCluster:
                     description: ManageCephCluster defines how to reconcile the Ceph
@@ -614,6 +633,12 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for cephfs
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephNonResilientPools:
                     description: ManageCephNonResilientPools defines how to reconcile
@@ -621,6 +646,12 @@ spec:
                     properties:
                       enable:
                         type: boolean
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph non-resilient pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephObjectStoreUsers:
                     description: ManageCephObjectStoreUsers defines how to reconcile
@@ -640,6 +671,12 @@ spec:
                         format: int32
                         type: integer
                       reconcileStrategy:
+                        type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph obc's
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     type: object
                   cephRBDMirror:
@@ -1219,6 +1256,12 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for NFS
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               nodeTopologies:
                 description: NodeTopologies specifies the nodes available for the

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -61,30 +61,51 @@ func generateNameForCephObjectStore(initData *ocsv1.StorageCluster) string {
 }
 
 func generateNameForCephRgwSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.ManagedResources.CephObjectStores.StorageClassName != "" {
+		return initData.Spec.ManagedResources.CephObjectStores.StorageClassName
+	}
 	return fmt.Sprintf("%s-ceph-rgw", initData.Name)
 }
 
 func generateNameForCephFilesystemSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.ManagedResources.CephFilesystems.StorageClassName != "" {
+		return initData.Spec.ManagedResources.CephFilesystems.StorageClassName
+	}
 	return fmt.Sprintf("%s-cephfs", initData.Name)
 }
 
 func generateNameForCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.ManagedResources.CephBlockPools.StorageClassName != "" {
+		return initData.Spec.ManagedResources.CephBlockPools.StorageClassName
+	}
 	return fmt.Sprintf("%s-ceph-rbd", initData.Name)
 }
 
 func generateNameForCephBlockPoolVirtualizationSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.ManagedResources.CephBlockPools.VirtualizationStorageClassName != "" {
+		return initData.Spec.ManagedResources.CephBlockPools.VirtualizationStorageClassName
+	}
 	return fmt.Sprintf("%s-ceph-rbd-virtualization", initData.Name)
 }
 
 func generateNameForNonResilientCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.ManagedResources.CephNonResilientPools.StorageClassName != "" {
+		return initData.Spec.ManagedResources.CephNonResilientPools.StorageClassName
+	}
 	return fmt.Sprintf("%s-ceph-non-resilient-rbd", initData.Name)
 }
 
 func generateNameForEncryptedCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.Encryption.StorageClassName != "" {
+		return initData.Spec.Encryption.StorageClassName
+	}
 	return fmt.Sprintf("%s-ceph-rbd-encrypted", initData.Name)
 }
 
 func generateNameForCephNetworkFilesystemSC(initData *ocsv1.StorageCluster) string {
+	if initData.Spec.NFS.StorageClassName != "" {
+		return initData.Spec.NFS.StorageClassName
+	}
 	return fmt.Sprintf("%s-ceph-nfs", initData.Name)
 }
 

--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -173,6 +173,8 @@ func initStorageClusterResourceCreateUpdateTestWithPlatform(
 		_ = reconciler.Client.Create(context.TODO(), rtObj)
 	}
 
+	err := os.Setenv("OPERATOR_NAMESPACE", cr.Namespace)
+	assert.NoError(t, err)
 	result, err := reconciler.Reconcile(context.TODO(), request)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)

--- a/controllers/storagecluster/storageclasses_test.go
+++ b/controllers/storagecluster/storageclasses_test.go
@@ -25,14 +25,50 @@ var (
 			},
 		},
 	}
+	customEncryptedSCNameSpec = &api.StorageClusterSpec{
+		Encryption: api.EncryptionSpec{
+			StorageClass:     true,
+			StorageClassName: "custom-ceph-rbd-encrypted",
+			KeyManagementService: api.KeyManagementServiceSpec{
+				Enable: true,
+			},
+		},
+	}
+	customSCNameSpec = &api.StorageClusterSpec{
+		NFS: &api.NFSSpec{
+			StorageClassName: "custom-ceph-nfs",
+		},
+		ManagedResources: api.ManagedResourcesSpec{
+			CephBlockPools: api.ManageCephBlockPools{
+				StorageClassName: "custom-ceph-rbd",
+			},
+			CephFilesystems: api.ManageCephFilesystems{
+				StorageClassName: "custom-cephfs",
+			},
+			CephNonResilientPools: api.ManageCephNonResilientPools{
+				StorageClassName: "custom-ceph-non-resilient-rbd",
+			},
+			CephObjectStores: api.ManageCephObjectStores{
+				StorageClassName: "custom-ceph-rgw",
+			},
+		},
+	}
 )
 
 func TestDefaultStorageClasses(t *testing.T) {
 	testStorageClasses(t, false, nil)
 }
 
+func TestCustomStorageClasses(t *testing.T) {
+	testStorageClasses(t, false, customSCNameSpec)
+}
+
 func TestEncryptedStorageClass(t *testing.T) {
 	testStorageClasses(t, true, customSpec)
+}
+
+func TestCustomEncryptedStorageClasses(t *testing.T) {
+	testStorageClasses(t, true, customEncryptedSCNameSpec)
 }
 
 func testStorageClasses(t *testing.T, pvEncryption bool, customSpec *api.StorageClusterSpec) {

--- a/deploy/csv-templates/crds/ics/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ics/ocs.openshift.io_storageclusters.yaml
@@ -480,6 +480,12 @@ spec:
                     type: object
                   storageClass:
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for ceph encrypted block pools
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When
@@ -580,6 +586,19 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph block pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      virtualizationStorageClassName:
+                        description: VirtualizationStorageClassName specifies the
+                          name of the storage class created for ceph block pools for
+                          virtualization environment
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephCluster:
                     description: ManageCephCluster defines how to reconcile the Ceph
@@ -614,6 +633,12 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for cephfs
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephNonResilientPools:
                     description: ManageCephNonResilientPools defines how to reconcile
@@ -621,6 +646,12 @@ spec:
                     properties:
                       enable:
                         type: boolean
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph non-resilient pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephObjectStoreUsers:
                     description: ManageCephObjectStoreUsers defines how to reconcile
@@ -640,6 +671,12 @@ spec:
                         format: int32
                         type: integer
                       reconcileStrategy:
+                        type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph obc's
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     type: object
                   cephRBDMirror:
@@ -1219,6 +1256,12 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for NFS
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               nodeTopologies:
                 description: NodeTopologies specifies the nodes available for the

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -480,6 +480,12 @@ spec:
                     type: object
                   storageClass:
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for ceph encrypted block pools
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When
@@ -580,6 +586,19 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph block pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      virtualizationStorageClassName:
+                        description: VirtualizationStorageClassName specifies the
+                          name of the storage class created for ceph block pools for
+                          virtualization environment
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephCluster:
                     description: ManageCephCluster defines how to reconcile the Ceph
@@ -614,6 +633,12 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for cephfs
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephNonResilientPools:
                     description: ManageCephNonResilientPools defines how to reconcile
@@ -621,6 +646,12 @@ spec:
                     properties:
                       enable:
                         type: boolean
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph non-resilient pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephObjectStoreUsers:
                     description: ManageCephObjectStoreUsers defines how to reconcile
@@ -640,6 +671,12 @@ spec:
                         format: int32
                         type: integer
                       reconcileStrategy:
+                        type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph obc's
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     type: object
                   cephRBDMirror:
@@ -1219,6 +1256,12 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for NFS
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               nodeTopologies:
                 description: NodeTopologies specifies the nodes available for the

--- a/deploy/ics-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ics-operator/manifests/storagecluster.crd.yaml
@@ -479,6 +479,12 @@ spec:
                     type: object
                   storageClass:
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for ceph encrypted block pools
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When
@@ -579,6 +585,19 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph block pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      virtualizationStorageClassName:
+                        description: VirtualizationStorageClassName specifies the
+                          name of the storage class created for ceph block pools for
+                          virtualization environment
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephCluster:
                     description: ManageCephCluster defines how to reconcile the Ceph
@@ -613,6 +632,12 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for cephfs
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephNonResilientPools:
                     description: ManageCephNonResilientPools defines how to reconcile
@@ -620,6 +645,12 @@ spec:
                     properties:
                       enable:
                         type: boolean
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph non-resilient pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephObjectStoreUsers:
                     description: ManageCephObjectStoreUsers defines how to reconcile
@@ -639,6 +670,12 @@ spec:
                         format: int32
                         type: integer
                       reconcileStrategy:
+                        type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph obc's
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     type: object
                   cephRBDMirror:
@@ -1218,6 +1255,12 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for NFS
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               nodeTopologies:
                 description: NodeTopologies specifies the nodes available for the

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -479,6 +479,12 @@ spec:
                     type: object
                   storageClass:
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for ceph encrypted block pools
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               externalStorage:
                 description: ExternalStorage is optional and defaults to false. When
@@ -579,6 +585,19 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph block pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      virtualizationStorageClassName:
+                        description: VirtualizationStorageClassName specifies the
+                          name of the storage class created for ceph block pools for
+                          virtualization environment
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephCluster:
                     description: ManageCephCluster defines how to reconcile the Ceph
@@ -613,6 +632,12 @@ spec:
                         type: boolean
                       reconcileStrategy:
                         type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for cephfs
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephNonResilientPools:
                     description: ManageCephNonResilientPools defines how to reconcile
@@ -620,6 +645,12 @@ spec:
                     properties:
                       enable:
                         type: boolean
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph non-resilient pools
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
                     type: object
                   cephObjectStoreUsers:
                     description: ManageCephObjectStoreUsers defines how to reconcile
@@ -639,6 +670,12 @@ spec:
                         format: int32
                         type: integer
                       reconcileStrategy:
+                        type: string
+                      storageClassName:
+                        description: StorageClassName specifies the name of the storage
+                          class created for ceph obc's
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     type: object
                   cephRBDMirror:
@@ -1218,6 +1255,12 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  storageClassName:
+                    description: StorageClassName specifies the name of the storage
+                      class created for NFS
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 type: object
               nodeTopologies:
                 description: NodeTopologies specifies the nodes available for the


### PR DESCRIPTION
Added a new field named `StorageClassName` to the CephFilesystems,
CephBlockPools, CephNonResilientPools, CephObjectStores, NFS and Encryption
spec that takes the user defined name of the storage class created for
the respective type of resource.
And, `VirtualizationStorageClassName` for SC created for ceph block pools in
virtualization environment.
Added `MaxLength`, `Pattern` and duplicate values validation on the field.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2112929

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>