### PR TITLE
Add prometheus rules verification in CI

### DIFF
--- a/.github/workflows/ocs-operator-prom-ci.yaml
+++ b/.github/workflows/ocs-operator-prom-ci.yaml
@@ -1,0 +1,20 @@
+name: Verify latest deployment prometheus yaml
+on:
+  push:
+    paths:
+      - 'metrics/*'
+  pull_request:
+    paths:
+      - 'metrics/*'
+
+jobs:
+  verify-deployment-prom:
+    name: verify deployment prometheus yaml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Verify deployment prometheus YAML
+        run: make verify-latest-prometheus-rules-yamls

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ gen-latest-prometheus-rules-yamls:
 	@echo "Generating latest Prometheus rules yamls"
 	hack/gen-promethues-rules.sh
 
+verify-latest-prometheus-rules-yamls: gen-latest-prometheus-rules-yamls
+	@echo "Verifying deployment yaml changes"
+	hack/verify-latest-prometheus-rules-yamls.sh
+
 verify-latest-deploy-yaml: gen-latest-deploy-yaml
 	@echo "Verifying deployment yaml changes"
 	hack/verify-latest-deploy-yaml.sh

--- a/hack/verify-latest-prometheus-rules-yamls.sh
+++ b/hack/verify-latest-prometheus-rules-yamls.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -n "$(git status --porcelain metrics/deploy)" ]]; then
+	git diff -u api metrics/deploy
+	echo "uncommitted prometheus rules changs. run 'make gen-latest-prometheus-rules-yamls' and commit results."
+	exit 1
+fi
+echo "Success: no out of source tree changes found for prometheus rules files"


### PR DESCRIPTION
This pull request does the following:

- Adds a new GitHub Actions workflow that verifies the latest Prometheus rules YAML files when changes occur in the metrics/* directory.
- Modifies the Makefile to include a new target 'verify-latest-prometheus-rules-yamls', which triggers the verification script.
- Creates a new script 'verify-latest-prometheus-rules-yamls.sh' in the hack directory. This script checks for uncommitted changes in the Prometheus rules files and prints a success message when no out-of-tree changes are found.