### PR TITLE
Bug 2209254: [release-4.11] Fix encryption enablement in Noobaa

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -184,13 +184,11 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	}
 
 	// Add KMS details to Noobaa spec, only if
-	// cluster-wide encryption or KMS is enabled
-	// ie, sc.Spec.Encryption.ClusterWide or sc.Spec.Encryption.KeyManagementService.Enable is True
-	// and KMS ConfigMap is available
+	// KMS is enabled, along with
+	// ClusterWide encryption OR in a StandAlone Noobaa cluster mode
 	// PS: sc.Spec.Encryption.Enable field is deprecated and added for backward compatibility
-	if sc.Spec.Encryption.Enable ||
-		sc.Spec.Encryption.ClusterWide ||
-		sc.Spec.Encryption.KeyManagementService.Enable {
+	if sc.Spec.Encryption.KeyManagementService.Enable &&
+		(sc.Spec.Encryption.Enable || sc.Spec.Encryption.ClusterWide || r.IsNoobaaStandalone) {
 		if kmsConfig, err := getKMSConfigMap(KMSConfigMapName, sc, r.Client); err != nil {
 			return err
 		} else if kmsConfig != nil {


### PR DESCRIPTION
Enable encryption only when KMS is enabled along with ClusterWide encryption OR in standalone Noobaa cluster mode

Updated tests accordingly.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>
(cherry picked from commit 326a658f734d04a660f1fc4530138879d5d7b48d)