### PR TITLE
Always call the ensureOCSOperatorConfig func irrespective of the mode

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -104,13 +104,6 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		return reconcile.Result{}, nil
 	}
 
-	// ensure the ocs-operator-config cm exists & has the correct values
-	err = r.ensureOCSOperatorConfig(sc)
-	if err != nil {
-		r.Log.Error(err, "Failed to ensure ocs-operator-config ConfigMap")
-		return reconcile.Result{}, err
-	}
-
 	if sc.Spec.ExternalStorage.Enable && len(sc.Spec.StorageDeviceSets) != 0 {
 		return reconcile.Result{}, fmt.Errorf("'StorageDeviceSets' should not be initialized in an external CephCluster")
 	}

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -295,6 +295,13 @@ func (r *StorageClusterReconciler) reconcilePhases(
 		return reconcile.Result{}, nil
 	}
 
+	// ensure the ocs-operator-config cm exists & has the correct values
+	err := r.ensureOCSOperatorConfig(instance)
+	if err != nil {
+		r.Log.Error(err, "Failed to ensure ocs-operator-config ConfigMap")
+		return reconcile.Result{}, err
+	}
+
 	if instance.Status.Phase != statusutil.PhaseReady &&
 		instance.Status.Phase != statusutil.PhaseClusterExpanding &&
 		instance.Status.Phase != statusutil.PhaseDeleting &&


### PR DESCRIPTION
Earlier the ensureOCSOperatorConfig func was being called while creation of the cephcluster, but in Noobaa standalone mode it was not being called, as a cephcluster is not created in that mode. So we have to ensure that the ensureOCSOperatorConfig is called irrespective of the modes. So we are moving it to the reconcile.go file and putting it at the end of reconcilePhases func.