### PR TITLE
Always update the template parameters & objects to keep it up-to-date

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -49,7 +49,8 @@ func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1
 	for _, tempFunc := range tempFuncs {
 		template := tempFunc(sc)
 		_, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, template, func() error {
-			template := tempFunc(sc)
+			template.Parameters = tempFunc(sc).Parameters
+			template.Objects = tempFunc(sc).Objects
 			return controllerutil.SetControllerReference(sc, template, r.Scheme)
 		})
 


### PR DESCRIPTION
Trying to update the whole template object doesn't work. So the template is not reconciled at all. We want the template to be updated to use new parameters, any new ceph commands, latest rook-ceph image, etc. So we need to update the parameters & objects separately to keep the template up-to-date.

This can be treated as an extension to https://github.com/red-hat-storage/ocs-operator/pull/1959