### PR TITLE
Bug 2211592: [release-4.12] Always update the template parameters & objects to keep it up-to-date

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -49,6 +49,8 @@ func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1
 	for _, tempFunc := range tempFuncs {
 		template := tempFunc(sc)
 		_, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, template, func() error {
+			template.Parameters = tempFunc(sc).Parameters
+			template.Objects = tempFunc(sc).Objects
 			return controllerutil.SetControllerReference(sc, template, r.Scheme)
 		})
 


### PR DESCRIPTION
Previously once the template existed we were not reconciling it. This resulted in the template using very old rook-ceph images and not having the newly added parameters. We want the template to be updated to use new parameters, any new ceph commands, latest rook-ceph image, etc. Trying to update the whole template object also doesn't work. So we need to update the parameters & objects separately to keep the template up-to-date.

/hold