### PR TITLE
Add namespace controller for ReclaimSpace

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -5,6 +5,12 @@ repo: github.com/red-hat-storage/ocs-operator
 resources:
 -
   controller: true
+  group: core
+  kind: Namespace
+  path: k8s.io/api/core/v1
+  version: v1
+-
+  controller: true
   domain: openshift.io
   group: ocs
   kind: OCSInitialization

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -144,6 +144,10 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -152,6 +156,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - list
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/controllers/namespace/namespace_controller.go
+++ b/controllers/namespace/namespace_controller.go
@@ -1,0 +1,210 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/red-hat-storage/ocs-operator/controllers/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// once is a pointer to the sync.Once type
+var once sync.Once
+
+// NamespaceReconciler reconciles the namespaces starting with openshift-*
+// nolint:revive
+type NamespaceReconciler struct {
+	client.Client
+	ctx    context.Context
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=list;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;update;patch
+
+// Reconcile reads that state of the cluster for a Namespace object and makes changes based on the state read
+// i.e,the annotations of the namespace
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+
+	prevLogger := r.Log
+	defer func() { r.Log = prevLogger }()
+	r.Log = r.Log.WithValues("Request.Name", request.Name)
+	r.ctx = ctx
+
+	r.Log.Info("Reconciling Namespace.")
+
+	var err error
+	updated := false
+
+	once.Do(func() {
+		updated, err = r.annotateOpenshiftNamespaces()
+	})
+
+	// If it's not the first reconcile and the namespaces were not updated in the once.Do func call
+	if !updated {
+		ns := &corev1.Namespace{}
+		err = r.Client.Get(ctx, request.NamespacedName, ns)
+		if err != nil {
+			// the namespace is probably deleted
+			if errors.IsNotFound(err) {
+				r.Log.Error(err, fmt.Sprintf("Namespace %s does not exist", request.Name))
+				return reconcile.Result{}, nil
+			}
+			return reconcile.Result{}, err
+		}
+
+		// Annotate namespaces starting with openshift-*, but ignore namespace if
+		// it has annotation "'skipReclaimspaceSchedule':'true'" set
+		updated, err = r.annotateNamespaces([]corev1.Namespace{*ns})
+		if err != nil {
+			r.Log.Error(err, fmt.Sprintf("Failed to annotate namespace: %s", ns.Name))
+			return reconcile.Result{}, err
+		}
+	}
+
+	// Restart the csi-addons controller pod if any namespace was annotated
+	if updated {
+		err = r.restartCSIAddonsPod()
+	}
+
+	return reconcile.Result{}, err
+}
+
+// annotateOpenshiftNamespaces annotates all the namespaces starting with openshift-*
+func (r *NamespaceReconciler) annotateOpenshiftNamespaces() (bool, error) {
+	nsList := &corev1.NamespaceList{}
+	err := r.Client.List(r.ctx, nsList)
+	if err != nil {
+		r.Log.Error(err, "Failed to list Namespaces")
+		return false, err
+	}
+
+	openshiftNamespaces := []corev1.Namespace{}
+	for _, ns := range nsList.Items {
+		if strings.HasPrefix(ns.Name, "openshift-") {
+			openshiftNamespaces = append(openshiftNamespaces, ns)
+		}
+	}
+
+	return r.annotateNamespaces(openshiftNamespaces)
+}
+
+// annotateNamespaces annotate the provided namespace but, ignores if
+// shouldSkipAnnotation() returns true
+func (r *NamespaceReconciler) annotateNamespaces(opNs []corev1.Namespace) (bool, error) {
+	updated := false
+	for _, ns := range opNs {
+		if shouldSkipAnnotation(ns) {
+			continue
+		}
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations["reclaimspace.csiaddons.openshift.io/schedule"] = "@weekly"
+
+		err := r.Client.Update(r.ctx, &ns)
+		if err != nil {
+			r.Log.Error(err, fmt.Sprintf("Failed to annotate namespace: %s", ns.Name))
+			return false, err
+		}
+		r.Log.Info(fmt.Sprintf("Successfully annotated namespace: %s", ns.Name))
+		updated = true
+	}
+	return updated, nil
+}
+
+// shouldSkipAnnotation checks if we should skip adding new annotations to the namespace
+func shouldSkipAnnotation(ns corev1.Namespace) bool {
+	if !ns.GetDeletionTimestamp().IsZero() || ns.Annotations["skipReclaimspaceSchedule"] == "true" ||
+		ns.Annotations["reclaimspace.csiaddons.openshift.io/schedule"] != "" {
+		return true
+	}
+	return false
+}
+
+// restartCSIAddonsPod restarts the CSIAddons pod by deleting all of its instances.
+func (r *NamespaceReconciler) restartCSIAddonsPod() error {
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(os.Getenv(util.OperatorNamespaceEnvVar)),
+		client.MatchingLabels{"app.kubernetes.io/name": "csi-addons"},
+	}
+	err := r.Client.List(r.ctx, podList, listOpts...)
+	if err != nil {
+		r.Log.Error(err, "Failed to get list of pods with label 'csi-addons'")
+		return err
+	}
+
+	// If no csi-addons pod is present
+	if len(podList.Items) == 0 {
+		r.Log.Error(err, "No csi-addons pod found")
+		return nil
+	}
+
+	for _, csiAddonsPod := range podList.Items {
+		err = r.Client.Delete(r.ctx, &csiAddonsPod, client.GracePeriodSeconds(0))
+		if err != nil {
+			r.Log.Error(err, "Failed to delete csi-addons pod")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up a controller with a manager
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	predicateFunc := func(obj runtime.Object) bool {
+		instance, ok := obj.(*corev1.Namespace)
+		if !ok {
+			return false
+		}
+
+		// ignore if the namespace's name doesn't start with openshift-*
+		if !strings.HasPrefix(instance.Name, "openshift-") {
+			return false
+		}
+
+		// If the namespace has already been annotated, or skip annotation is set,
+		// or the namespace is marked for deletion
+		if shouldSkipAnnotation(*instance) {
+			return false
+		}
+
+		return true
+	}
+
+	nameSpacePredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return predicateFunc(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return predicateFunc(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Ignore delete events
+			return false
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{},
+			builder.WithPredicates(nameSpacePredicate)).
+		Complete(r)
+}

--- a/controllers/namespace/namespace_controller_test.go
+++ b/controllers/namespace/namespace_controller_test.go
@@ -1,0 +1,77 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/red-hat-storage/ocs-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func getReconciler(t *testing.T) NamespaceReconciler {
+	scheme := createFakeScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	log := logf.Log.WithName("controller_namespace_test")
+
+	return NamespaceReconciler{
+		Scheme: scheme,
+		Client: client,
+		Log:    log,
+	}
+}
+
+func createFakeScheme(t *testing.T) *runtime.Scheme {
+	scheme, err := v1.SchemeBuilder.Build()
+	if err != nil {
+		assert.Fail(t, "unable to build scheme")
+	}
+
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add corev1 scheme")
+	}
+
+	return scheme
+}
+
+func TestReconcilerImplementsInterface(t *testing.T) {
+	reconciler := NamespaceReconciler{}
+	var i interface{} = &reconciler
+	_, ok := i.(reconcile.Reconciler)
+	assert.True(t, ok)
+}
+
+func TestNamespaceAnnotated(t *testing.T) {
+	ctx := context.TODO()
+	reconciler := getReconciler(t)
+	opNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-storage-test",
+		},
+	}
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "openshift-storage-test",
+			Namespace: "",
+		},
+	}
+
+	err := reconciler.Create(ctx, opNS)
+	assert.NoError(t, err, "failed to create namespace")
+	_, err = reconciler.Reconcile(ctx, request)
+	assert.NoError(t, err, "failed to reconcile")
+	nsList := &corev1.NamespaceList{}
+	err = reconciler.List(ctx, nsList)
+	assert.NoError(t, err, "failed to list namespaces")
+	for _, testNs := range nsList.Items {
+		assert.Equal(t, testNs.Name, "openshift-storage-test")
+		assert.Equal(t, testNs.Annotations["reclaimspace.csiaddons.openshift.io/schedule"], "@weekly")
+	}
+}

--- a/deploy/csv-templates/ics-operator.csv.yaml.in
+++ b/deploy/csv-templates/ics-operator.csv.yaml.in
@@ -347,6 +347,10 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -355,6 +359,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - list
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -347,6 +347,10 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -355,6 +359,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - list
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ics-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1948,6 +1948,10 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -1956,6 +1960,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - list
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1948,6 +1948,10 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -1956,6 +1960,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - list
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v1alpha1"
+	"github.com/red-hat-storage/ocs-operator/controllers/namespace"
 	"github.com/red-hat-storage/ocs-operator/controllers/ocsinitialization"
 	"github.com/red-hat-storage/ocs-operator/controllers/storageclassrequest"
 	"github.com/red-hat-storage/ocs-operator/controllers/storagecluster"
@@ -145,6 +146,15 @@ func main() {
 	condition, err := storagecluster.NewUpgradeable(mgr.GetClient())
 	if err != nil {
 		setupLog.Error(err, "Unable to get OperatorCondition")
+		os.Exit(1)
+	}
+
+	if err = (&namespace.NamespaceReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Namespace"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Added a new namespace controller that adds a reclaimspace schedule annotation to all the namespaces starting with `openshift-*`, and restarts the csi-addons pod once done.

*NOTE:*
The controller doesn't restart the csi-addons pod if the value of reclaimspace annotation is updated to a different value manully. The pod needs to be restarted manually in that case.