### PR TITLE
Toggle between OCS Provider Server Service Type

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -85,6 +85,12 @@ type StorageClusterSpec struct {
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
+
+	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
+	// The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+	// This will only be used when AllowRemoteStorageConsumers is set to true
+	ProviderAPIServerServiceType corev1.ServiceType `json:"providerAPIServerServiceType,omitempty"`
+
 	// EnableCephTools toggles on whether or not the ceph tools pod
 	// should be deployed.
 	// Defaults to false

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -2442,6 +2442,13 @@ spec:
                 description: Placement is optional and used to specify placements
                   of OCS components explicitly
                 type: object
+              providerAPIServerServiceType:
+                description: ProviderAPIServerServiceType Indicates the ServiceType
+                  for OCS Provider API Server Service. The supported values are NodePort
+                  or LoadBalancer. The default ServiceType is NodePort if the value
+                  is empty. This will only be used when AllowRemoteStorageConsumers
+                  is set to true
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -2442,6 +2442,13 @@ spec:
                 description: Placement is optional and used to specify placements
                   of OCS components explicitly
                 type: object
+              providerAPIServerServiceType:
+                description: ProviderAPIServerServiceType Indicates the ServiceType
+                  for OCS Provider API Server Service. The supported values are NodePort
+                  or LoadBalancer. The default ServiceType is NodePort if the value
+                  is empty. This will only be used when AllowRemoteStorageConsumers
+                  is set to true
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -2441,6 +2441,13 @@ spec:
                 description: Placement is optional and used to specify placements
                   of OCS components explicitly
                 type: object
+              providerAPIServerServiceType:
+                description: ProviderAPIServerServiceType Indicates the ServiceType
+                  for OCS Provider API Server Service. The supported values are NodePort
+                  or LoadBalancer. The default ServiceType is NodePort if the value
+                  is empty. This will only be used when AllowRemoteStorageConsumers
+                  is set to true
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource


### PR DESCRIPTION
Update the storageCluster CR to set the type of service as nodePort or LoadBalancer

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2212773

Different cloud providers needs different annotations to be added in order to bring up the ocs provider server service in private network, hence we might need to create a load balancer externally, hence added a field in storageCluster CR to toggle between NodePort and LoadBalancer Service type

Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer