### PR TITLE
Create a storageclass with rxbounce option if kubevirt crd is present

### DIFF
--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -72,6 +72,10 @@ func generateNameForCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-ceph-rbd", initData.Name)
 }
 
+func generateNameForCephBlockPoolVirtualizationSC(initData *ocsv1.StorageCluster) string {
+	return fmt.Sprintf("%s-ceph-rbd-virtualization", initData.Name)
+}
+
 func generateNameForNonResilientCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-ceph-non-resilient-rbd", initData.Name)
 }

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -12,6 +12,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -280,6 +281,16 @@ func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) S
 	}
 }
 
+// newCephBlockPoolVirtualizationStorageClassConfiguration generates configuration options for a Ceph Block Pool StorageClass for virtualization environment.
+func newCephBlockPoolVirtualizationStorageClassConfiguration(initData *ocsv1.StorageCluster) StorageClassConfiguration {
+	virtualizationStorageClassConfig := newCephBlockPoolStorageClassConfiguration(initData)
+	virtualizationStorageClassConfig.storageClass.ObjectMeta.Name = generateNameForCephBlockPoolVirtualizationSC(initData)
+	virtualizationStorageClassConfig.storageClass.ObjectMeta.Annotations["description"] = "Provides RWO and RWX Block volumes suitable for Virtual Machine disks"
+	virtualizationStorageClassConfig.storageClass.Parameters["mounter"] = "rbd"
+	virtualizationStorageClassConfig.storageClass.Parameters["mapOptions"] = "krbd:rxbounce"
+	return virtualizationStorageClassConfig
+}
+
 // newNonResilientCephBlockPoolStorageClassConfiguration generates configuration options for a Non-Resilient Ceph Block Pool StorageClass.
 func newNonResilientCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) StorageClassConfiguration {
 	persistentVolumeReclaimDelete := corev1.PersistentVolumeReclaimDelete
@@ -394,6 +405,12 @@ func (r *StorageClusterReconciler) newStorageClassConfigurations(initData *ocsv1
 	ret := []StorageClassConfiguration{
 		newCephFilesystemStorageClassConfiguration(initData),
 		newCephBlockPoolStorageClassConfiguration(initData),
+	}
+	// If kubevirt crd is present, we create a specialized rbd storageclass for virtualization environment
+	kvcrd := &extv1.CustomResourceDefinition{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "virtualmachines.kubevirt.io", Namespace: ""}, kvcrd)
+	if err == nil {
+		ret = append(ret, newCephBlockPoolVirtualizationStorageClassConfiguration(initData))
 	}
 	if initData.Spec.ManagedResources.CephNonResilientPools.Enable {
 		ret = append(ret, newNonResilientCephBlockPoolStorageClassConfiguration(initData))


### PR DESCRIPTION
We will watch for the virtualmachines.kubevirt.io crd. Then create a special ceph rbd storageclass for the virtualization
environment. This storageclass will have the rxbounce option to use a bounce buffer during I/O operation. This is mostly targeted to fix issues with windows VMs using ceph rbd. This storageclass has all the same options as the default ceph rbd storageclass with this extra rxbounce option.