### PR TITLE
storagecluster: set allowVolumeExpansion to true for rbd enc sc

### DIFF
--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -352,8 +352,7 @@ func newCephNFSStorageClassConfiguration(initData *ocsv1.StorageCluster) Storage
 // newEncryptedCephBlockPoolStorageClassConfiguration generates configuration options for an encrypted Ceph Block Pool StorageClass.
 // when user has asked for PV encryption during deployment.
 func newEncryptedCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster, serviceName string) StorageClassConfiguration {
-	// PV resize of encrypted volume is not officially supported in ODF 4.10 hence setting it to False
-	allowVolumeExpansion := false
+	allowVolumeExpansion := true
 	encryptedStorageClassConfig := newCephBlockPoolStorageClassConfiguration(initData)
 	encryptedStorageClassConfig.storageClass.ObjectMeta.Name = generateNameForEncryptedCephBlockPoolSC(initData)
 	encryptedStorageClassConfig.storageClass.Parameters["encrypted"] = "true"


### PR DESCRIPTION
CephCSI supports expansion for rbd encrypted PVCs. This pr sets allowVolumeExpansion to true in
the default encrypted rbd storageclass that
ocs-operator creates.

resolves: https://issues.redhat.com/browse/RHSTOR-4650

/cc @iamniting @agarwal-mudit @malayparida2000 @Madhu-1 @nixpanic 