### PR TITLE
Add make targets with hack shell scripts to install ocs & noobaa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,3 +233,11 @@ export KUSTOMIZE=$(GOBIN)/kustomize
 else
 export KUSTOMIZE=$(shell which kustomize)
 endif
+
+install-noobaa:
+	@echo "Installing noobaa operator"
+	hack/install-noobaa.sh
+
+install-ocs:
+	@echo "Installing ocs operator"
+	hack/install-ocs.sh

--- a/hack/install-noobaa.sh
+++ b/hack/install-noobaa.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+source hack/common.sh
+
+NAMESPACE=$(oc get ns "$INSTALL_NAMESPACE" -o jsonpath="{.metadata.name}" 2>/dev/null || true)
+if [[ -n "$NAMESPACE" ]]; then
+    echo "Namespace \"$NAMESPACE\" exists"
+else
+    echo "Namespace \"$INSTALL_NAMESPACE\" does not exist: creating it"
+    oc create ns "$INSTALL_NAMESPACE"
+fi
+
+operator-sdk run bundle "$NOOBAA_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"
+
+oc wait --timeout=5m --for condition=Available -n "$INSTALL_NAMESPACE" deployment noobaa-operator

--- a/hack/install-ocs.sh
+++ b/hack/install-ocs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+source hack/common.sh
+
+NAMESPACE=$(oc get ns "$INSTALL_NAMESPACE" -o jsonpath="{.metadata.name}" 2>/dev/null || true)
+if [[ -n "$NAMESPACE" ]]; then
+    echo "Namespace \"$NAMESPACE\" exists"
+else
+    echo "Namespace \"$INSTALL_NAMESPACE\" does not exist: creating it"
+    oc create ns "$INSTALL_NAMESPACE"
+fi
+
+operator-sdk run bundle "$BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"
+
+oc wait --timeout=5m --for condition=Available -n "$INSTALL_NAMESPACE" deployment ocs-operator
+oc wait --timeout=5m --for condition=Available -n "$INSTALL_NAMESPACE" deployment ocs-metrics-exporter
+oc wait --timeout=5m --for condition=Available -n "$INSTALL_NAMESPACE" deployment rook-ceph-operator


### PR DESCRIPTION
Both the scripts use operator-sdk run bundle command to directly install the operators from their bundles. The scripts also wait for the operator deployments to be ready before exiting.