### PR TITLE
Toggle between OCS Provider Server Service Type

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -85,6 +85,12 @@ type StorageClusterSpec struct {
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
+
+	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
+	// The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+	// This will only be used when AllowRemoteStorageConsumers is set to true
+	ProviderAPIServerServiceType corev1.ServiceType `json:"providerAPIServerServiceType,omitempty"`
+
 	// EnableCephTools toggles on whether or not the ceph tools pod
 	// should be deployed.
 	// Defaults to false

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -2398,6 +2398,13 @@ spec:
                 description: Placement is optional and used to specify placements
                   of OCS components explicitly
                 type: object
+              providerAPIServerServiceType:
+                description: ProviderAPIServerServiceType Indicates the ServiceType
+                  for OCS Provider API Server Service. The supported values are NodePort
+                  or LoadBalancer. The default ServiceType is NodePort if the value
+                  is empty. This will only be used when AllowRemoteStorageConsumers
+                  is set to true
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource

--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -145,6 +145,12 @@ func (o *ocsProviderServer) createDeployment(r *StorageClusterReconciler, instan
 
 func (o *ocsProviderServer) createService(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
+	if instance.Spec.ProviderAPIServerServiceType == corev1.ServiceTypeClusterIP || instance.Spec.ProviderAPIServerServiceType == corev1.ServiceTypeExternalName {
+		err := fmt.Errorf("providerAPIServer only supports service of type %s and %s", corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer)
+		r.Log.Error(err, "Failed to create/update service, Requested ServiceType is", "ServiceType", instance.Spec.ProviderAPIServerServiceType)
+		return reconcile.Result{}, err
+	}
+
 	desiredService := GetProviderAPIServerService(instance)
 	actualService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -306,6 +312,10 @@ func GetProviderAPIServerDeployment(instance *ocsv1.StorageCluster) *appsv1.Depl
 
 func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service {
 
+	if instance.Spec.ProviderAPIServerServiceType == "" {
+		instance.Spec.ProviderAPIServerServiceType = corev1.ServiceTypeNodePort
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ocsProviderServerName,
@@ -325,7 +335,7 @@ func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service
 					TargetPort: intstr.FromString("ocs-provider"),
 				},
 			},
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type: instance.Spec.ProviderAPIServerServiceType,
 		},
 	}
 }

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -2398,6 +2398,13 @@ spec:
                 description: Placement is optional and used to specify placements
                   of OCS components explicitly
                 type: object
+              providerAPIServerServiceType:
+                description: ProviderAPIServerServiceType Indicates the ServiceType
+                  for OCS Provider API Server Service. The supported values are NodePort
+                  or LoadBalancer. The default ServiceType is NodePort if the value
+                  is empty. This will only be used when AllowRemoteStorageConsumers
+                  is set to true
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -2397,6 +2397,13 @@ spec:
                 description: Placement is optional and used to specify placements
                   of OCS components explicitly
                 type: object
+              providerAPIServerServiceType:
+                description: ProviderAPIServerServiceType Indicates the ServiceType
+                  for OCS Provider API Server Service. The supported values are NodePort
+                  or LoadBalancer. The default ServiceType is NodePort if the value
+                  is empty. This will only be used when AllowRemoteStorageConsumers
+                  is set to true
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource


### PR DESCRIPTION
Update the storageCluster CR to set the type of service as nodePort or LoadBalancer 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2212773

Different cloud providers needs different annotations to be added in order to bring up the ocs provider server service in private network, hence we might need to create a load balancer externally, hence added a field in storageCluster CR to toggle between NodePort and LoadBalancer Service type

Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer