### PR TITLE
Improve the bundle build process for the operator

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -1,0 +1,15 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ocs-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.4
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
+
+# Copy files to locations specified by labels.
+COPY deploy/ocs-operator/manifests /manifests/
+COPY deploy/ocs-operator/metadata /metadata/

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ verify-operator-bundle: operator-sdk
 	@echo "Verifying operator bundle"
 	hack/verify-operator-bundle.sh
 
-operator-bundle:
+operator-bundle: gen-latest-csv
+	@echo "Building ocs operator bundle"
 	hack/build-operator-bundle.sh
 
 operator-index:

--- a/hack/build-operator-bundle.sh
+++ b/hack/build-operator-bundle.sh
@@ -5,21 +5,6 @@ set -e
 source hack/common.sh
 source hack/docker-common.sh
 
-TMP_ROOT="$(dirname "${BASH_SOURCE[@]}")/.."
-REPO_ROOT=$(readlink -e "${TMP_ROOT}" 2> /dev/null || perl -MCwd -e 'print Cwd::abs_path shift' "${TMP_ROOT}")
-
-function build_operator_bundle() {
-    DOCKERFILE=$1
-
-    pushd "${REPO_ROOT}/deploy"
-    $IMAGE_BUILD_CMD build --no-cache -t "$BUNDLE_FULL_IMAGE_NAME" -f "$DOCKERFILE" .
-
-    echo
-    echo "Run '${IMAGE_BUILD_CMD} push ${BUNDLE_FULL_IMAGE_NAME}' to push operator bundle to image registry."
-    echo
-    echo "Run './hack/build-operator-index.sh' to add this bundle to operator index."
-    popd
-}
-
-echo "Building Red Hat OpenShift Container Storage Operator Bundle"
-build_operator_bundle Dockerfile
+${IMAGE_BUILD_CMD} build --no-cache -t "$BUNDLE_FULL_IMAGE_NAME" -f Dockerfile.bundle .
+echo
+echo "Run '${IMAGE_BUILD_CMD} push ${BUNDLE_FULL_IMAGE_NAME}' to push operator bundle to image registry."

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -104,4 +104,4 @@ gen_ocs_csv
 
 echo "Manifests sourced into $OUTDIR_TEMPLATES directory"
 
-rm bundle.Dockerfile
+mv bundle.Dockerfile Dockerfile.bundle


### PR DESCRIPTION
Always call gen-latest-csv before building the bundle. Generate & Update the bundle Dockerfile each time. Simplify the hack/build-operator-bundle.sh script.