### PR TITLE
Use new module path for ocs in ldflags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR /workspace
 
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 go build -tags 'netgo osusergo' -o ocs-operator main.go
-RUN GOOS=linux GOARCH=amd64 go build -tags 'netgo osusergo' -o provider-api services/provider/main.go
+ARG LDFLAGS
+
+RUN GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o ocs-operator main.go
+RUN GOOS=linux GOARCH=amd64 go build -tags netgo,osusergo -o provider-api services/provider/main.go
 
 # Build stage 2
 

--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -15,8 +15,6 @@ else
 	echo "GINKO binary found at $GINKGO"
 fi
 
-LDFLAGS="-X github.com/red-hat-storage/ocs-operator/version.Version=${CSV_VERSION}"
-
 "${GINKGO}" build --ldflags "${LDFLAGS}" "functests/${suite}/"
 
 mkdir -p $OUTDIR_BIN

--- a/hack/build-metrics-exporter.sh
+++ b/hack/build-metrics-exporter.sh
@@ -5,4 +5,4 @@ set -e
 source hack/common.sh
 source hack/docker-common.sh
 
-${IMAGE_BUILD_CMD} build --no-cache -f metrics/Dockerfile -t "${METRICS_EXPORTER_FULL_IMAGE_NAME}" .
+${IMAGE_BUILD_CMD} build --build-arg="LDFLAGS=${LDFLAGS}" --no-cache -f metrics/Dockerfile -t "${METRICS_EXPORTER_FULL_IMAGE_NAME}" .

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -5,4 +5,4 @@ set -e
 source hack/common.sh
 source hack/docker-common.sh
 
-${IMAGE_BUILD_CMD} build --no-cache -t "${OPERATOR_FULL_IMAGE_NAME}" .
+${IMAGE_BUILD_CMD} build --build-arg="LDFLAGS=${LDFLAGS}" --no-cache -t "${OPERATOR_FULL_IMAGE_NAME}" .

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,6 +17,7 @@ GO_LINT_IMG="${GO_LINT_IMG:-${GO_LINT_IMG_LOCATION}:${GO_LINT_IMG_TAG}}"
 DEFAULT_CSV_VERSION="4.13.0"
 CSV_VERSION="${CSV_VERSION:-${DEFAULT_CSV_VERSION}}"
 VERSION="${VERSION:-${CSV_VERSION}}"
+LDFLAGS="-X github.com/red-hat-storage/ocs-operator/v4/version.Version=${CSV_VERSION}"
 
 OUTDIR="build/_output"
 OUTDIR_BIN="build/_output/bin"

--- a/hack/generate-unified-csv.sh
+++ b/hack/generate-unified-csv.sh
@@ -5,7 +5,6 @@ set -e
 source hack/common.sh
 
 CSV_MERGER="tools/csv-merger/csv-merger"
-LDFLAGS="-X github.com/red-hat-storage/ocs-operator/version.Version=${CSV_VERSION}"
 
 (cd tools/csv-merger/ && go build -ldflags="${LDFLAGS}")
 

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -4,7 +4,5 @@ set -e
 
 source hack/common.sh
 
-LDFLAGS="-X github.com/red-hat-storage/ocs-operator/version.Version=${CSV_VERSION}"
-
 # shellcheck disable=SC2046
 go test -ldflags="${LDFLAGS}" -v -cover $(go list ./... | grep -v "functest")

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /workspace
 
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 go build -tags 'netgo osusergo' -o metrics-exporter metrics/main.go
+ARG LDFLAGS
+
+RUN GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o metrics-exporter metrics/main.go
 
 # Build stage 2
 


### PR DESCRIPTION
Recently we updated the moduele path for ocs to v4 so we need to update the ldflags accordingly. Also ldflags is now a variable in the hack/common.sh file so we need not define it in every script.