### PR TITLE
Fix shellcheck test

### DIFF
--- a/hack/build-operator-catalog.sh
+++ b/hack/build-operator-catalog.sh
@@ -10,12 +10,12 @@ echo
 echo "Did you push the bundle image? It must be pullable from '$IMAGE_REGISTRY'."
 echo "Run '${IMAGE_BUILD_CMD} push ${BUNDLE_FULL_IMAGE_NAME}'"
 echo
-${OPM} render --output=yaml ${BUNDLE_FULL_IMAGE_NAME} > catalog/ocs-bundle.yaml
+${OPM} render --output=yaml "${BUNDLE_FULL_IMAGE_NAME}" > catalog/ocs-bundle.yaml
 ${OPM} render --output=yaml ${NOOBAA_BUNDLE_FULL_IMAGE_NAME} > catalog/noobaa-bundle.yaml
 ${OPM} validate catalog
 ${OPM} generate dockerfile catalog
 
 mv catalog.Dockerfile Dockerfile.catalog
-${IMAGE_BUILD_CMD} build --no-cache -t ${FILE_BASED_CATALOG_FULL_IMAGE_NAME} -f Dockerfile.catalog .
+${IMAGE_BUILD_CMD} build --no-cache -t "${FILE_BASED_CATALOG_FULL_IMAGE_NAME}" -f Dockerfile.catalog .
 
 echo "Run '${IMAGE_BUILD_CMD} push ${FILE_BASED_CATALOG_FULL_IMAGE_NAME}' to push operator catalog image to image registry."

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -48,7 +48,7 @@ fi
 
 
 cd "${BASE_DIR}" || exit 2
-SCRIPTS=$(find . \( -path "*/vendor/*" -o -path "*/build/*" -o -path "*/_cache/*" \) -prune -o -name "*~" -prune -o -name "*.swp" -prune -o -type f -exec grep -l -e '^#!/bin/bash$' {} \;)
+SCRIPTS=$(find . \( -path "*/vendor/*" -o -path "*/build/*" -o -path "*/_cache/*" \) -prune -o -name "*~" -prune -o -name "*.swp" -prune -o -type f -exec grep -l -e '^#!/usr/bin/env bash$' {} \;)
 
 failed=0
 for script in ${SCRIPTS}; do


### PR DESCRIPTION
After https://github.com/red-hat-storage/ocs-operator/pull/1796 the shellcheck test was not functioning at all. The find command was not able to find any files as the hack files were updated with new bash version syntax & the find command was looking for files with the old syntax.