### PR TITLE
Fix KMSServerConnectionAlert stays even when KMS connection is re-established

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -177,6 +177,9 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 				return reconcile.Result{}, err
 			}
 			if kmsConfigMap != nil {
+				// reset the KMS connection's error field,
+				// it will be anyway set if there is an error
+				sc.Status.KMSServerConnection.KMSServerConnectionError = ""
 				if kmsConfigMap.Data["KMS_PROVIDER"] == "vault" {
 					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["VAULT_ADDR"]
 				}


### PR DESCRIPTION
KMSServerConnectionAlert is not revoked even when the KMS connection is re-established. The alert is dependent on StorageCluster object's 'Status.KMSServerConnection.KMSServerConnectionError' field which is populated when KMS is unreachable. But we fail to reset the field when connection is re-established.

Fix is to reset this field when connection is fine.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2192852