### PR TITLE
Move autoscale into DesiredState method for upgrade

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -78,10 +78,6 @@ func (obj *ocsNoobaaSystem) ensureCreated(r *StorageClusterReconciler, sc *ocsv1
 			Labels: nbv1.LabelsSpec{
 				"monitoring": getNooBaaMonitoringLabels(*sc),
 			},
-			Autoscaler: nbv1.AutoscalerSpec{
-				AutoscalerType:      nbv1.AutoscalerTypeHPAV2,
-				PrometheusNamespace: MonitoringNamespace,
-			},
 		},
 	}
 	err = controllerutil.SetControllerReference(sc, nb, r.Scheme)
@@ -168,6 +164,11 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 		// definition should hold a constant value. and should not be read from
 		// GetDaemonResources()
 		Resources: &endpointResources,
+	}
+	// Add autoscale spec for noobaa CR
+	nb.Spec.Autoscaler = nbv1.AutoscalerSpec{
+		AutoscalerType:      nbv1.AutoscalerTypeHPAV2,
+		PrometheusNamespace: MonitoringNamespace,
 	}
 
 	// Override with MCG options specified in the storage cluster spec


### PR DESCRIPTION
### Explain the changes
1. make sure noobaa autoscale configuration will added/updated to noobaa CR if noobaa CR missing the configuration


### Issues: Fixed #xxx / Gap #xxx
1. After upgrading to 4.14, MCG endpoint minCount and maxCount in ocs-storagecluster are ignored,
since 4.13 noobaa CR missing autoscaling configuration, after upgrade this configuration was still missing and this created issue

https://bugzilla.redhat.com/show_bug.cgi?id=2227607

### Testing Instructions:

1. install ODF in openshift 4.13 and upgrade it to 4.14
2. update noobaa endpoint maxCount to 2, wait for the second noobaa endpoint pod

- [ ] Doc added/updated
- [ ] Tests added
