### PR TITLE
Avoid wrong detection of disk type, such as HDD instead of SSD on vSAN

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -36,6 +36,7 @@ mon_osd_nearfull_ratio = .75
 mon_max_pg_per_osd = 600
 mon_pg_warn_max_object_skew = 0
 mon_data_avail_warn = 15
+bluestore_prefer_deferred_size_hdd = 0
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.8
 `


### PR DESCRIPTION
Resolves-https://bugzilla.redhat.com/show_bug.cgi?id=2218116

In some situations, such as vSphere VSAN, the drive media type is detected wrongly, for instance as HDD instead of SSD. For that, we have to force BlueStore to use settings designed for SSDs. We have 2 options for this.

1) bluestore_debug_enforce_settings = "ssd"
but it requires restart

OR

2) bluestore_prefer_deferred_size_hdd = 0
should work right away and no new deferred writes will be enqueued

We are choosing the second option as it does not require osd restart.