### PR TITLE
provider-server: enhance logging of corner case

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -105,7 +105,7 @@ func (s *OCSProviderServer) OnboardConsumer(ctx context.Context, req *pb.Onboard
 			return nil, status.Errorf(codes.Internal, "failed to create storageConsumer %q. %v", req.ConsumerName, err)
 		}
 
-		stoageConsumer, getErr := s.consumerManager.GetByName(ctx, req.ConsumerName)
+		storageConsumer, getErr := s.consumerManager.GetByName(ctx, req.ConsumerName)
 		if getErr != nil {
 			if kerrors.IsNotFound(getErr) && err == errTicketAlreadyExists {
 				msg := "Failed to get storageConsumer. Considering the presence of the Onboarding ticket," +
@@ -115,11 +115,11 @@ func (s *OCSProviderServer) OnboardConsumer(ctx context.Context, req *pb.Onboard
 			return nil, status.Errorf(codes.Internal, "Failed to get storageConsumer. %v", getErr)
 		}
 
-		if stoageConsumer.Spec.Enable {
+		if storageConsumer.Spec.Enable {
 			err = fmt.Errorf("storageconsumers.ocs.openshift.io %s already exists", req.ConsumerName)
 			return nil, status.Errorf(codes.AlreadyExists, "failed to create storageConsumer %q. %v", req.ConsumerName, err)
 		}
-		storageConsumerUUID = string(stoageConsumer.UID)
+		storageConsumerUUID = string(storageConsumer.UID)
 	}
 
 	return &pb.OnboardConsumerResponse{StorageConsumerUUID: storageConsumerUUID}, nil


### PR DESCRIPTION
Improve Logging for ocs-consumer Addon Re-installation with Same
Onboarding Ticket.

Previously, re-installing the ocs-consumer addon on a cluster using
the same onboarding ticket led to installation failures and left
the StorageCluster in an 'Error' phase with generic error
"Failed to get storageConsumer. storageconsumer not found".

The enhancement introduced in this commit addresses this issue by
incorporating more informative and accurate logging.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2088434

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>