### PR TITLE
Use optimized osd store for new clusters

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -45,7 +45,6 @@ type StorageClusterSpec struct {
 	// Resources follows the conventions of and is mapped to CephCluster.Spec.Resources
 	Resources          map[string]corev1.ResourceRequirements `json:"resources,omitempty"`
 	Encryption         EncryptionSpec                         `json:"encryption,omitempty"`
-	OSDStore           rookCephv1.OSDStore                    `json:"osdStore,omitempty"`
 	StorageDeviceSets  []StorageDeviceSet                     `json:"storageDeviceSets,omitempty"`
 	MonPVCTemplate     *corev1.PersistentVolumeClaim          `json:"monPVCTemplate,omitempty"`
 	MonDataDirHostPath string                                 `json:"monDataDirHostPath,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -728,7 +728,6 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		}
 	}
 	out.Encryption = in.Encryption
-	out.OSDStore = in.OSDStore
 	if in.StorageDeviceSets != nil {
 		in, out := &in.StorageDeviceSets, &out.StorageDeviceSets
 		*out = make([]StorageDeviceSet, len(*in))

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -1291,18 +1291,6 @@ spec:
                     nullable: true
                     type: object
                 type: object
-              osdStore:
-                description: OSDStore is the backend storage type used for creating
-                  the OSDs
-                properties:
-                  type:
-                    description: Type of backend storage to be used while creating
-                      OSDs. If empty, then bluestore will be used
-                    enum:
-                    - bluestore
-                    - bluestore-rdr
-                    type: string
-                type: object
               overprovisionControl:
                 description: OverprovisionControl specifies the allowed hard-limit
                   PVs overprovisioning relative to the effective usable storage capacity.

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -72,6 +72,8 @@ const (
 	networkProvider           = "multus"
 	publicNetworkSelectorKey  = "public"
 	clusterNetworkSelectorKey = "cluster"
+	// DisasterRecoveryTargetAnnotation signifies that the cluster is intended to be used for Disaster Recovery
+	DisasterRecoveryTargetAnnotation = "ocs.openshift.io/clusterIsDisasterRecoveryTarget"
 )
 
 const (
@@ -261,6 +263,9 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	// Record actual Ceph container image version before attempting update
 	sc.Status.Images.Ceph.ActualImage = found.Spec.CephVersion.Image
 
+	// Prevent removal of any RDR optimizations if they are already applied to the existing cluster spec.
+	cephCluster.Spec.Storage.Store = determineOSDStore(cephCluster.Spec.Storage.Store, found.Spec.Storage.Store)
+
 	// Add it to the list of RelatedObjects if found
 	objectRef, err := reference.GetReference(r.Scheme, found)
 	if err != nil {
@@ -405,6 +410,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 		MaxLogSize:  &maxLogSize,
 	}
 
+	osdStore := getOSDStoreConfig(sc)
+	if osdStore.Type != "" {
+		reqLogger.Info("osd store settings", osdStore)
+	}
+
 	cephCluster := &rookCephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateNameForCephCluster(sc),
@@ -434,6 +444,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 			},
 			Storage: rookCephv1.StorageScopeSpec{
 				StorageClassDeviceSets: newStorageClassDeviceSets(sc, serverVersion),
+				Store:                  osdStore,
 			},
 			Placement: rookCephv1.PlacementSpec{
 				"all":     getPlacement(sc, "all"),
@@ -1254,4 +1265,32 @@ func getIPFamilyConfig(c client.Client) (rookCephv1.IPFamilyType, bool, error) {
 	}
 
 	return rookCephv1.IPv4, false, nil
+}
+
+func getOSDStoreConfig(sc *ocsv1.StorageCluster) rookCephv1.OSDStore {
+	osdStore := rookCephv1.OSDStore{}
+	if !sc.Spec.ExternalStorage.Enable && optimizeDisasterRecovery(sc) {
+		osdStore.Type = string(rookCephv1.StoreTypeBlueStoreRDR)
+	}
+
+	return osdStore
+}
+
+// optimizeDisasterRecovery returns true if any RDR optimizations are required
+func optimizeDisasterRecovery(sc *ocsv1.StorageCluster) bool {
+	if annotation, found := sc.GetAnnotations()[DisasterRecoveryTargetAnnotation]; found {
+		if annotation == "true" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func determineOSDStore(newOSDStore, existingOSDStore rookCephv1.OSDStore) rookCephv1.OSDStore {
+	if existingOSDStore.Type == string(rookCephv1.StoreTypeBlueStoreRDR) {
+		return existingOSDStore
+	}
+
+	return newOSDStore
 }

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -434,7 +434,6 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 			},
 			Storage: rookCephv1.StorageScopeSpec{
 				StorageClassDeviceSets: newStorageClassDeviceSets(sc, serverVersion),
-				Store:                  sc.Spec.OSDStore,
 			},
 			Placement: rookCephv1.PlacementSpec{
 				"all":     getPlacement(sc, "all"),

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -75,9 +75,6 @@ var mockStorageCluster = &api.StorageCluster{
 		LogCollector: &rookCephv1.LogCollectorSpec{
 			Enabled: false,
 		},
-		OSDStore: rookCephv1.OSDStore{
-			Type: "bluestore",
-		},
 	},
 }
 

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -1291,18 +1291,6 @@ spec:
                     nullable: true
                     type: object
                 type: object
-              osdStore:
-                description: OSDStore is the backend storage type used for creating
-                  the OSDs
-                properties:
-                  type:
-                    description: Type of backend storage to be used while creating
-                      OSDs. If empty, then bluestore will be used
-                    enum:
-                    - bluestore
-                    - bluestore-rdr
-                    type: string
-                type: object
               overprovisionControl:
                 description: OverprovisionControl specifies the allowed hard-limit
                   PVs overprovisioning relative to the effective usable storage capacity.

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -1290,18 +1290,6 @@ spec:
                     nullable: true
                     type: object
                 type: object
-              osdStore:
-                description: OSDStore is the backend storage type used for creating
-                  the OSDs
-                properties:
-                  type:
-                    description: Type of backend storage to be used while creating
-                      OSDs. If empty, then bluestore will be used
-                    enum:
-                    - bluestore
-                    - bluestore-rdr
-                    type: string
-                type: object
               overprovisionControl:
                 description: OverprovisionControl specifies the allowed hard-limit
                   PVs overprovisioning relative to the effective usable storage capacity.


### PR DESCRIPTION
If `ocs.openshift.io/clusterIsDisasterRecoveryTarget: true` annotation is available in the StorageCluster, then create `cephCluster` using `bluestore-rdr` backend store. 

If storageCluster is some how updated to remove this annotation, then ensure that
`bluestore-rdr` store type is not overridden

This PR also reverts the changes that exposed the OSD store in the storageCluster spec, that is #2116. 