### PR TITLE
Incorporate the CSI_TOPOLOGY_DOMAIN_LABELS key into the configmap

### DIFF
--- a/controllers/storagecluster/ocs_operator_config.go
+++ b/controllers/storagecluster/ocs_operator_config.go
@@ -68,7 +68,7 @@ func (r *StorageClusterReconciler) ensureOCSOperatorConfig(sc *ocsv1.StorageClus
 		if cm.Data[enableTopologyKey] != enableTopologyVal {
 			cm.Data[enableTopologyKey] = enableTopologyVal
 		}
-		if cm.Data[topologyDomainLabelsKey] != topologyDomainLabelsVal {
+		if cm.Data[topologyDomainLabelsKey] != topologyDomainLabelsVal || topologyDomainLabelsVal == "" {
 			cm.Data[topologyDomainLabelsKey] = topologyDomainLabelsVal
 		}
 		return ctrl.SetControllerReference(sc, cm, r.Scheme)


### PR DESCRIPTION
Presently, the value for CSI_TOPOLOGY_DOMAIN_LABELS key is derived from the sc.Status.FailureDomainKey, which remains empty in the case of a standalone mcg setup. The comparison logic for updating the configmap relies on the value we intend to write versus the existing value. However, as both values are empty strings, the system identifies them as matching and thus refrains from updating the configmap. Despite this, it is crucial to update the configmap to include the key, even with an empty value, to ensure its presence.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2232344