### PR TITLE
When NFS is enabled on the storagecluster pass ROOK_CSI_ENABLE_NFS: true

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -238,6 +238,7 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 		cephFSKernelMountOptionsKey = "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS"
 		enableTopologyKey           = "CSI_ENABLE_TOPOLOGY"
 		topologyDomainLabelsKey     = "CSI_TOPOLOGY_DOMAIN_LABELS"
+		enableNFSKey                = "ROOK_CSI_ENABLE_NFS"
 	)
 	ocsOperatorConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -251,6 +252,7 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 			cephFSKernelMountOptionsKey: "ms_mode=prefer-crc",
 			enableTopologyKey:           "false",
 			topologyDomainLabelsKey:     "",
+			enableNFSKey:                "false",
 		},
 	}
 	err := r.Client.Create(r.ctx, ocsOperatorConfig)

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -3137,6 +3137,11 @@ spec:
                     configMapKeyRef:
                       key: CSI_TOPOLOGY_DOMAIN_LABELS
                       name: ocs-operator-config
+                - name: ROOK_CSI_ENABLE_NFS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ROOK_CSI_ENABLE_NFS
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -306,6 +306,17 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				},
 			},
 			{
+				Name: "ROOK_CSI_ENABLE_NFS",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "ROOK_CSI_ENABLE_NFS",
+					},
+				},
+			},
+			{
 				Name: "CSI_PROVISIONER_TOLERATIONS",
 				Value: `
 - key: node.ocs.openshift.io/storage


### PR DESCRIPTION
Earlier when enabling NFS the key needed to be passed manually to
rook via patching the rook-ceph-operator-config cm. Now the key is
passed automatically via env variable to the rook pod.

bz-https://bugzilla.redhat.com/show_bug.cgi?id=2233410