### PR TITLE
support using bluestore-rdr for RDR customers

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -269,6 +269,12 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	// Prevent removal of any RDR optimizations if they are already applied to the existing cluster spec.
 	cephCluster.Spec.Storage.Store = determineOSDStore(cephCluster.Spec.Storage.Store, found.Spec.Storage.Store)
 
+	// Use bluestore-rdr if mirrioring is enabled
+	if sc.Spec.Mirroring.Enabled && !sc.Spec.ExternalStorage.Enable {
+		cephCluster.Spec.Storage.Store.Type = string(rookCephv1.StoreTypeBlueStoreRDR)
+		cephCluster.Spec.Storage.Store.UpdateStore = "yes-really-update-store"
+	}
+
 	// Add it to the list of RelatedObjects if found
 	objectRef, err := reference.GetReference(r.Scheme, found)
 	if err != nil {


### PR DESCRIPTION
If mirroring is enabled, then use bluestore-rdr store and allow migration of OSDs running on bluestore to bluestore-rdr

We always enable `bluestore-rdr` and `yes-really-update-store`. Rook takes care of migrating the OSDs and pauses migration if cluster is unhealthy. We don't need to remove `yes-really-update-store` flag, because if all OSDs are already migrated, then it will be no-op. 