### PR TITLE
Use client variable to make api calls to k8s cluster

### DIFF
--- a/controllers/namespace/namespace_controller_test.go
+++ b/controllers/namespace/namespace_controller_test.go
@@ -69,7 +69,7 @@ func TestNamespaceAnnotated(t *testing.T) {
 	_, err = reconciler.Reconcile(ctx, request)
 	assert.NoError(t, err, "failed to reconcile")
 	nsList := &corev1.NamespaceList{}
-	err = reconciler.List(ctx, nsList)
+	err = reconciler.Client.List(ctx, nsList)
 	assert.NoError(t, err, "failed to list namespaces")
 	for _, testNs := range nsList.Items {
 		assert.Equal(t, testNs.Name, "openshift-storage-test")

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -134,7 +134,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			// Get the StorageCluster objects
 			scList := &ocsv1.StorageClusterList{}
-			err := r.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
+			err := r.Client.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
 			if err != nil {
 				r.Log.Error(err, "Unable to list StorageCluster objects")
 				return []reconcile.Request{}


### PR DESCRIPTION
Use the client.Client property of the reconciler object to make client calls instead of using the reconciler object directly.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2231076