### PR TITLE
Bug 2237370:[release-4.12] external: update objectstore with hostname if rgw-endpoint is hostname

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -190,6 +190,9 @@ func newExternalGatewaySpec(rgwEndpoint string, reqLogger logr.Logger, tlsEnable
 		return nil, err
 	}
 	gateWay.ExternalRgwEndpoints = []corev1.EndpointAddress{{IP: hostIP}}
+	if net.ParseIP(hostIP) == nil {
+		gateWay.ExternalRgwEndpoints = []corev1.EndpointAddress{{Hostname: hostIP}}
+	}
 	var portInt64 int64
 	if portInt64, err = strconv.ParseInt(portStr, 10, 32); err != nil {
 		reqLogger.Error(err,

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -405,8 +405,8 @@ func assertCephObjectStore(t *testing.T, reconciler StorageClusterReconciler, re
 		}
 		// length of 'ExternalRgwEndpoints' should be at least 1
 		assert.True(t, len(cObjS.Spec.Gateway.ExternalRgwEndpoints) > 0, true)
-		// and the first IP should be that of the host we passed from 'ceph-rgw' resource
-		assert.Equal(t, hostFound, cObjS.Spec.Gateway.ExternalRgwEndpoints[0].IP)
+		// and the first IP/Hostname should be that of the host we passed from 'ceph-rgw' resource
+		assert.Equal(t, hostFound, cObjS.Spec.Gateway.ExternalRgwEndpoints[0].Hostname)
 	}
 }
 


### PR DESCRIPTION
fqdn is supported in with objectstore,
If the rgw-endoint is passing the fqdn
Gateway should be updated with hostname or fqdn name


(cherry picked from commit 4064e9f6f431e9976ca28b7fb2b313fedda1679a)