### PR TITLE
[DNM] Revert changes to migrate OSDs to bluestore-rdr

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -269,12 +269,6 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	// Prevent removal of any RDR optimizations if they are already applied to the existing cluster spec.
 	cephCluster.Spec.Storage.Store = determineOSDStore(cephCluster.Spec.Storage.Store, found.Spec.Storage.Store)
 
-	// Use bluestore-rdr if mirrioring is enabled
-	if sc.Spec.Mirroring.Enabled && !sc.Spec.ExternalStorage.Enable {
-		cephCluster.Spec.Storage.Store.Type = string(rookCephv1.StoreTypeBlueStoreRDR)
-		cephCluster.Spec.Storage.Store.UpdateStore = "yes-really-update-store"
-	}
-
 	// Add it to the list of RelatedObjects if found
 	objectRef, err := reference.GetReference(r.Scheme, found)
 	if err != nil {


### PR DESCRIPTION
This PR reverts the changes done in PR #2162 to migrate existing bluestore OSDs to use bluestore-rdr
Note: The plan is to merge this before the 4.14 RC.  Refer [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2234735#c7)