### PR TITLE
Bug 2234664:[release-4.13] When NFS is enabled on the storagecluster pass ROOK_CSI_ENABLE_NFS: true

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -237,6 +237,7 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 		clusterNameKey              = "CSI_CLUSTER_NAME"
 		enableReadAffinityKey       = "CSI_ENABLE_READ_AFFINITY"
 		cephFSKernelMountOptionsKey = "CSI_CEPHFS_KERNEL_MOUNT_OPTIONS"
+		enableNFSKey                = "ROOK_CSI_ENABLE_NFS"
 	)
 	ocsOperatorConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -248,6 +249,7 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 			clusterNameKey:              "",
 			enableReadAffinityKey:       "true",
 			cephFSKernelMountOptionsKey: "ms_mode=prefer-crc",
+			enableNFSKey:                "false",
 		},
 	}
 	err := r.Client.Create(r.ctx, ocsOperatorConfig)

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2996,6 +2996,11 @@ spec:
                     configMapKeyRef:
                       key: CSI_CEPHFS_KERNEL_MOUNT_OPTIONS
                       name: ocs-operator-config
+                - name: ROOK_CSI_ENABLE_NFS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ROOK_CSI_ENABLE_NFS
+                      name: ocs-operator-config
                 - name: CSI_PROVISIONER_TOLERATIONS
                   value: |2-
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -271,6 +271,17 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				},
 			},
 			{
+				Name: "ROOK_CSI_ENABLE_NFS",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "ocs-operator-config",
+						},
+						Key: "ROOK_CSI_ENABLE_NFS",
+					},
+				},
+			},
+			{
 				Name: "CSI_PROVISIONER_TOLERATIONS",
 				Value: `
 - key: node.ocs.openshift.io/storage


### PR DESCRIPTION
This is a manual backport for https://github.com/red-hat-storage/ocs-operator/pull/2157.
