### PR TITLE
Correcting the job names in prometheus metrics

### DIFF
--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -11,10 +11,10 @@ spec:
   - name: ceph.rules
     rules:
     - expr: |
-        kube_node_status_condition{condition="Ready",job="kube-state-metrics",status="true"} * on (node) group_right() max by (node, namespace) (label_replace(ceph_disk_occupation{job="rook-ceph-exporter"},"node","$1","exported_instance","(.*)"))
+        kube_node_status_condition{condition="Ready",job="kube-state-metrics",status="true"} * on (node) group_right() max by (node, namespace) (label_replace(ceph_disk_occupation{job="rook-ceph-mgr"},"node","$1","exported_instance","(.*)"))
       record: cluster:ceph_node_down:join_kube
     - expr: |
-        avg by (namespace) (topk by (ceph_daemon, namespace) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-exporter"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) * on(instance, device) group_right(ceph_daemon, namespace) topk by (instance, device, namespace) (1,(irate(node_disk_read_time_seconds_total[1m]) + irate(node_disk_write_time_seconds_total[1m]) / (clamp_min(irate(node_disk_reads_completed_total[1m]), 1) + irate(node_disk_writes_completed_total[1m])))))
+        avg by (namespace) (topk by (ceph_daemon, namespace) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) * on(instance, device) group_right(ceph_daemon, namespace) topk by (instance, device, namespace) (1,(irate(node_disk_read_time_seconds_total[1m]) + irate(node_disk_write_time_seconds_total[1m]) / (clamp_min(irate(node_disk_reads_completed_total[1m]), 1) + irate(node_disk_writes_completed_total[1m])))))
       record: cluster:ceph_disk_latency:join_ceph_node_disk_irate1m
   - name: telemeter.rules
     rules:
@@ -25,10 +25,10 @@ spec:
         count by (namespace) (kube_persistentvolume_info * on (storageclass) group_left(provisioner, namespace) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(.*topolvm.cybozu.com)"})
       record: job:odf_system_pvs:count
     - expr: |
-        sum by (namespace) (ceph_pool_rd{job="rook-ceph-exporter"} + on(pool_id, namespace) ceph_pool_wr)
+        sum by (namespace) (ceph_pool_rd{job="rook-ceph-mgr"} + on(pool_id, namespace) ceph_pool_wr)
       record: job:ceph_pools_iops:total
     - expr: |
-        sum by (namespace) (ceph_pool_rd_bytes{job="rook-ceph-exporter"} + on(pool_id, namespace) ceph_pool_wr_bytes)
+        sum by (namespace) (ceph_pool_rd_bytes{job="rook-ceph-mgr"} + on(pool_id, namespace) ceph_pool_wr_bytes)
       record: job:ceph_pools_iops_bytes:total
     - expr: |
         count by (namespace) (count by (ceph_version, namespace) (ceph_mon_metadata{job="rook-ceph-mgr"} or ceph_osd_metadata{job="rook-ceph-mgr"} or ceph_rgw_metadata{job="rook-ceph-mgr"} or ceph_mds_metadata{job="rook-ceph-mgr"} or ceph_mgr_metadata{job="rook-ceph-mgr"}))
@@ -79,7 +79,7 @@ spec:
         severity_level: error
         storage_type: ceph
       expr: |
-        count by (namespace) (ceph_mon_quorum_status{job="rook-ceph-exporter"} == 1) <= (floor(count by (namespace) (ceph_mon_metadata{job="rook-ceph-mgr"}) / 2) + 1)
+        count by (namespace) (ceph_mon_quorum_status{job="rook-ceph-mgr"} == 1) <= (floor(count by (namespace) (ceph_mon_metadata{job="rook-ceph-mgr"}) / 2) + 1)
       for: 15m
       labels:
         severity: critical
@@ -160,7 +160,7 @@ spec:
         severity_level: error
         storage_type: ceph
       expr: |
-        label_replace((ceph_osd_in == 1 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon, namespace) group_left(host, device) label_replace(ceph_disk_occupation{job="rook-ceph-exporter"},"host","$1","exported_instance","(.*)")
+        label_replace((ceph_osd_in == 1 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon, namespace) group_left(host, device) label_replace(ceph_disk_occupation{job="rook-ceph-mgr"},"host","$1","exported_instance","(.*)")
       for: 15m
       labels:
         severity: critical
@@ -171,7 +171,7 @@ spec:
         severity_level: error
         storage_type: ceph
       expr: |
-        label_replace((ceph_osd_in == 0 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon, namespace) group_left(host, device) label_replace(ceph_disk_occupation{job="rook-ceph-exporter"},"host","$1","exported_instance","(.*)")
+        label_replace((ceph_osd_in == 0 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon, namespace) group_left(host, device) label_replace(ceph_disk_occupation{job="rook-ceph-mgr"},"host","$1","exported_instance","(.*)")
       for: 1m
       labels:
         severity: critical
@@ -241,7 +241,7 @@ spec:
         severity_level: error
         storage_type: ceph
       expr: |
-        ceph_health_status{job="rook-ceph-exporter"} > 1
+        ceph_health_status{job="rook-ceph-mgr"} > 1
       for: 10m
       labels:
         severity: critical
@@ -252,7 +252,7 @@ spec:
         severity_level: warning
         storage_type: ceph
       expr: |
-        ceph_health_status{job="rook-ceph-exporter"} == 1
+        ceph_health_status{job="rook-ceph-mgr"} == 1
       for: 15m
       labels:
         severity: warning

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -8,7 +8,7 @@
             record: 'cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m',
             expr: |||
               sum by (namespace, managedBy) (
-                  topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-exporter"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
+                  topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
                 * on(instance, device) group_left topk by (instance,device) 
                   (1,
                     (
@@ -22,7 +22,7 @@
             record: 'cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m',
             expr: |||
               sum by (namespace, managedBy) (
-                  topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-exporter"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
+                  topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
                 * on(instance, device) group_left topk by (instance,device) 
                   (1,
                     (
@@ -92,7 +92,7 @@
             expr: |||
               sum by (namespace, managedBy, job, service)
               (
-                topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-exporter"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
+                topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
                 * on(instance, device) group_left() topk by (instance,device) 
                 (1,
                   (


### PR DESCRIPTION
Earlier we decided that a few metrics will be exposed through job, 'rook-ceph-exporter'. But now the implementation has changed and 'ceph_mon_num_elections' will be the only metric produced by the job. Rest of the metrics will still be coming from 'rook-ceph-mgr' job itself.