### PR TITLE
Fix typo in metrics code comment

### DIFF
--- a/metrics/internal/collectors/registry.go
+++ b/metrics/internal/collectors/registry.go
@@ -87,7 +87,7 @@ func enableCephBlocklistMirrorStore(opts *options.Options) {
 	go reflector.Run(opts.StopCh)
 }
 
-// RegisterPersistentVolumeAttributesCollector registers PV attribute colletor to registry
+// RegisterPersistentVolumeAttributesCollector registers PV attribute collector to registry
 func RegisterPersistentVolumeAttributesCollector(registry *prometheus.Registry, opts *options.Options) {
 	if !pvStoreEnabled {
 		enablePVStore(opts)


### PR DESCRIPTION
Fixed typo in word `collector` under metrics component and make the code-spell-check CI stable