### PR TITLE
Add new field 'monCount' in storagecluster CR

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -171,6 +171,8 @@ type ManagedResourcesSpec struct {
 // ManageCephCluster defines how to reconcile the Ceph cluster definition
 type ManageCephCluster struct {
 	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
+	// +kubebuilder:validation:Enum=3;5
+	MonCount int `json:"monCount,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -655,6 +655,11 @@ spec:
                     description: ManageCephCluster defines how to reconcile the Ceph
                       cluster definition
                     properties:
+                      monCount:
+                        enum:
+                        - 3
+                        - 5
+                        type: integer
                       reconcileStrategy:
                         type: string
                     type: object

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -435,7 +435,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				Image:            cephImage,
 				AllowUnsupported: allowUnsupportedCephVersion(),
 			},
-			Mon:             generateMonSpec(sc, nodeCount),
+			Mon:             generateMonSpec(sc),
 			Mgr:             generateMgrSpec(sc),
 			DataDirHostPath: "/var/lib/rook",
 			DisruptionManagement: rookCephv1.DisruptionManagementSpec{
@@ -696,7 +696,7 @@ func getMgrCount(arbiterMode bool) int {
 	return defaults.DefaultMgrCount
 }
 
-func getMonCount(nodeCount int, arbiter bool) int {
+func getMonCount(monCount int, arbiter bool) int {
 	// return static value if overridden
 	override := os.Getenv(monCountOverrideEnvVar)
 	if override != "" {
@@ -711,6 +711,11 @@ func getMonCount(nodeCount int, arbiter bool) int {
 	if arbiter {
 		return defaults.ArbiterModeMonCount
 	}
+
+	if monCount != 0 {
+		return monCount
+	}
+
 	return defaults.DefaultMonCount
 }
 
@@ -1050,17 +1055,17 @@ func generateStretchClusterSpec(sc *ocsv1.StorageCluster) *rookCephv1.StretchClu
 	return &stretchClusterSpec
 }
 
-func generateMonSpec(sc *ocsv1.StorageCluster, nodeCount int) rookCephv1.MonSpec {
+func generateMonSpec(sc *ocsv1.StorageCluster) rookCephv1.MonSpec {
 	if arbiterEnabled(sc) {
 		return rookCephv1.MonSpec{
-			Count:                getMonCount(nodeCount, true),
+			Count:                getMonCount(sc.Spec.ManagedResources.CephCluster.MonCount, true),
 			AllowMultiplePerNode: false,
 			StretchCluster:       generateStretchClusterSpec(sc),
 		}
 	}
 
 	return rookCephv1.MonSpec{
-		Count:                getMonCount(nodeCount, false),
+		Count:                getMonCount(sc.Spec.ManagedResources.CephCluster.MonCount, false),
 		AllowMultiplePerNode: statusutil.IsSingleNodeDeployment(),
 	}
 }

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1054,7 +1054,7 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 func TestMonCountChange(t *testing.T) {
 	for nodeCount := 0; nodeCount <= 10; nodeCount++ {
 		monCountExpected := defaults.DefaultMonCount
-		monCountActual := getMonCount(nodeCount, false)
+		monCountActual := getMonCount(0, false)
 		assert.Equal(t, monCountExpected, monCountActual)
 	}
 }

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -655,6 +655,11 @@ spec:
                     description: ManageCephCluster defines how to reconcile the Ceph
                       cluster definition
                     properties:
+                      monCount:
+                        enum:
+                        - 3
+                        - 5
+                        type: integer
                       reconcileStrategy:
                         type: string
                     type: object

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -654,6 +654,11 @@ spec:
                     description: ManageCephCluster defines how to reconcile the Ceph
                       cluster definition
                     properties:
+                      monCount:
+                        enum:
+                        - 3
+                        - 5
+                        type: integer
                       reconcileStrategy:
                         type: string
                     type: object


### PR DESCRIPTION
Added a new field 'monCount' in storagecluster CR that takes in the custom mon count from user i.e, either 3 or 5. Also, updated the `getMonCount` function definition to remove the unused `nodeCount` param.