### PR TITLE
Fix Provisioner Namespace Configuration

### DIFF
--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -2,9 +2,11 @@ package storagecluster
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/v4/api/v1"
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 )
 
@@ -110,7 +112,7 @@ func generateNameForCephNetworkFilesystemSC(initData *ocsv1.StorageCluster) stri
 }
 
 func generateNameForNFSCSIProvisioner(initData *ocsv1.StorageCluster) string {
-	return fmt.Sprintf("%s.nfs.csi.ceph.com", initData.Namespace)
+	return fmt.Sprintf("%s.nfs.csi.ceph.com", os.Getenv(util.OperatorNamespaceEnvVar))
 }
 
 // generateNameForSnapshotClass function generates 'SnapshotClass' name.

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -227,7 +228,7 @@ func newCephFilesystemStorageClassConfiguration(initData *ocsv1.StorageCluster) 
 					"description": "Provides RWO and RWX Filesystem volumes",
 				},
 			},
-			Provisioner:   fmt.Sprintf("%s.cephfs.csi.ceph.com", initData.Namespace),
+			Provisioner:   fmt.Sprintf("%s.cephfs.csi.ceph.com", os.Getenv(util.OperatorNamespaceEnvVar)),
 			ReclaimPolicy: &persistentVolumeReclaimDelete,
 			// AllowVolumeExpansion is set to true to enable expansion of OCS backed Volumes
 			AllowVolumeExpansion: &allowVolumeExpansion,
@@ -261,7 +262,7 @@ func newCephBlockPoolStorageClassConfiguration(initData *ocsv1.StorageCluster) S
 					"description": "Provides RWO Filesystem volumes, and RWO and RWX Block volumes",
 				},
 			},
-			Provisioner:   fmt.Sprintf("%s.rbd.csi.ceph.com", initData.Namespace),
+			Provisioner:   fmt.Sprintf("%s.rbd.csi.ceph.com", os.Getenv(util.OperatorNamespaceEnvVar)),
 			ReclaimPolicy: &persistentVolumeReclaimDelete,
 			// AllowVolumeExpansion is set to true to enable expansion of OCS backed Volumes
 			AllowVolumeExpansion: &allowVolumeExpansion,
@@ -310,7 +311,7 @@ func newNonResilientCephBlockPoolStorageClassConfiguration(initData *ocsv1.Stora
 					"description": "Ceph Non Resilient Pools : Provides RWO Filesystem volumes, and RWO and RWX Block volumes",
 				},
 			},
-			Provisioner:       fmt.Sprintf("%s.rbd.csi.ceph.com", initData.Namespace),
+			Provisioner:       fmt.Sprintf("%s.rbd.csi.ceph.com", os.Getenv(util.OperatorNamespaceEnvVar)),
 			ReclaimPolicy:     &persistentVolumeReclaimDelete,
 			VolumeBindingMode: &volumeBindingWaitForFirstConsumer,
 			// AllowVolumeExpansion is set to true to enable expansion of OCS backed Volumes
@@ -392,7 +393,7 @@ func newCephOBCStorageClassConfiguration(initData *ocsv1.StorageCluster) Storage
 					"description": "Provides Object Bucket Claims (OBCs)",
 				},
 			},
-			Provisioner:   fmt.Sprintf("%s.ceph.rook.io/bucket", initData.Namespace),
+			Provisioner:   fmt.Sprintf("%s.ceph.rook.io/bucket", os.Getenv(util.OperatorNamespaceEnvVar)),
 			ReclaimPolicy: &reclaimPolicy,
 			Parameters: map[string]string{
 				"objectStoreNamespace": initData.Namespace,


### PR DESCRIPTION
Previously the storage cluster was deployed within the operator namespace, which was matching the Provisioner namespace and working well. However with the introduction of multiple StorageClusters, using the storagecluster namespace as provisioner namespace is no longer viable. Instead we should use operator namespace as that is the namespace where provisoners are deployed.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>