### PR TITLE
Bug 2241872: Fix for metrics exporter pod going in crashbacklloop

### DIFF
--- a/metrics/internal/collectors/storageconsumer.go
+++ b/metrics/internal/collectors/storageconsumer.go
@@ -31,7 +31,7 @@ func NewStorageConsumerCollector(opts *options.Options) *StorageConsumerCollecto
 		StorageConsumerMetadata: prometheus.NewDesc(
 			prometheus.BuildFQName("ocs", "storage_consumer", "metadata"),
 			`Attributes of OCS Storage Consumers`,
-			[]string{"storage_consumer_name", "capacity", "state", "granted_capacity"},
+			[]string{"storage_consumer_name", "state"},
 			nil,
 		),
 		Informer: sharedIndexInformer,


### PR DESCRIPTION
After removing the capacity field from StorageConsumer CR, the dependency on that field in the metrics exporter was apparently not removed.  