### PR TITLE
Bug 2244426: check for existing CephBlockPool for given consumer/profile in StorageClassRequest

### DIFF
--- a/api/v1/storageprofile_types.go
+++ b/api/v1/storageprofile_types.go
@@ -17,6 +17,11 @@ limitations under the License.
 package v1
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -91,4 +96,14 @@ const (
 
 func init() {
 	SchemeBuilder.Register(&StorageProfile{}, &StorageProfileList{})
+}
+
+func (sp *StorageProfile) GetSpecHash() string {
+	specJSON, err := json.Marshal(sp.Spec)
+	if err != nil {
+		errStr := fmt.Errorf("failed to marshal StorageProfile.Spec for %s", sp.Name)
+		panic(errStr)
+	}
+	specHash := md5.Sum(specJSON)
+	return hex.EncodeToString(specHash[:])
 }

--- a/config/samples/ocs_v1_storageprofile.yaml
+++ b/config/samples/ocs_v1_storageprofile.yaml
@@ -1,12 +1,6 @@
 apiVersion: ocs.openshift.io/v1
 kind: StorageProfile
 metadata:
-  labels:
-    app.kubernetes.io/name: storageprofile
-    app.kubernetes.io/instance: storageprofile-sample
-    app.kubernetes.io/part-of: ocs-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: ocs-operator
-  name: storageprofile-sample
+  name: medium
 spec:
-  # TODO(user): Add fields here
+  deviceClass: ssd

--- a/controllers/storageclassrequest/storageclassrequest_controller.go
+++ b/controllers/storageclassrequest/storageclassrequest_controller.go
@@ -321,6 +321,7 @@ func (r *StorageClassRequestReconciler) reconcileCephBlockPool(storageProfile *v
 		}
 
 		addLabel(r.cephBlockPool, controllers.StorageConsumerNameLabel, r.storageConsumer.Name)
+		addLabel(r.cephBlockPool, controllers.StorageProfileSpecLabel, storageProfile.GetSpecHash())
 
 		r.cephBlockPool.Spec = rookCephv1.NamedBlockPoolSpec{
 			PoolSpec: rookCephv1.PoolSpec{
@@ -389,6 +390,7 @@ func (r *StorageClassRequestReconciler) reconcileCephFilesystemSubVolumeGroup(st
 		}
 
 		addLabel(r.cephFilesystemSubVolumeGroup, controllers.StorageConsumerNameLabel, r.storageConsumer.Name)
+		addLabel(r.cephFilesystemSubVolumeGroup, controllers.StorageProfileSpecLabel, storageProfile.GetSpecHash())
 		// This label is required to set the dataPool on the CephFS
 		// storageclass so that each PVC created from CephFS storageclass can
 		// use correct dataPool backed by deviceclass.

--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -44,6 +44,7 @@ const (
 	StorageConsumerAnnotation     = "ocs.openshift.io.storageconsumer"
 	StorageRequestAnnotation      = "ocs.openshift.io.storagerequest"
 	StorageCephUserTypeAnnotation = "ocs.openshift.io.cephusertype"
+	StorageProfileSpecLabel       = "ocs.openshift.io/storageprofile-spec"
 	ConsumerUUIDLabel             = "ocs.openshift.io/storageconsumer-uuid"
 	StorageConsumerNameLabel      = "ocs.openshift.io/storageconsumer-name"
 )

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -63,16 +63,11 @@ metadata:
           "apiVersion": "ocs.openshift.io/v1",
           "kind": "StorageProfile",
           "metadata": {
-            "labels": {
-              "app.kubernetes.io/created-by": "ocs-operator",
-              "app.kubernetes.io/instance": "storageprofile-sample",
-              "app.kubernetes.io/managed-by": "kustomize",
-              "app.kubernetes.io/name": "storageprofile",
-              "app.kubernetes.io/part-of": "ocs-operator"
-            },
-            "name": "storageprofile-sample"
+            "name": "medium"
           },
-          "spec": null
+          "spec": {
+            "deviceClass": "ssd"
+          }
         },
         {
           "apiVersion": "ocs.openshift.io/v1alpha1",


### PR DESCRIPTION
Prior to this, a new CephBlockPool would be created for every new StorageClassRequest. This change allows the reconciler to use an existing CephBlockPool if the StorageClassRequest is from the same StorageConsumer with the same StorageProfile.

Addresses [BZ 2244426](https://bugzilla.redhat.com/show_bug.cgi?id=2244426).

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>