### PR TITLE
monitoring: runbooks documentation files

### DIFF
--- a/metrics/mixin/README.md
+++ b/metrics/mixin/README.md
@@ -25,7 +25,7 @@ The scope of this directory is to provide OCS specific Prometheus rule files usi
 * Promtool
   1. [Download](https://golang.org/dl/) Go (>=1.11) and [install](https://golang.org/doc/install) it on your system.
   2. Setup the [GOPATH](http://www.g33knotes.org/2014/07/60-second-count-down-to-go.html) environment.
-  3. Run `$ go get -d github.com/prometheus/prometheus/cmd/promtool`  
+  3. Run `$ go get -d github.com/prometheus/prometheus/cmd/promtool`
 
 
 ## How to use?
@@ -37,13 +37,13 @@ The scope of this directory is to provide OCS specific Prometheus rule files usi
 ### To add new alerts/rules:
 
 * Add new alerts in 'metrics/mixin/alerts' directory in libsonnet format. Learn about Jsonnet and Libsonnet from https://jsonnet.org/.
-  * Example: 
+  * Example:
     * To create a new alert for notifying if OCS request are above 5 per second in last one minute
       * Create the alert expression using the metric exposed by the ocs exporter
         * Metric exposed : **ocs_exporter_requests_total**
         * Alert expression : **rate(ocs_exporter_requests_total[1m]) > 5**
     * Create a file under metrics/mixin/alerts directory called requests.libsonnet and add the alert in the libsonnet following format.
-      * 
+      *
       ```
       {
          prometheusAlerts+:: {
@@ -66,6 +66,7 @@ The scope of this directory is to provide OCS specific Prometheus rule files usi
                      clusterRequestsAlertTime,
                      storage_type: $._config.storageType,
                      severity_level: 'error',
+                     runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ClusterRequests.md
                   },
                },
                ],
@@ -80,6 +81,9 @@ The scope of this directory is to provide OCS specific Prometheus rule files usi
     * Test the alert/rule generation by using targets in metrics/mixin/Makefile. Eg:  `make prometheus_alert_rules.yaml`. This is **optional** and can be used to isolate issues.
 
 * Generate deployment manifests by using the OCS-operator Makefile target **gen-latest-prometheus-rules-yamls** : ` make gen-latest-prometheus-rules-yamls `. The generated manifests will be written at metrics/deploy/**prometheus-ocs-rules.yaml**(Internal mode) and metrics/deploy/**prometheus-ocs-rules-external.yaml**(External mode)
+
+* Remember to add a documentation file in the [runbooks OCS folder](https://github.com/openshift/runbooks/tree/master/alerts/openshift-container-storage-operator) with information about the meaning, diagnosis and troubleshooting of the new alert. The new documentation file must follow the same structure other alarms.
+The `runbook_url` label in the alert annotations section must point to this new file.
 
 ## Background
 * [Prometheus Monitoring Mixin design doc](https://docs.google.com/document/d/1A9xvzwqnFVSOZ5fD3blKODXfsat5fg6ZhnKu9LK3lB4/edit#)


### PR DESCRIPTION
Include information about how to add the alert documentation files in runbook repo and how to link the alert and the runbook file