### PR TITLE
Fix for metrics exporter pod going in crashbacklloop

### DIFF
--- a/metrics/internal/collectors/registry.go
+++ b/metrics/internal/collectors/registry.go
@@ -87,7 +87,7 @@ func enableCephBlocklistMirrorStore(opts *options.Options) {
 	go reflector.Run(opts.StopCh)
 }
 
-// RegisterPersistentVolumeAttributesCollector registers PV attribute colletor to registry
+// RegisterPersistentVolumeAttributesCollector registers PV attribute collector to registry
 func RegisterPersistentVolumeAttributesCollector(registry *prometheus.Registry, opts *options.Options) {
 	if !pvStoreEnabled {
 		enablePVStore(opts)

--- a/metrics/internal/collectors/storageconsumer.go
+++ b/metrics/internal/collectors/storageconsumer.go
@@ -31,7 +31,7 @@ func NewStorageConsumerCollector(opts *options.Options) *StorageConsumerCollecto
 		StorageConsumerMetadata: prometheus.NewDesc(
 			prometheus.BuildFQName("ocs", "storage_consumer", "metadata"),
 			`Attributes of OCS Storage Consumers`,
-			[]string{"storage_consumer_name", "capacity", "state", "granted_capacity"},
+			[]string{"storage_consumer_name", "state"},
 			nil,
 		),
 		Informer: sharedIndexInformer,


### PR DESCRIPTION
After removing the capacity field from StorageConsumer CR, the dependency on that field in the metrics exporter was apparently not removed.