### PR TITLE
Use context passed via handler instead of reconciler's context

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -134,7 +134,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			// Get the StorageCluster objects
 			scList := &ocsv1.StorageClusterList{}
-			err := r.Client.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
+			err := r.Client.List(context, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
 			if err != nil {
 				r.Log.Error(err, "Unable to list StorageCluster objects")
 				return []reconcile.Request{}


### PR DESCRIPTION
The reconciler's context can be `nil`, when the handler is executed if the storagecluster CR is not present, as the reconcile loop will not be triggered and the context field will never be initialised.

But, even if it's `nil` the `r.Client.List` operation doesn't always panic because there is a race scenario of the `cache` being synced by the time code execution reaches here. If the cache is not synced, then it waits for the cache to sync before executing the `List` operation and sends a close request via the `Done` channel of `ctx`, which results in a panic as `ctx` is nil in this case.

Therefore, we should not be using the `r.ctx` field and instead use the `context` pass by the handler to execute the `List` operation.

BUG: https://bugzilla.redhat.com/show_bug.cgi?id=2231076