### PR TITLE
Bug 2246526:[release-4.13] Use context.TODO() instead of reconciler's context

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -133,7 +133,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			// Get the StorageCluster objects
 			scList := &ocsv1.StorageClusterList{}
-			err := r.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
+			err := r.Client.List(context.TODO(), scList, &client.ListOptions{Namespace: obj.GetNamespace()})
 			if err != nil {
 				r.Log.Error(err, "Unable to list StorageCluster objects")
 				return []reconcile.Request{}


### PR DESCRIPTION
This is a manual backport of #2232 and #2174, with some changes due to package version changes.
DO NOT MERGE before #2235 is merged