### PR TITLE
Bug 2246527:[release-4.14] Use context passed via handler instead of reconciler's context

### DIFF
--- a/controllers/namespace/namespace_controller_test.go
+++ b/controllers/namespace/namespace_controller_test.go
@@ -69,7 +69,7 @@ func TestNamespaceAnnotated(t *testing.T) {
 	_, err = reconciler.Reconcile(ctx, request)
 	assert.NoError(t, err, "failed to reconcile")
 	nsList := &corev1.NamespaceList{}
-	err = reconciler.List(ctx, nsList)
+	err = reconciler.Client.List(ctx, nsList)
 	assert.NoError(t, err, "failed to list namespaces")
 	for _, testNs := range nsList.Items {
 		assert.Equal(t, testNs.Name, "openshift-storage-test")

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -134,7 +134,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			// Get the StorageCluster objects
 			scList := &ocsv1.StorageClusterList{}
-			err := r.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
+			err := r.Client.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
 			if err != nil {
 				r.Log.Error(err, "Unable to list StorageCluster objects")
 				return []reconcile.Request{}

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -121,7 +121,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	enqueueStorageClusterRequest := handler.EnqueueRequestsFromMapFunc(
-		func(_ context.Context, obj client.Object) []reconcile.Request {
+		func(context context.Context, obj client.Object) []reconcile.Request {
 
 			ocinit, ok := obj.(*ocsv1.OCSInitialization)
 			if !ok {
@@ -134,7 +134,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			// Get the StorageCluster objects
 			scList := &ocsv1.StorageClusterList{}
-			err := r.Client.List(r.ctx, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
+			err := r.Client.List(context, scList, &client.ListOptions{Namespace: obj.GetNamespace()})
 			if err != nil {
 				r.Log.Error(err, "Unable to list StorageCluster objects")
 				return []reconcile.Request{}


### PR DESCRIPTION
This is a manual backport of #2174 and #2232 