### PR TITLE
Add resource profiles to control the resourceRequirements for ceph pods

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -43,14 +43,21 @@ type StorageClusterSpec struct {
 	// Placement is optional and used to specify placements of OCS components explicitly
 	Placement rookCephv1.PlacementSpec `json:"placement,omitempty"`
 	// Resources follows the conventions of and is mapped to CephCluster.Spec.Resources
-	Resources          map[string]corev1.ResourceRequirements `json:"resources,omitempty"`
-	Encryption         EncryptionSpec                         `json:"encryption,omitempty"`
-	StorageDeviceSets  []StorageDeviceSet                     `json:"storageDeviceSets,omitempty"`
-	MonPVCTemplate     *corev1.PersistentVolumeClaim          `json:"monPVCTemplate,omitempty"`
-	MonDataDirHostPath string                                 `json:"monDataDirHostPath,omitempty"`
-	Mgr                *MgrSpec                               `json:"mgr,omitempty"`
-	MultiCloudGateway  *MultiCloudGatewaySpec                 `json:"multiCloudGateway,omitempty"`
-	NFS                *NFSSpec                               `json:"nfs,omitempty"`
+	Resources map[string]corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Resource Profile can be used to choose from a set of predefined resource profiles for the ceph daemons.
+	// We have 3 profiles
+	// lean: suitable for clusters with limited resources,
+	// balanced: suitable for most use cases,
+	// performance: suitable for clusters with high amount of resources.
+	// +kubebuilder:validation:Enum=lean;Lean;balanced;Balanced;performance;Performance
+	ResourceProfile    string                        `json:"resourceProfile,omitempty"`
+	Encryption         EncryptionSpec                `json:"encryption,omitempty"`
+	StorageDeviceSets  []StorageDeviceSet            `json:"storageDeviceSets,omitempty"`
+	MonPVCTemplate     *corev1.PersistentVolumeClaim `json:"monPVCTemplate,omitempty"`
+	MonDataDirHostPath string                        `json:"monDataDirHostPath,omitempty"`
+	Mgr                *MgrSpec                      `json:"mgr,omitempty"`
+	MultiCloudGateway  *MultiCloudGatewaySpec        `json:"multiCloudGateway,omitempty"`
+	NFS                *NFSSpec                      `json:"nfs,omitempty"`
 	// Monitoring controls the configuration of resources for exposing OCS metrics
 	Monitoring *MonitoringSpec `json:"monitoring,omitempty"`
 	// Version specifies the version of StorageCluster

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -2637,6 +2637,20 @@ spec:
                   is empty. This will only be used when AllowRemoteStorageConsumers
                   is set to true
                 type: string
+              resourceProfile:
+                description: 'Resource Profile can be used to choose from a set of
+                  predefined resource profiles for the ceph daemons. We have 3 profiles
+                  lean: suitable for clusters with limited resources, balanced: suitable
+                  for most use cases, performance: suitable for clusters with high
+                  amount of resources.'
+                enum:
+                - lean
+                - Lean
+                - balanced
+                - Balanced
+                - performance
+                - Performance
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource

--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -9,76 +9,6 @@ var (
 	// DaemonResources map contains the default resource requirements for the
 	// various OCS daemons
 	DaemonResources = map[string]corev1.ResourceRequirements{
-		"osd": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("5Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("5Gi"),
-			},
-		},
-		"mon": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
-		},
-		"mds": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
-			},
-		},
-		"nfs": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
-			},
-		},
-		"rgw": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
-			},
-		},
-		"mgr": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("3Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("3Gi"),
-			},
-		},
-		"mgr-sidecar": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("40Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
-			},
-		},
 		"noobaa-core": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("999m"),
@@ -114,6 +44,16 @@ var (
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},
+		"nfs": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
 		"rbd-mirror": {
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -122,6 +62,165 @@ var (
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+	}
+
+	LeanDaemonResources = map[string]corev1.ResourceRequirements{
+		"mgr": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		"mon": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		"osd": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1.5"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1.5"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+		},
+		"mds": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+		"rgw": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+
+	BalancedDaemonResources = map[string]corev1.ResourceRequirements{
+		"mgr": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1.5Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1.5Gi"),
+			},
+		},
+		"mon": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+		"osd": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("5Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("5Gi"),
+			},
+		},
+		"mds": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("6Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("6Gi"),
+			},
+		},
+		"rgw": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+	}
+
+	PerformanceDaemonResources = map[string]corev1.ResourceRequirements{
+		"mgr": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+		"mon": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1.5"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1.5"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+		},
+		"osd": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		"mds": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		"rgw": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
 	}

--- a/controllers/defaults/utils.go
+++ b/controllers/defaults/utils.go
@@ -1,6 +1,9 @@
 package defaults
 
 import (
+	"strings"
+
+	ocsv1 "github.com/red-hat-storage/ocs-operator/v4/api/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -12,4 +15,23 @@ func GetDaemonResources(name string, custom map[string]corev1.ResourceRequiremen
 		return res
 	}
 	return DaemonResources[name]
+}
+
+func GetProfileDaemonResources(name string, sc *ocsv1.StorageCluster) corev1.ResourceRequirements {
+	customResourceRequirements := sc.Spec.Resources
+	if res, ok := customResourceRequirements[name]; ok {
+		return res
+	}
+	resourceProfile := sc.Spec.ResourceProfile
+	resourceProfile = strings.ToLower(resourceProfile)
+	switch resourceProfile {
+	case "lean":
+		return LeanDaemonResources[name]
+	case "balanced":
+		return BalancedDaemonResources[name]
+	case "performance":
+		return PerformanceDaemonResources[name]
+	default:
+		return BalancedDaemonResources[name]
+	}
 }

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -723,7 +723,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 	for _, ds := range storageDeviceSets {
 		resources := ds.Resources
 		if resources.Requests == nil && resources.Limits == nil {
-			resources = defaults.DaemonResources["osd"]
+			resources = defaults.GetProfileDaemonResources("osd", sc)
 		}
 
 		portable := ds.Portable
@@ -875,7 +875,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			ds := rookCephv1.StorageClassDeviceSet{}
 			ds.Name = failureDomainValue
 			ds.Count = 1
-			ds.Resources = defaults.DaemonResources["osd"]
+			ds.Resources = defaults.GetProfileDaemonResources("osd", sc)
 			// passing on existing defaults from existing devcicesets
 			ds.TuneSlowDeviceClass = sc.Spec.StorageDeviceSets[0].Config.TuneSlowDeviceClass
 			ds.TuneFastDeviceClass = sc.Spec.StorageDeviceSets[0].Config.TuneFastDeviceClass
@@ -949,17 +949,11 @@ func countAndReplicaOf(ds *ocsv1.StorageDeviceSet) (int, int) {
 }
 
 func newCephDaemonResources(sc *ocsv1.StorageCluster) map[string]corev1.ResourceRequirements {
-	custom := sc.Spec.Resources
 	resources := map[string]corev1.ResourceRequirements{
-		"mon": defaults.DaemonResources["mon"],
-		"mgr": defaults.DaemonResources["mgr"],
-		"mds": defaults.DaemonResources["mds"],
-		"rgw": defaults.DaemonResources["rgw"],
+		"mon": defaults.GetProfileDaemonResources("mon", sc),
+		"mgr": defaults.GetProfileDaemonResources("mgr", sc),
 	}
-	if arbiterEnabled(sc) {
-		resources["mgr-sidecar"] = defaults.DaemonResources["mgr-sidecar"]
-	}
-
+	custom := sc.Spec.Resources
 	for k := range custom {
 		if r, ok := custom[k]; ok {
 			resources[k] = r

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -38,7 +38,7 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 				ActiveCount:   int32(getActiveMetadataServers(initStorageCluster)),
 				ActiveStandby: true,
 				Placement:     getPlacement(initStorageCluster, "mds"),
-				Resources:     defaults.GetDaemonResources("mds", initStorageCluster.Spec.Resources),
+				Resources:     defaults.GetProfileDaemonResources("mds", initStorageCluster),
 				// set PriorityClassName for the MDS pods
 				PriorityClassName: openshiftUserCritical,
 			},

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -184,7 +184,7 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 					},
 					Instances: int32(getCephObjectStoreGatewayInstances(initData)),
 					Placement: getPlacement(initData, "rgw"),
-					Resources: defaults.GetDaemonResources("rgw", initData.Spec.Resources),
+					Resources: defaults.GetProfileDaemonResources("rgw", initData),
 					// set PriorityClassName for the rgw pods
 					PriorityClassName: openshiftUserCritical,
 				},

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -2637,6 +2637,20 @@ spec:
                   is empty. This will only be used when AllowRemoteStorageConsumers
                   is set to true
                 type: string
+              resourceProfile:
+                description: 'Resource Profile can be used to choose from a set of
+                  predefined resource profiles for the ceph daemons. We have 3 profiles
+                  lean: suitable for clusters with limited resources, balanced: suitable
+                  for most use cases, performance: suitable for clusters with high
+                  amount of resources.'
+                enum:
+                - lean
+                - Lean
+                - balanced
+                - Balanced
+                - performance
+                - Performance
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -2636,6 +2636,20 @@ spec:
                   is empty. This will only be used when AllowRemoteStorageConsumers
                   is set to true
                 type: string
+              resourceProfile:
+                description: 'Resource Profile can be used to choose from a set of
+                  predefined resource profiles for the ceph daemons. We have 3 profiles
+                  lean: suitable for clusters with limited resources, balanced: suitable
+                  for most use cases, performance: suitable for clusters with high
+                  amount of resources.'
+                enum:
+                - lean
+                - Lean
+                - balanced
+                - Balanced
+                - performance
+                - Performance
+                type: string
               resources:
                 additionalProperties:
                   description: ResourceRequirements describes the compute resource


### PR DESCRIPTION
```
• Add an storageCluster api field to specify the resource profile.
• The field can only take values "lean", "balanced" and "performance".
• Accordingly, the resourceRequirements for the ceph daemons are set,
  currently only mgr, mon, osd, mds and rgw pods are supported.
• It's checked if custom resourceRequirements are specified in the CR,
  if yes, then those are used. If not, then profiles are used.
• If no resource profile is specified, balanced profile values are used.
```