### PR TITLE
Use exact ceph image version v17.2.6 instead of v17

### DIFF
--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -3064,7 +3064,7 @@ spec:
                 - name: ROOK_CEPH_IMAGE
                   value: docker.io/rook/ceph:v1.12.5-17.ge48f4f088
                 - name: CEPH_IMAGE
-                  value: quay.io/ceph/ceph:v17
+                  value: quay.io/ceph/ceph:v17.2.6
                 - name: NOOBAA_CORE_IMAGE
                   value: quay.io/noobaa/noobaa-core:master-20230718
                 - name: NOOBAA_DB_IMAGE
@@ -3611,7 +3611,7 @@ spec:
   relatedImages:
   - image: docker.io/rook/ceph:v1.12.5-17.ge48f4f088
     name: rook-container
-  - image: quay.io/ceph/ceph:v17
+  - image: quay.io/ceph/ceph:v17.2.6
     name: ceph-container
   - image: quay.io/csiaddons/k8s-sidecar:v0.6.0
     name: csiaddons-sidecar

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -52,7 +52,7 @@ LATEST_ROOK_IMAGE="docker.io/rook/ceph:v1.12.5-17.ge48f4f088"
 LATEST_NOOBAA_IMAGE="quay.io/noobaa/noobaa-operator:master-20230718"
 LATEST_NOOBAA_CORE_IMAGE="quay.io/noobaa/noobaa-core:master-20230718"
 LATEST_NOOBAA_DB_IMAGE="docker.io/centos/postgresql-12-centos8"
-LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v17"
+LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v17.2.6"
 LATEST_ROOK_CSIADDONS_IMAGE="quay.io/csiaddons/k8s-sidecar:v0.6.0"
 # TODO: change image once the quay repo is changed
 LATEST_MUST_GATHER_IMAGE="quay.io/ocs-dev/ocs-must-gather:latest"


### PR DESCRIPTION
Using the tag v17 pulls the latest image from the v17 tag, and the latest image is v17.2.7. This image is problematic and causes the osd-prepare pods to fail. So use the exact version v17.2.6.

BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2247313