### PR TITLE
Refactor isActiveStorageCluster to handle internal and external clusters

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -92,6 +92,7 @@ type StorageClusterReconciler struct {
 	recorder           *util.EventReporter
 	OperatorCondition  conditions.Condition
 	IsNoobaaStandalone bool
+	clusters           *util.Clusters
 }
 
 // SetupWithManager sets up a controller with manager

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -592,8 +592,7 @@ func TestIsActiveStorageCluster(t *testing.T) {
 			isActive: true,
 		},
 		{
-			label:           "Case 4", // storageCluster2 should be active as there are no other storageClusters available
-			storageCluster1: &api.StorageCluster{},
+			label: "Case 4", // storageCluster2 should be active as there are no other storageClusters available
 			storageCluster2: &api.StorageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "storage-test-b",
@@ -605,7 +604,14 @@ func TestIsActiveStorageCluster(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		reconciler := createFakeStorageClusterReconciler(t, tc.storageCluster1, tc.storageCluster2)
+
+		var reconciler StorageClusterReconciler
+		if tc.storageCluster1 != nil && tc.storageCluster2 != nil {
+			reconciler = createFakeStorageClusterReconciler(t, tc.storageCluster1, tc.storageCluster2)
+		} else {
+			reconciler = createFakeStorageClusterReconciler(t, tc.storageCluster2)
+		}
+
 		actual, err := reconciler.isActiveStorageCluster(tc.storageCluster2)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.isActive, actual, "[%q] failed to assert if current storagecluster is active or not", tc.label)
@@ -972,6 +978,11 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 	obj = append(obj, cbp, cfs)
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj...).WithStatusSubresource(sc).Build()
 
+	clusters, err := util.GetClusters(context.TODO(), client)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get clusters %s", err.Error()))
+	}
+
 	return StorageClusterReconciler{
 		Client:            client,
 		Scheme:            scheme,
@@ -979,6 +990,7 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 		serverVersion:     &k8sVersion.Info{},
 		Log:               logf.Log.WithName("controller_storagecluster_test"),
 		platform:          &Platform{platform: configv1.NonePlatformType},
+		clusters:          clusters,
 	}
 }
 


### PR DESCRIPTION
Previously, the isActiveStorageCluster function listed all storage clusters and checked them. To support one internal and one external cluster, it has been modified to check them separately.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>