### PR TITLE
storageclassrequest: refactor and unit testing

### DIFF
--- a/controllers/storageclassrequest/storageclassrequest_controller_test.go
+++ b/controllers/storageclassrequest/storageclassrequest_controller_test.go
@@ -1,0 +1,494 @@
+/*
+Copyright 2023 Red Hat OpenShift Container Storage.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclassrequest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	controllers "github.com/red-hat-storage/ocs-operator/v4/controllers/storageconsumer"
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var fakeStorageProfile = &v1.StorageProfile{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "medium",
+		Namespace: "test-ns",
+	},
+	Spec: v1.StorageProfileSpec{
+		DeviceClass: "ssd",
+	},
+}
+
+var fakeStorageCluster = &v1.StorageCluster{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-storagecluster",
+		Namespace: "test-ns",
+	},
+	Spec: v1.StorageClusterSpec{
+		DefaultStorageProfile: fakeStorageProfile.Name,
+		StorageDeviceSets: []v1.StorageDeviceSet{
+			{
+				DeviceClass: "ssd",
+			},
+		},
+	},
+	Status: v1.StorageClusterStatus{
+		FailureDomain: "zone",
+	},
+}
+
+var fakeStorageConsumer = &v1alpha1.StorageConsumer{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-consumer",
+		Namespace: "test-ns",
+	},
+}
+
+var fakeCephFs = &rookCephv1.CephFilesystem{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      fmt.Sprintf("%s-cephfilesystem", fakeStorageCluster.Name),
+		Namespace: fakeStorageCluster.Namespace,
+	},
+	Spec: rookCephv1.FilesystemSpec{
+		DataPools: []rookCephv1.NamedPoolSpec{
+			{
+				PoolSpec: rookCephv1.PoolSpec{
+					DeviceClass: "ssd",
+				},
+			},
+		},
+	},
+}
+
+func createFakeScheme(t *testing.T) *runtime.Scheme {
+
+	scheme := runtime.NewScheme()
+	err := v1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "unable to build scheme")
+	}
+
+	err = v1alpha1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add ocsv1alpha1 scheme")
+	}
+
+	err = rookCephv1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add rookCephv1scheme")
+	}
+
+	return scheme
+}
+
+func createFakeReconciler(t *testing.T) StorageClassRequestReconciler {
+	var fakeReconciler StorageClassRequestReconciler
+
+	fakeReconciler.Scheme = createFakeScheme(t)
+	fakeReconciler.log = log.Log.WithName("controller_storagecluster_test")
+	fakeReconciler.OperatorNamespace = "test-ns"
+	fakeReconciler.StorageClassRequest = &v1alpha1.StorageClassRequest{}
+	fakeReconciler.cephResourcesByName = map[string]*v1alpha1.CephResourcesSpec{}
+
+	fakeReconciler.storageConsumer = fakeStorageConsumer
+	fakeReconciler.storageCluster = fakeStorageCluster
+
+	return fakeReconciler
+}
+
+func TestProfileReconcile(t *testing.T) {
+	var err error
+	var caseCounter int
+
+	var primaryTestCases = []struct {
+		label           string
+		scrType         string
+		profileName     string
+		failureExpected bool
+		createObjects   []runtime.Object
+	}{
+		{
+			label:       "Reconcile blockpool StorageClassRequest",
+			scrType:     "blockpool",
+			profileName: fakeStorageProfile.Name,
+		},
+		{
+			label:       "Reconcile sharedfilesystem StorageClassRequest",
+			scrType:     "sharedfilesystem",
+			profileName: fakeStorageProfile.Name,
+		},
+		{
+			label:   "Reconcile blockpool StorageClassRequest with default StorageProfile",
+			scrType: "blockpool",
+		},
+		{
+			label:   "Reconcile sharedfilesystem StorageClassRequest with default StorageProfile",
+			scrType: "sharedfilesystem",
+		},
+		{
+			label:           "Reconcile blockpool StorageClassRequest with invalid StorageProfile",
+			scrType:         "blockpool",
+			profileName:     "nope",
+			failureExpected: true,
+		},
+		{
+			label:           "Reconcile sharedfilesystem StorageClassRequest with invalid StorageProfile",
+			scrType:         "sharedfilesystem",
+			profileName:     "nope",
+			failureExpected: true,
+		},
+	}
+
+	for _, c := range primaryTestCases {
+		caseCounter++
+		caseLabel := fmt.Sprintf("Case %d: %s", caseCounter, c.label)
+		fmt.Println(caseLabel)
+
+		r := createFakeReconciler(t)
+
+		fakeStorageClassRequest := &v1alpha1.StorageClassRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-scr",
+				Namespace: "test-ns",
+			},
+			Spec: v1alpha1.StorageClassRequestSpec{
+				Type:           c.scrType,
+				StorageProfile: c.profileName,
+			},
+		}
+		err = controllerutil.SetOwnerReference(fakeStorageConsumer, fakeStorageClassRequest, r.Scheme)
+		assert.NoError(t, err, caseLabel)
+
+		c.createObjects = append(c.createObjects, fakeCephFs)
+		c.createObjects = append(c.createObjects, fakeStorageClassRequest)
+		c.createObjects = append(c.createObjects, fakeStorageCluster)
+		c.createObjects = append(c.createObjects, fakeStorageConsumer)
+		c.createObjects = append(c.createObjects, fakeStorageProfile)
+
+		r.Cache = &informertest.FakeInformers{Scheme: r.Scheme}
+		fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme).WithRuntimeObjects(c.createObjects...).WithStatusSubresource(fakeStorageClassRequest)
+		r.Client = fakeClient.Build()
+
+		req := reconcile.Request{}
+		req.Name = fakeStorageClassRequest.Name
+		req.Namespace = fakeStorageClassRequest.Namespace
+		_, err = r.Reconcile(context.TODO(), req)
+		if c.failureExpected {
+			assert.Error(t, err, caseLabel)
+			continue
+		}
+		assert.NoError(t, err, caseLabel)
+	}
+
+	caseCounter++
+	caseLabel := fmt.Sprintf("Case %d: No StorageClassRequest exists", caseCounter)
+	fmt.Println(caseLabel)
+
+	r := createFakeReconciler(t)
+	r.Cache = &informertest.FakeInformers{Scheme: r.Scheme}
+	r.Client = fake.NewClientBuilder().WithScheme(r.Scheme).Build()
+
+	req := reconcile.Request{}
+	req.Name = "nope"
+	req.Namespace = r.OperatorNamespace
+	_, err = r.Reconcile(context.TODO(), req)
+	assert.NoError(t, err, caseLabel)
+}
+
+func TestCephBlockPool(t *testing.T) {
+	var err error
+	var caseCounter int
+
+	var primaryTestCases = []struct {
+		label            string
+		expectedPoolName string
+		failureExpected  bool
+		createObjects    []runtime.Object
+		cephResources    []*v1alpha1.CephResourcesSpec
+	}{
+		{
+			label: "No CephBlockPool exists",
+		},
+		{
+			label:            "Valid CephBlockPool exists",
+			expectedPoolName: "test-blockpool",
+			createObjects: []runtime.Object{
+				&rookCephv1.CephBlockPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							controllers.StorageConsumerNameLabel: fakeStorageConsumer.Name,
+							controllers.StorageProfileSpecLabel:  fakeStorageProfile.GetSpecHash(),
+						},
+					},
+				},
+				&rookCephv1.CephBlockPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool2",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							controllers.StorageConsumerNameLabel: "wrongConsumer",
+							controllers.StorageProfileSpecLabel:  "0123456789",
+						},
+					},
+				},
+			},
+		},
+		{
+			label: "Valid CephBlockPool only exists for different consumer/profile",
+			createObjects: []runtime.Object{
+				&rookCephv1.CephBlockPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							controllers.StorageConsumerNameLabel: "wrongConsumer",
+							controllers.StorageProfileSpecLabel:  "0123456789",
+						},
+					},
+				},
+			},
+		},
+		{
+			label:           "More than one valid CephBlockPool exists",
+			failureExpected: true,
+			createObjects: []runtime.Object{
+				&rookCephv1.CephBlockPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							controllers.StorageConsumerNameLabel: fakeStorageConsumer.Name,
+							controllers.StorageProfileSpecLabel:  fakeStorageProfile.GetSpecHash(),
+						},
+					},
+				},
+				&rookCephv1.CephBlockPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool2",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							controllers.StorageConsumerNameLabel: fakeStorageConsumer.Name,
+							controllers.StorageProfileSpecLabel:  fakeStorageProfile.GetSpecHash(),
+						},
+					},
+				},
+			},
+		},
+		{
+			label:            "Request status already has valid CephResource",
+			expectedPoolName: "test-blockpool",
+			cephResources: []*v1alpha1.CephResourcesSpec{
+				{
+					Name: "test-blockpool",
+					Kind: "CephBlockPool",
+				},
+			},
+			createObjects: []runtime.Object{
+				&rookCephv1.CephBlockPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							controllers.StorageConsumerNameLabel: fakeStorageConsumer.Name,
+							controllers.StorageProfileSpecLabel:  fakeStorageProfile.GetSpecHash(),
+						},
+					},
+				},
+			},
+		},
+		{
+			label:            "Request status has CephResource that doesn't exist",
+			expectedPoolName: "test-blockpool",
+			cephResources: []*v1alpha1.CephResourcesSpec{
+				{
+					Name: "test-blockpool",
+					Kind: "CephBlockPool",
+				},
+			},
+		},
+	}
+
+	for _, c := range primaryTestCases {
+		caseCounter++
+		caseLabel := fmt.Sprintf("Case %d: %s", caseCounter, c.label)
+		fmt.Println(caseLabel)
+
+		r := createFakeReconciler(t)
+		r.StorageClassRequest.Status.CephResources = c.cephResources
+		r.StorageClassRequest.Spec.Type = "blockpool"
+		r.StorageClassRequest.Spec.StorageProfile = fakeStorageProfile.Name
+
+		c.createObjects = append(c.createObjects, fakeStorageProfile)
+		c.createObjects = append(c.createObjects, fakeStorageConsumer)
+		fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme).WithRuntimeObjects(c.createObjects...)
+		r.Client = fakeClient.Build()
+
+		_, err = r.reconcilePhases()
+		if c.failureExpected {
+			assert.Error(t, err, caseLabel)
+			continue
+		}
+		assert.NoError(t, err, caseLabel)
+
+		if c.expectedPoolName == "" {
+			assert.NotEmpty(t, r.cephBlockPool, caseLabel)
+			createdBlockpool := &rookCephv1.CephBlockPool{}
+			createdBlockpool.Name = r.cephBlockPool.Name
+			createdBlockpool.Namespace = r.cephBlockPool.Namespace
+
+			err = r.get(createdBlockpool)
+			assert.NoError(t, err, caseLabel)
+		} else {
+			assert.Equal(t, c.expectedPoolName, r.cephBlockPool.Name, caseLabel)
+		}
+	}
+
+	caseCounter++
+	caseLabel := fmt.Sprintf("Case %d: StorageProfile has invalid DeviceClass", caseCounter)
+	fmt.Println(caseLabel)
+
+	badStorageProfile := fakeStorageProfile.DeepCopy()
+	badStorageProfile.Spec.DeviceClass = "nope"
+
+	r := createFakeReconciler(t)
+	r.StorageClassRequest.Spec.Type = "blockpool"
+	r.StorageClassRequest.Spec.StorageProfile = badStorageProfile.Name
+	fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme)
+	r.Client = fakeClient.WithRuntimeObjects(badStorageProfile, fakeStorageConsumer).Build()
+
+	_, err = r.reconcilePhases()
+	assert.Error(t, err, caseLabel)
+}
+
+func TestCephFsSubVolGroup(t *testing.T) {
+	var err error
+	var caseCounter int
+
+	var primaryTestCases = []struct {
+		label             string
+		expectedGroupName string
+		createObjects     []runtime.Object
+		cephResources     []*v1alpha1.CephResourcesSpec
+	}{
+		{
+			label: "No CephFilesystemSubVolumeGroup exists",
+		},
+		{
+			label:             "Request status already has valid CephResource",
+			expectedGroupName: "test-subvolgroup",
+			cephResources: []*v1alpha1.CephResourcesSpec{
+				{
+					Name: "test-subvolgroup",
+					Kind: "CephFilesystemSubVolumeGroup",
+				},
+			},
+			createObjects: []runtime.Object{
+				&rookCephv1.CephFilesystemSubVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-blockpool",
+						Namespace: "test-ns",
+					},
+					Status: &rookCephv1.CephFilesystemSubVolumeGroupStatus{},
+				},
+			},
+		},
+		{
+			label:             "Request status has CephResource that doesn't exist",
+			expectedGroupName: "test-subvolgroup",
+			cephResources: []*v1alpha1.CephResourcesSpec{
+				{
+					Name: "test-subvolgroup",
+					Kind: "CephFilesystemSubVolumeGroup",
+				},
+			},
+		},
+	}
+
+	for _, c := range primaryTestCases {
+		caseCounter++
+		caseLabel := fmt.Sprintf("Case %d: %s", caseCounter, c.label)
+		fmt.Println(caseLabel)
+
+		r := createFakeReconciler(t)
+		r.StorageClassRequest.Status.CephResources = c.cephResources
+		r.StorageClassRequest.Spec.Type = "sharedfilesystem"
+		r.StorageClassRequest.Spec.StorageProfile = fakeStorageProfile.Name
+
+		c.createObjects = append(c.createObjects, fakeCephFs)
+		c.createObjects = append(c.createObjects, fakeStorageProfile)
+		c.createObjects = append(c.createObjects, fakeStorageConsumer)
+		fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme).WithRuntimeObjects(c.createObjects...)
+
+		r.Client = fakeClient.Build()
+		r.StorageClassRequest.Status.CephResources = c.cephResources
+
+		_, err = r.reconcilePhases()
+		assert.NoError(t, err, caseLabel)
+
+		if c.expectedGroupName == "" {
+			assert.NotEmpty(t, r.cephFilesystemSubVolumeGroup, caseLabel)
+			createdSubVolGroup := &rookCephv1.CephFilesystemSubVolumeGroup{}
+			createdSubVolGroup.Name = r.cephFilesystemSubVolumeGroup.Name
+			createdSubVolGroup.Namespace = r.cephFilesystemSubVolumeGroup.Namespace
+
+			err = r.get(createdSubVolGroup)
+			assert.NoError(t, err, caseLabel)
+		} else {
+			assert.Equal(t, c.expectedGroupName, r.cephFilesystemSubVolumeGroup.Name, caseLabel)
+		}
+	}
+
+	caseCounter++
+	caseLabel := fmt.Sprintf("Case %d: No CephFilesystem exists", caseCounter)
+	fmt.Println(caseLabel)
+
+	r := createFakeReconciler(t)
+	r.StorageClassRequest.Spec.Type = "sharedfilesystem"
+	r.StorageClassRequest.Spec.StorageProfile = fakeStorageProfile.Name
+	fakeClient := fake.NewClientBuilder().WithScheme(r.Scheme)
+	r.Client = fakeClient.WithRuntimeObjects(fakeStorageProfile, fakeStorageConsumer).Build()
+
+	_, err = r.reconcilePhases()
+	assert.Error(t, err, caseLabel)
+
+	caseCounter++
+	caseLabel = fmt.Sprintf("Case %d: StorageProfile has invalid DeviceClass", caseCounter)
+	fmt.Println(caseLabel)
+
+	badStorageProfile := fakeStorageProfile.DeepCopy()
+	badStorageProfile.Spec.DeviceClass = "nope"
+
+	r = createFakeReconciler(t)
+	r.StorageClassRequest.Spec.Type = "sharedfilesystem"
+	r.StorageClassRequest.Spec.StorageProfile = badStorageProfile.Name
+	fakeClient = fake.NewClientBuilder().WithScheme(r.Scheme)
+	r.Client = fakeClient.WithRuntimeObjects(badStorageProfile, fakeStorageConsumer, fakeCephFs).Build()
+
+	_, err = r.reconcilePhases()
+	assert.Error(t, err, caseLabel)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -947,6 +947,7 @@ sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage/v1alpha1
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
 sigs.k8s.io/controller-runtime/pkg/cache
+sigs.k8s.io/controller-runtime/pkg/cache/informertest
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/certwatcher
 sigs.k8s.io/controller-runtime/pkg/certwatcher/metrics
@@ -959,6 +960,7 @@ sigs.k8s.io/controller-runtime/pkg/cluster
 sigs.k8s.io/controller-runtime/pkg/config
 sigs.k8s.io/controller-runtime/pkg/config/v1alpha1
 sigs.k8s.io/controller-runtime/pkg/controller
+sigs.k8s.io/controller-runtime/pkg/controller/controllertest
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/conversion
 sigs.k8s.io/controller-runtime/pkg/event

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informertest/fake_cache.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informertest/fake_cache.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informertest
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	toolscache "k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+)
+
+var _ cache.Cache = &FakeInformers{}
+
+// FakeInformers is a fake implementation of Informers.
+type FakeInformers struct {
+	InformersByGVK map[schema.GroupVersionKind]toolscache.SharedIndexInformer
+	Scheme         *runtime.Scheme
+	Error          error
+	Synced         *bool
+}
+
+// GetInformerForKind implements Informers.
+func (c *FakeInformers) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind, opts ...cache.InformerGetOption) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	obj, err := c.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return c.informerFor(gvk, obj)
+}
+
+// FakeInformerForKind implements Informers.
+func (c *FakeInformers) FakeInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (*controllertest.FakeInformer, error) {
+	i, err := c.GetInformerForKind(ctx, gvk)
+	if err != nil {
+		return nil, err
+	}
+	return i.(*controllertest.FakeInformer), nil
+}
+
+// GetInformer implements Informers.
+func (c *FakeInformers) GetInformer(ctx context.Context, obj client.Object, opts ...cache.InformerGetOption) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	gvks, _, err := c.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	return c.informerFor(gvk, obj)
+}
+
+// WaitForCacheSync implements Informers.
+func (c *FakeInformers) WaitForCacheSync(ctx context.Context) bool {
+	if c.Synced == nil {
+		return true
+	}
+	return *c.Synced
+}
+
+// FakeInformerFor implements Informers.
+func (c *FakeInformers) FakeInformerFor(ctx context.Context, obj client.Object) (*controllertest.FakeInformer, error) {
+	i, err := c.GetInformer(ctx, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.(*controllertest.FakeInformer), nil
+}
+
+func (c *FakeInformers) informerFor(gvk schema.GroupVersionKind, _ runtime.Object) (toolscache.SharedIndexInformer, error) {
+	if c.Error != nil {
+		return nil, c.Error
+	}
+	if c.InformersByGVK == nil {
+		c.InformersByGVK = map[schema.GroupVersionKind]toolscache.SharedIndexInformer{}
+	}
+	informer, ok := c.InformersByGVK[gvk]
+	if ok {
+		return informer, nil
+	}
+
+	c.InformersByGVK[gvk] = &controllertest.FakeInformer{}
+	return c.InformersByGVK[gvk], nil
+}
+
+// Start implements Informers.
+func (c *FakeInformers) Start(ctx context.Context) error {
+	return c.Error
+}
+
+// IndexField implements Cache.
+func (c *FakeInformers) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return nil
+}
+
+// Get implements Cache.
+func (c *FakeInformers) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return nil
+}
+
+// List implements Cache.
+func (c *FakeInformers) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllertest contains fake informers for testing controllers
+// When in doubt, it's almost always better to test against a real API server
+// using envtest.Environment.
+package controllertest

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/testing.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/testing.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ runtime.Object = &ErrorType{}
+
+// ErrorType implements runtime.Object but isn't registered in any scheme and should cause errors in tests as a result.
+type ErrorType struct{}
+
+// GetObjectKind implements runtime.Object.
+func (ErrorType) GetObjectKind() schema.ObjectKind { return nil }
+
+// DeepCopyObject implements runtime.Object.
+func (ErrorType) DeepCopyObject() runtime.Object { return nil }
+
+var _ workqueue.RateLimitingInterface = &Queue{}
+
+// Queue implements a RateLimiting queue as a non-ratelimited queue for testing.
+// This helps testing by having functions that use a RateLimiting queue synchronously add items to the queue.
+type Queue struct {
+	workqueue.Interface
+	AddedRateLimitedLock sync.Mutex
+	AddedRatelimited     []any
+}
+
+// AddAfter implements RateLimitingInterface.
+func (q *Queue) AddAfter(item interface{}, duration time.Duration) {
+	q.Add(item)
+}
+
+// AddRateLimited implements RateLimitingInterface.  TODO(community): Implement this.
+func (q *Queue) AddRateLimited(item interface{}) {
+	q.AddedRateLimitedLock.Lock()
+	q.AddedRatelimited = append(q.AddedRatelimited, item)
+	q.AddedRateLimitedLock.Unlock()
+	q.Add(item)
+}
+
+// Forget implements RateLimitingInterface.  TODO(community): Implement this.
+func (q *Queue) Forget(item interface{}) {}
+
+// NumRequeues implements RateLimitingInterface.  TODO(community): Implement this.
+func (q *Queue) NumRequeues(item interface{}) int {
+	return 0
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/unconventionallisttypecrd.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/unconventionallisttypecrd.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ runtime.Object = &UnconventionalListType{}
+var _ runtime.Object = &UnconventionalListTypeList{}
+
+// UnconventionalListType is used to test CRDs with List types that
+// have a slice of pointers rather than a slice of literals.
+type UnconventionalListType struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              string `json:"spec,omitempty"`
+}
+
+// DeepCopyObject implements runtime.Object
+// Handwritten for simplicity.
+func (u *UnconventionalListType) DeepCopyObject() runtime.Object {
+	return u.DeepCopy()
+}
+
+// DeepCopy implements *UnconventionalListType
+// Handwritten for simplicity.
+func (u *UnconventionalListType) DeepCopy() *UnconventionalListType {
+	return &UnconventionalListType{
+		TypeMeta:   u.TypeMeta,
+		ObjectMeta: *u.ObjectMeta.DeepCopy(),
+		Spec:       u.Spec,
+	}
+}
+
+// UnconventionalListTypeList is used to test CRDs with List types that
+// have a slice of pointers rather than a slice of literals.
+type UnconventionalListTypeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []*UnconventionalListType `json:"items"`
+}
+
+// DeepCopyObject implements runtime.Object
+// Handwritten for simplicity.
+func (u *UnconventionalListTypeList) DeepCopyObject() runtime.Object {
+	return u.DeepCopy()
+}
+
+// DeepCopy implements *UnconventionalListTypeListt
+// Handwritten for simplicity.
+func (u *UnconventionalListTypeList) DeepCopy() *UnconventionalListTypeList {
+	out := &UnconventionalListTypeList{
+		TypeMeta: u.TypeMeta,
+		ListMeta: *u.ListMeta.DeepCopy(),
+	}
+	for _, item := range u.Items {
+		out.Items = append(out.Items, item.DeepCopy())
+	}
+	return out
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/util.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/util.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.SharedIndexInformer = &FakeInformer{}
+
+// FakeInformer provides fake Informer functionality for testing.
+type FakeInformer struct {
+	// Synced is returned by the HasSynced functions to implement the Informer interface
+	Synced bool
+
+	// RunCount is incremented each time RunInformersAndControllers is called
+	RunCount int
+
+	handlers []eventHandlerWrapper
+}
+
+type modernResourceEventHandler interface {
+	OnAdd(obj interface{}, isInInitialList bool)
+	OnUpdate(oldObj, newObj interface{})
+	OnDelete(obj interface{})
+}
+
+type legacyResourceEventHandler interface {
+	OnAdd(obj interface{})
+	OnUpdate(oldObj, newObj interface{})
+	OnDelete(obj interface{})
+}
+
+// eventHandlerWrapper wraps a ResourceEventHandler in a manner that is compatible with client-go 1.27+ and older.
+// The interface was changed in these versions.
+type eventHandlerWrapper struct {
+	handler any
+}
+
+func (e eventHandlerWrapper) OnAdd(obj interface{}) {
+	if m, ok := e.handler.(modernResourceEventHandler); ok {
+		m.OnAdd(obj, false)
+		return
+	}
+	e.handler.(legacyResourceEventHandler).OnAdd(obj)
+}
+
+func (e eventHandlerWrapper) OnUpdate(oldObj, newObj interface{}) {
+	if m, ok := e.handler.(modernResourceEventHandler); ok {
+		m.OnUpdate(oldObj, newObj)
+		return
+	}
+	e.handler.(legacyResourceEventHandler).OnUpdate(oldObj, newObj)
+}
+
+func (e eventHandlerWrapper) OnDelete(obj interface{}) {
+	if m, ok := e.handler.(modernResourceEventHandler); ok {
+		m.OnDelete(obj)
+		return
+	}
+	e.handler.(legacyResourceEventHandler).OnDelete(obj)
+}
+
+// AddIndexers does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) AddIndexers(indexers cache.Indexers) error {
+	return nil
+}
+
+// GetIndexer does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetIndexer() cache.Indexer {
+	return nil
+}
+
+// Informer returns the fake Informer.
+func (f *FakeInformer) Informer() cache.SharedIndexInformer {
+	return f
+}
+
+// HasSynced implements the Informer interface.  Returns f.Synced.
+func (f *FakeInformer) HasSynced() bool {
+	return f.Synced
+}
+
+// AddEventHandler implements the Informer interface.  Adds an EventHandler to the fake Informers. TODO(community): Implement Registration.
+func (f *FakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	f.handlers = append(f.handlers, eventHandlerWrapper{handler})
+	return nil, nil
+}
+
+// Run implements the Informer interface.  Increments f.RunCount.
+func (f *FakeInformer) Run(<-chan struct{}) {
+	f.RunCount++
+}
+
+// Add fakes an Add event for obj.
+func (f *FakeInformer) Add(obj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnAdd(obj)
+	}
+}
+
+// Update fakes an Update event for obj.
+func (f *FakeInformer) Update(oldObj, newObj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnUpdate(oldObj, newObj)
+	}
+}
+
+// Delete fakes an Delete event for obj.
+func (f *FakeInformer) Delete(obj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnDelete(obj)
+	}
+}
+
+// AddEventHandlerWithResyncPeriod does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+// RemoveEventHandler does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	return nil
+}
+
+// GetStore does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetStore() cache.Store {
+	return nil
+}
+
+// GetController does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetController() cache.Controller {
+	return nil
+}
+
+// LastSyncResourceVersion does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) LastSyncResourceVersion() string {
+	return ""
+}
+
+// SetWatchErrorHandler does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) SetWatchErrorHandler(cache.WatchErrorHandler) error {
+	return nil
+}
+
+// SetTransform does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) SetTransform(t cache.TransformFunc) error {
+	return nil
+}
+
+// IsStopped does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) IsStopped() bool {
+	return false
+}


### PR DESCRIPTION
This PR is a follow-up to #2228 that addresses some remaining discussion points. First is a refactor to better define the "Initialization" phase of the reconciliation loop. Second is the introduction of unit tests for the controller, as well as a small bug fix that was discovered because of the new tests.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>