### PR TITLE
monitoring: Add new alert CephMonLowNumber

### DIFF
--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -278,6 +278,17 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: CephMonLowNumber
+      annotations:
+        description: The number of node failure zones available (5) allow to increase the number of Ceph monitors from 3 to 5 in order to improve cluster resilience.
+        message: The current number of Ceph monitors can be increased in order to improve cluster resilience
+        severity_level: info
+        storage_type: ceph
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/CephMonLowNumber.md
+      expr: |
+        (count(ceph_mon_metadata)) < (count(count by (label_failure_domain_beta_kubernetes_io_zone, label_provider_id) (ocs_node_labels))) and (count(count by (label_failure_domain_beta_kubernetes_io_zone, label_provider_id) (ocs_node_labels))) >= 5
+      labels:
+        severity: info
   - name: cluster-utilization-alert.rules
     rules:
     - alert: CephClusterNearFull

--- a/metrics/internal/collectors/ceph-cluster_test.go
+++ b/metrics/internal/collectors/ceph-cluster_test.go
@@ -9,6 +9,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephv1listers "github.com/rook/rook/pkg/client/listers/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -218,4 +219,70 @@ func TestCollectMirrorinDaemonCount(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCollectNodeLabels(t *testing.T) {
+	mockOpts.StopCh = make(chan struct{})
+	defer close(mockOpts.StopCh)
+
+	cephClusterCollector := getMockCephClusterCollector(t, mockOpts)
+
+	cephNodeList := &corev1.NodeList{
+		TypeMeta: metav1.TypeMeta{Kind: "NodeList"},
+		Items: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Node1",
+					Labels: map[string]string{
+						"cluster.ocs.openshift.io/openshift-storage": "",
+						"failure-domain.beta.kubernetes.io/zone":     "zonea",
+						"hostnameLabel":                              "node1",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					ProviderID: "aws://x",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Node2",
+					Labels: map[string]string{
+						"cluster.ocs.openshift.io/openshift-storage": "",
+						"failure-domain.beta.kubernetes.io/zone":     "",
+						"hostnameLabel":                              "node2",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					ProviderID: "aws",
+				},
+			},
+		},
+	}
+
+	ch := make(chan prometheus.Metric)
+	metric := dto.Metric{}
+	go func() {
+		cephClusterCollector.collectNodeLabels(cephNodeList, ch)
+		close(ch)
+	}()
+
+	for m := range ch {
+		assert.Contains(t, m.Desc().String(), "ocs_node_labels")
+		metric.Reset()
+		err := m.Write(&metric)
+		assert.Nil(t, err)
+		labels := metric.GetLabel()
+		assert.Equal(t, len(labels), 3)
+		for _, label := range labels {
+			if *label.Name == "label_provider_id" {
+				assert.True(t, *label.Value == "aws" || *label.Value == "")
+			}
+			if *label.Name == "label_failure_domain_beta_kubernetes_io_zone" {
+				assert.True(t, *label.Value == "zonea" || *label.Value == "")
+			}
+			if *label.Name == "hostnameLabel" {
+				assert.True(t, *label.Value == "node1" || *label.Value == "node2")
+			}
+		}
+	}
 }


### PR DESCRIPTION
To raise the new alert it was needed also to create the new metric ocs_node_labels.

The new metrics can be watched using:
- Executing the following command in the ocs-metrics-exporter pod:
```
sh-4.4$ curl http://localhost:8080/metrics | grep node
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2533    0  2533    0     0   206k      0 --:--:-- --:--:-- --:--:--  206k
# HELP ocs_node_labels Labels for the Ceph node
# TYPE ocs_node_labels gauge
ocs_node_labels{label_failure_domain_beta_kubernetes_io_zone="us-east-2a",label_kubernetes_io_hostname="ip-10-0-10-78.us-east-2.compute.internal",label_provider_id="aws"} 1
ocs_node_labels{label_failure_domain_beta_kubernetes_io_zone="us-east-2b",label_kubernetes_io_hostname="ip-10-0-33-83.us-east-2.compute.internal",label_provider_id="aws"} 1
ocs_node_labels{label_failure_domain_beta_kubernetes_io_zone="us-east-2c",label_kubernetes_io_hostname="ip-10-0-92-173.us-east-2.compute.internal",label_provider_id="aws"} 1
```

- Accessing the "observe" menu in OCP console, and searching the metric "ocs_node_labels"


The new alert is defined as:

```
jolmomar:~/.../clusters/juanmi0711$ oc -n openshift-storage describe prometheusrule | grep CephMonLowNumber -A9
      Alert:  CephMonLowNumber
      Annotations:
        Description:     The number of node failure zones avail
![cephmonlownumber_alert](https://github.com/red-hat-storage/ocs-operator/assets/1820049/63163d3d-dac6-47c8-af60-a6806ece841a)
able allow to increase the number of Ceph monitors in order to improve cluster resilience.
        Message:         The current number of monitors can be increasedin order to improve cluster resilience
        runbook_url:     https://github.com/openshift/runbooks/blob/master/alerts/CephMonLowNumber.md
        severity_level:  info
        storage_type:    ceph
      Expr:              (count(ceph_mon_metadata)) < (count(count by (label_failure_domain_beta_kubernetes_io_zone, label_provider_id) (ocs_node_labels))) and (count(count by (label_failure_domain_beta_kubernetes_io_zone, label_provider_id) (ocs_node_labels))) >= 5

      Labels:
        Severity:  info
Events:            <none>
```

And can be seen in the UI, in the "Observe/alerting/alerting" rules:

Fixes: [RHSTOR-4919](https://issues.redhat.com//browse/RHSTOR-4919)