### PR TITLE
Bug 2248625: Simplify version comparison for StorageClient Alerts

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -253,15 +253,15 @@ spec:
         message: Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by 1 minor version
         severity_level: warning
       expr: |
-        floor(((ocs_storage_provider_operator_version > 0) - ignoring(storage_consumer_name) group_right() (ocs_storage_client_operator_version > 0)) / 1000) == 1
+        floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) == 1
       labels:
         severity: warning
     - alert: StorageClientIncompatibleOperatorVersion
       annotations:
         description: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version. Client configuration may be incompatible and unsupported
         message: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version
-        severity_level: warning
+        severity_level: critical
       expr: |
-        floor(((ocs_storage_provider_operator_version > 0) - ignoring(storage_consumer_name) group_right() (ocs_storage_client_operator_version > 0)) / 1000) > 1 or floor(((ocs_storage_client_operator_version > 0) - ignoring(storage_consumer_name) group_left() (ocs_storage_provider_operator_version > 0)) / 1000) >= 1
+        floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > 1 or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= 1
       labels:
         severity: critical

--- a/metrics/mixin/alerts/storage-client.libsonnet
+++ b/metrics/mixin/alerts/storage-client.libsonnet
@@ -37,7 +37,7 @@
             # warn if client lags provider by one minor version
             alert: 'StorageClientIncompatibleOperatorVersion',
             expr: |||
-              floor(((ocs_storage_provider_operator_version > 0) - ignoring(storage_consumer_name) group_right() (ocs_storage_client_operator_version > 0)) / 1000) == %(clientOperatorMinorVerDiff)d
+              floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) == %(clientOperatorMinorVerDiff)d
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -50,10 +50,11 @@
           },
           {
             # divide by 1000 here removes patch version
-            # critical if client differs provider by more than one minor version
+            # critical if client lags provider by more than one minor version or
+            # client is ahead of provider
             alert: 'StorageClientIncompatibleOperatorVersion',
             expr: |||
-              floor(((ocs_storage_provider_operator_version > 0) - ignoring(storage_consumer_name) group_right() (ocs_storage_client_operator_version > 0)) / 1000) > %(clientOperatorMinorVerDiff)d or floor(((ocs_storage_client_operator_version > 0) - ignoring(storage_consumer_name) group_left() (ocs_storage_provider_operator_version > 0)) / 1000) >= %(clientOperatorMinorVerDiff)d
+              floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > %(clientOperatorMinorVerDiff)d or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= %(clientOperatorMinorVerDiff)d
             ||| % $._config,
             labels: {
               severity: 'critical',
@@ -61,7 +62,7 @@
             annotations: {
               message: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version' % $._config.clientOperatorMinorVerDiff,
               description: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version. Client configuration may be incompatible and unsupported' % $._config.clientOperatorMinorVerDiff,
-              severity_level: 'warning',
+              severity_level: 'critical',
             },
           },
         ],


### PR DESCRIPTION
- In existing rule division is performed on difference of Version to remove patch version and compare against config
- Above calculation results in unwanted behaviour in some cases and is flaky depending on patch version
- This commit removes the patch version at the start resulting in non-flaky calculations always