### PR TITLE
Revert "Delete a template job after the job gets completed"

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -58,21 +56,6 @@ func (obj *ocsJobTemplates) ensureCreated(r *StorageClusterReconciler, sc *ocsv1
 
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return reconcile.Result{}, fmt.Errorf("failed to create Template : %v", err.Error())
-		}
-
-		// Delete a template job after the job gets completed
-		// This eliminates the need to delete the older/existing job when triggering the job for a second time
-		job := &batchv1.Job{}
-		err = r.Client.Get(r.ctx, client.ObjectKey{Name: fmt.Sprintf("%s-job", template.Name), Namespace: template.Namespace}, job)
-		if err == nil {
-			if job.Status.Succeeded >= 1 {
-				err = r.Client.Delete(r.ctx, job)
-				if err != nil && !errors.IsNotFound(err) {
-					r.Log.Error(err, "Job couldn't be deleted successfully after completion", "Job", klog.KRef(job.Namespace, job.Name))
-				} else {
-					r.Log.Info("Job deleted successfully after completion", "Job", klog.KRef(job.Namespace, job.Name))
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 61bfdd5fabe3530a16c8036d7cbc5aaa93f97c24.

We merged a fix for the original [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1970939) we deleted any completed osd removal job after they were successful, So that while creating another osd removal job a check for the earlier completed job's deletion is not necessary. But we didn't know our docs had these steps where customer using encryption have a step where they depend on the logs of the successful job logs to get the PVC name for the replaced osd. They would use this PVC name to clean up the dmcrypt mapping on the node. 

Updating the docs for so many types of platforms at so many places feels risky & anyway, this fix is not adding much value instead just creating more issues. So we should revert the fix.

Ref-https://bugzilla.redhat.com/show_bug.cgi?id=2248832