### PR TITLE
Bug fix of failed data pool retreival

### DIFF
--- a/controllers/storageclassrequest/storageclassrequest_controller.go
+++ b/controllers/storageclassrequest/storageclassrequest_controller.go
@@ -399,7 +399,7 @@ func (r *StorageClassRequestReconciler) reconcileCephFilesystemSubVolumeGroup(st
 			return err
 		}
 		deviceClass := storageProfile.Spec.DeviceClass
-		dataPool := &rookCephv1.NamedPoolSpec{}
+		var dataPool *rookCephv1.NamedPoolSpec
 		for i := range cephFilesystem.Spec.DataPools {
 			if cephFilesystem.Spec.DataPools[i].DeviceClass == deviceClass {
 				dataPool = &cephFilesystem.Spec.DataPools[i]


### PR DESCRIPTION
While attempting to retrieve a `cephfilesystem`'s data pool that matches the requested profile's device class, the error in case of failure isn't captured properly and gets skipped. ⚠️ Must be merged prior to #2262 