### PR TITLE
Enable MetricsExporter and PrometheusRules on each StorageCluster namespaces

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -134,8 +134,10 @@ rules:
   - events
   - nodes
   - persistentvolumeclaims
+  - persistentvolumes
   - pods
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - '*'
@@ -190,6 +192,15 @@ rules:
   - noobaas
   verbs:
   - '*'
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbucketclaims
+  - objectbuckets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ocs.openshift.io
   resources:
@@ -276,6 +287,21 @@ rules:
   - clusterresourcequotas
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -2,40 +2,95 @@ package storagecluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/imdario/mergo"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/v4/api/v1"
+	"github.com/red-hat-storage/ocs-operator/v4/version"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
-	exporterName         = "ocs-metrics-exporter"
-	portMetrics          = "metrics"
-	portExporter         = "exporter"
-	metricsPath          = "/metrics"
-	rbdMirrorMetricsPath = "/metrics/rbd-mirror"
-	scrapeInterval       = "1m"
+	metricsExporterName     = "ocs-metrics-exporter"
+	metricsExporterRoleName = "ocs-metrics-svc"
+	portMetrics             = "metrics"
+	portExporter            = "exporter"
+	metricsPath             = "/metrics"
+	rbdMirrorMetricsPath    = "/metrics/rbd-mirror"
+	scrapeInterval          = "1m"
+
+	componentLabel = "app.kubernetes.io/component"
+	nameLabel      = "app.kubernetes.io/name"
+	versionLabel   = "app.kubernetes.io/version"
 )
 
 var exporterLabels = map[string]string{
-	"app.kubernetes.io/component": exporterName,
-	"app.kubernetes.io/name":      exporterName,
+	componentLabel: metricsExporterName,
+	nameLabel:      metricsExporterName,
 }
 
-// enableMetricsExporter is a wrapper around CreateOrUpdateService()
-// and CreateOrUpdateServiceMonitor()
-func (r *StorageClusterReconciler) enableMetricsExporter(instance *ocsv1.StorageCluster) error {
-	_, err := CreateOrUpdateService(r, instance)
+// enableMetricsExporter function start metrics exporter deployment
+// and needed services
+func (r *StorageClusterReconciler) enableMetricsExporter(
+	ctx context.Context, instance *ocsv1.StorageCluster) error {
+	// create the needed serviceaccount
+	if err := createMetricsExporterServiceAccount(ctx, r, instance); err != nil {
+		r.Log.Error(err, "unable to create serviceaccount for ocs metrics exporter")
+		return err
+	}
+
+	// create/update clusterrole for metrics exporter
+	if err := updateMetricsExporterClusterRoles(ctx, r, instance); err != nil {
+		r.Log.Error(err, "unable to update clusterroles for metrics exporter")
+		return err
+	}
+
+	// create/update the cluster wide role-bindings for the above serviceaccount
+	if err := updateMetricsExporterClusterRoleBindings(ctx, r, instance); err != nil {
+		r.Log.Error(err, "unable to update rolebindings for metrics exporter")
+		return err
+	}
+
+	// create/update the namespace wise roles
+	if err := createMetricsExporterRoles(ctx, r, instance); err != nil {
+		r.Log.Error(err, "failed to create/update roles for metrics exporter")
+		return err
+	}
+
+	// create/update the rolebindings for the above roles
+	if err := createMetricsExporterRolebindings(ctx, r, instance); err != nil {
+		r.Log.Error(err, "failed to create/update rolebindings for metrics exporter")
+		return err
+	}
+
+	// create/update the config-map needed for the exporter deployment
+	if err := createMetricsExporterConfigMap(ctx, r, instance); err != nil {
+		r.Log.Error(err, "failed to create configmap for metrics exporter")
+		return err
+	}
+
+	// create the metrics exporter deployment
+	if err := deployMetricsExporter(ctx, r, instance); err != nil {
+		r.Log.Error(err, "failed to create ocs-metric-exporter deployment")
+		return err
+	}
+
+	// start the exporter service
+	_, err := createMetricsExporterService(ctx, r, instance)
 	if err != nil {
 		return err
 	}
-	_, err = CreateOrUpdateServiceMonitor(r, instance)
+	// add the servicemonitor
+	_, err = createMetricsExporterServiceMonitor(ctx, r, instance)
 	if err != nil {
 		return err
 	}
@@ -45,7 +100,7 @@ func (r *StorageClusterReconciler) enableMetricsExporter(instance *ocsv1.Storage
 func getMetricsExporterService(instance *ocsv1.StorageCluster) *corev1.Service {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      exporterName,
+			Name:      metricsExporterName,
 			Namespace: instance.Namespace,
 			Labels:    exporterLabels,
 			OwnerReferences: []metav1.OwnerReference{
@@ -88,18 +143,18 @@ func getMetricsExporterService(instance *ocsv1.StorageCluster) *corev1.Service {
 	return service
 }
 
-// CreateOrUpdateService creates service object or an error
-func CreateOrUpdateService(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (*corev1.Service, error) {
+// createMetricsExporterService creates service object or an error
+func createMetricsExporterService(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (*corev1.Service, error) {
 	service := getMetricsExporterService(instance)
 	namespacedName := types.NamespacedName{Namespace: service.GetNamespace(), Name: service.GetName()}
 
 	r.Log.Info("Reconciling metrics exporter service", "NamespacedName", namespacedName)
 
 	oldService := &corev1.Service{}
-	err := r.Client.Get(context.TODO(), namespacedName, oldService)
+	err := r.Client.Get(ctx, namespacedName, oldService)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			err = r.Client.Create(context.TODO(), service)
+			err = r.Client.Create(ctx, service)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create metrics exporter service %v. %v", namespacedName, err)
 			}
@@ -109,7 +164,7 @@ func CreateOrUpdateService(r *StorageClusterReconciler, instance *ocsv1.StorageC
 	}
 	service.ResourceVersion = oldService.ResourceVersion
 	service.Spec.ClusterIP = oldService.Spec.ClusterIP
-	err = r.Client.Update(context.TODO(), service)
+	err = r.Client.Update(ctx, service)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update service %v. %v", namespacedName, err)
 	}
@@ -117,7 +172,6 @@ func CreateOrUpdateService(r *StorageClusterReconciler, instance *ocsv1.StorageC
 }
 
 func getMetricsExporterServiceMonitor(instance *ocsv1.StorageCluster) *monitoringv1.ServiceMonitor {
-
 	// Make a copy of the exporterLabels. Because we use exporterLabels in multiple places
 	// (labels and selector for the ocs-metrics-exporter service, as well as service monitor),
 	// changing the value of labels of a service monitor affects all of them.
@@ -128,24 +182,24 @@ func getMetricsExporterServiceMonitor(instance *ocsv1.StorageCluster) *monitorin
 	}
 
 	// To add storagecluster CR name to the metrics as label: managedBy
-	relabelConfig := monitoringv1.RelabelConfig{
-		TargetLabel: "managedBy",
-		Replacement: instance.Name,
+	relabelConfigs := []*monitoringv1.RelabelConfig{
+		{
+			TargetLabel: "managedBy",
+			Replacement: instance.Name,
+		},
 	}
 
 	serviceMonitor := &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      exporterName,
+			Name:      metricsExporterName,
 			Namespace: instance.Namespace,
 			Labels:    serviceMonitorLabels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: instance.APIVersion,
-					Kind:       instance.Kind,
-					Name:       instance.Name,
-					UID:        instance.UID,
-				},
-			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: instance.APIVersion,
+				Kind:       instance.Kind,
+				Name:       instance.Name,
+				UID:        instance.UID,
+			}},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			NamespaceSelector: monitoringv1.NamespaceSelector{
@@ -159,13 +213,13 @@ func getMetricsExporterServiceMonitor(instance *ocsv1.StorageCluster) *monitorin
 					Port:           portMetrics,
 					Path:           metricsPath,
 					Interval:       scrapeInterval,
-					RelabelConfigs: []*monitoringv1.RelabelConfig{&relabelConfig},
+					RelabelConfigs: relabelConfigs,
 				},
 				{
 					Port:           portMetrics,
 					Path:           rbdMirrorMetricsPath,
 					Interval:       scrapeInterval,
-					RelabelConfigs: []*monitoringv1.RelabelConfig{&relabelConfig},
+					RelabelConfigs: relabelConfigs,
 				},
 				{
 					Port:     portExporter,
@@ -178,8 +232,8 @@ func getMetricsExporterServiceMonitor(instance *ocsv1.StorageCluster) *monitorin
 	return serviceMonitor
 }
 
-// CreateOrUpdateServiceMonitor creates serviceMonitor object or an error
-func CreateOrUpdateServiceMonitor(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (*monitoringv1.ServiceMonitor, error) {
+// createMetricsExporterServiceMonitor creates serviceMonitor object or an error
+func createMetricsExporterServiceMonitor(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (*monitoringv1.ServiceMonitor, error) {
 	serviceMonitor := getMetricsExporterServiceMonitor(instance)
 	namespacedName := types.NamespacedName{Name: serviceMonitor.Name, Namespace: serviceMonitor.Namespace}
 
@@ -191,10 +245,10 @@ func CreateOrUpdateServiceMonitor(r *StorageClusterReconciler, instance *ocsv1.S
 	r.Log.Info("Reconciling metrics exporter service monitor", "NamespacedName", namespacedName)
 
 	oldSm := &monitoringv1.ServiceMonitor{}
-	err = r.Client.Get(context.TODO(), namespacedName, oldSm)
+	err = r.Client.Get(ctx, namespacedName, oldSm)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			err = r.Client.Create(context.TODO(), serviceMonitor)
+			err = r.Client.Create(ctx, serviceMonitor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create metrics exporter servicemonitor %v. %v", namespacedName, err)
 			}
@@ -209,9 +263,528 @@ func CreateOrUpdateServiceMonitor(r *StorageClusterReconciler, instance *ocsv1.S
 		return nil, err
 	}
 
-	err = r.Client.Update(context.TODO(), oldSm)
+	err = r.Client.Update(ctx, oldSm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update metrics exporter servicemonitor %v. %v", namespacedName, err)
 	}
 	return serviceMonitor, nil
+}
+
+func getMetricExporterDeployment(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) *appsv1.Deployment {
+	var (
+		falsePtr                      = new(bool) // defaults to 'false'
+		truePtr                       = new(bool)
+		progressDeadlineSeconds int32 = 600
+		replicas                int32 = 1
+		revisionHistoryLimit    int32 = 1
+		maxSurge                      = intstr.Parse("25%")
+		maxUnavailable                = intstr.Parse("25%")
+	)
+	*truePtr = true
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      metricsExporterName,
+			Namespace: instance.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         instance.APIVersion,
+				BlockOwnerDeletion: falsePtr,
+				Controller:         falsePtr,
+				Kind:               instance.Kind,
+				Name:               instance.Name,
+				UID:                instance.UID,
+			}},
+			Labels: map[string]string{
+				componentLabel: exporterLabels[componentLabel],
+				nameLabel:      exporterLabels[nameLabel],
+				versionLabel:   version.Version,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			ProgressDeadlineSeconds: &progressDeadlineSeconds,
+			Replicas:                &replicas,
+			RevisionHistoryLimit:    &revisionHistoryLimit,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: exporterLabels,
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						componentLabel: exporterLabels[componentLabel],
+						nameLabel:      exporterLabels[nameLabel],
+						versionLabel:   version.Version,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Args:    []string{"--namespaces", instance.Namespace},
+						Command: []string{"/usr/local/bin/metrics-exporter"},
+						Image:   r.images.OCSMetricsExporter,
+						Name:    metricsExporterName,
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: 8080},
+							{ContainerPort: 8081},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: truePtr,
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "ceph-config",
+							MountPath: "/etc/ceph",
+						}},
+					}},
+					ServiceAccountName: metricsExporterName,
+					Volumes: []corev1.Volume{{
+						Name: "ceph-config",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "ocs-metrics-exporter-ceph-conf",
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	return dep
+}
+
+func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	expectedDep := getMetricExporterDeployment(r, instance)
+	namespacedName := types.NamespacedName{
+		Name:      expectedDep.Name,
+		Namespace: expectedDep.Namespace,
+	}
+	r.Log.Info("Deploying metrics exporter", "NamespacedName", namespacedName)
+
+	currentDep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      expectedDep.Name,
+			Namespace: expectedDep.Namespace,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentDep, func() error {
+		currentDep.ResourceVersion = expectedDep.ResourceVersion
+		var currentImage string
+		var currentOwner metav1.OwnerReference
+		if len(currentDep.Spec.Template.Spec.Containers) > 0 {
+			currentImage = currentDep.Spec.Template.Spec.Containers[0].Image
+			// log if the images are different
+			if currentImage != expectedDep.Spec.Template.Spec.Containers[0].Image {
+				r.Log.Info("Different container image specified in the exporter deployment",
+					"CurrentImage", currentImage,
+					"DefaultImage", expectedDep.Spec.Template.Spec.Containers[0].Image)
+			}
+		} else {
+			currentImage = expectedDep.Spec.Template.Spec.Containers[0].Image
+		}
+		if len(currentDep.OwnerReferences) > 0 {
+			currentDep.OwnerReferences[0].DeepCopyInto(&currentOwner)
+		} else {
+			expectedDep.OwnerReferences[0].DeepCopyInto(&currentOwner)
+		}
+		if currentDep.Labels == nil {
+			currentDep.Labels = make(map[string]string)
+		}
+		for lKey, lValue := range expectedDep.Labels {
+			currentDep.Labels[lKey] = lValue
+		}
+		expectedDep.Spec.DeepCopyInto(&currentDep.Spec)
+		if len(currentDep.OwnerReferences) == 0 {
+			currentDep.OwnerReferences = make([]metav1.OwnerReference, 1)
+		}
+		// set the image and ownerref back to the current deployment
+		currentDep.Spec.Template.Spec.Containers[0].Image = currentImage
+		if currentOwner.APIVersion != "" && currentOwner.Kind != "" && currentOwner.Name != "" &&
+			currentOwner.UID != "" {
+			currentOwner.DeepCopyInto(&currentDep.OwnerReferences[0])
+		}
+		return nil
+	}); err != nil {
+		r.Log.Error(err, "failed to create/update metrics exporter deployment", "NamespacedName", namespacedName)
+		return err
+	}
+	return nil
+}
+
+func createMetricsExporterServiceAccount(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	expectedServiceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      metricsExporterName,
+			Namespace: instance.Namespace,
+			Labels: map[string]string{
+				componentLabel: exporterLabels[componentLabel],
+				nameLabel:      exporterLabels[nameLabel],
+				versionLabel:   version.Version,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: instance.APIVersion,
+				Kind:       instance.Kind,
+				Name:       instance.Name,
+				UID:        instance.UID,
+			}},
+		},
+	}
+	currentServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      expectedServiceAccount.Name,
+			Namespace: expectedServiceAccount.Namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentServiceAccount, func() error {
+		if len(currentServiceAccount.OwnerReferences) == 0 {
+			currentServiceAccount.OwnerReferences = make([]metav1.OwnerReference, 1)
+		}
+		currentOwner := &currentServiceAccount.OwnerReferences[0]
+		// if any of the ownerref criteria is not satisfied,
+		// set to the expected SA owenerref
+		if currentOwner.APIVersion == "" || currentOwner.Kind == "" ||
+			currentOwner.Name == "" || currentOwner.UID == "" {
+			currentServiceAccount.OwnerReferences[0] = expectedServiceAccount.OwnerReferences[0]
+		}
+		return nil
+	})
+	return err
+}
+
+// updateMetricsExporterClusterRoleBindings function updates the
+// cluster level rolebindings for the metrics exporter in this namespace
+func updateMetricsExporterClusterRoleBindings(ctx context.Context,
+	r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	currentCRB := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
+		Name: metricsExporterName,
+	}}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentCRB, func() error {
+		currentCRB.RoleRef.Name = metricsExporterName
+		currentCRB.RoleRef.Kind = "ClusterRole"
+		currentCRB.RoleRef.APIGroup = "rbac.authorization.k8s.io"
+		subjectNotFound := true
+		expectedSubject := rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      metricsExporterName,
+			Namespace: instance.Namespace,
+		}
+		for _, subject := range currentCRB.Subjects {
+			if subject.Kind == expectedSubject.Kind &&
+				subject.Name == expectedSubject.Name &&
+				subject.Namespace == expectedSubject.Namespace {
+				subjectNotFound = false
+				break
+			}
+		}
+		if subjectNotFound {
+			currentCRB.Subjects = append(currentCRB.Subjects, expectedSubject)
+		}
+		return nil
+	})
+	return err
+}
+
+func createMetricsExporterConfigMap(ctx context.Context,
+	r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	configMapName := "ocs-metrics-exporter-ceph-conf"
+	currentConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: instance.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: instance.APIVersion,
+				Kind:       instance.Kind,
+				Name:       instance.Name,
+				UID:        instance.UID,
+			}},
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentConfigMap, func() error {
+		currentConfigMap.Data = map[string]string{
+			"ceph.conf": `
+[global]
+auth_cluster_required = cephx
+auth_service_required = cephx
+auth_client_required = cephx
+`,
+			// keyring is a required key and its value should be empty
+			"keyring": "",
+		}
+		return nil
+	})
+	return err
+}
+
+const metricsExporterClusterRoleJSON = `
+{
+	"apiVersion":"rbac.authorization.k8s.io/v1",
+	"kind":"ClusterRole",
+	"metadata":{"name":"ocs-metrics-exporter"},
+	"rules":[
+		{
+			"apiGroups":[""],
+			"resources":["persistentvolumes","nodes"],
+			"verbs":["get","list","watch"]
+		},
+		{
+			"apiGroups":["quota.openshift.io"],
+			"resources":["clusterresourcequotas"],
+			"verbs":["get","list","watch"]
+		},
+		{
+			"apiGroups":["storage.k8s.io"],
+			"resources":["storageclasses"],
+			"verbs":["get","list","watch"]
+		},
+		{
+			"apiGroups":["objectbucket.io"],
+			"resources":["objectbuckets"],
+			"verbs":["get","list"]
+		}
+	]
+}`
+
+func updateMetricsExporterClusterRoles(ctx context.Context,
+	r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	currentClusterRole := new(rbacv1.ClusterRole)
+	var expectedClusterRole = new(rbacv1.ClusterRole)
+	err := json.Unmarshal([]byte(metricsExporterClusterRoleJSON), expectedClusterRole)
+	if err != nil {
+		r.Log.Error(err, "an unexpected error occurred while unmarshalling clusterrole yaml")
+		return err
+	}
+	expectedClusterRole.Name, currentClusterRole.Name = metricsExporterName, metricsExporterName
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, currentClusterRole, func() error {
+		expectedRulesLen := len(expectedClusterRole.Rules)
+		if len(currentClusterRole.Rules) != expectedRulesLen {
+			currentClusterRole.Rules = make([]rbacv1.PolicyRule, expectedRulesLen)
+		}
+		copy(currentClusterRole.Rules, expectedClusterRole.Rules)
+		return nil
+	})
+	return err
+}
+
+const expectedPrometheusK8RoleJSON = `
+{
+	"apiVersion":"rbac.authorization.k8s.io/v1",
+	"kind":"Role",
+	"metadata":{"name":"ocs-metrics-svc"},
+	"rules":[
+		{
+			"apiGroups":[""],
+			"resources":["services","endpoints","pods"],
+			"verbs":["get","list","watch"]
+		},
+		{
+			"apiGroups":[""],
+			"resources":["persistentvolumeclaims","pods","configmaps","secrets"],
+			"verbs":["get","list","watch"]
+		}
+	]
+}
+`
+
+const expectedMetricExporterRoleJSON = `
+{
+	"apiVersion":"rbac.authorization.k8s.io/v1",
+	"kind":"Role",
+	"metadata":{"name":"ocs-metrics-exporter"},
+	"rules":[
+		{
+			"apiGroups":[""],
+			"resources":["secrets","configmaps"],
+			"verbs":["get","list","watch"]
+		},
+		{
+			"apiGroups":["monitoring.coreos.com"],
+			"resources":["prometheusrules","servicemonitors"],
+			"verbs":["get","list","watch","create","update","delete"]
+		},
+		{
+			"apiGroups":["ceph.rook.io"],
+			"resources":["cephobjectstores","cephclusters","cephblockpools","cephrbdmirrors"],
+			"verbs":["get","list","watch"]
+		},
+		{
+			"apiGroups":["objectbucket.io"],
+			"resources":["objectbucketclaims"],
+			"verbs":["get","list"]
+		},
+		{
+			"apiGroups":["ocs.openshift.io"],
+			"resources":["storageconsumers","storageclusters"],
+			"verbs":["get","list","watch"]
+		}
+	]
+}
+`
+
+func createMetricsExporterRoles(ctx context.Context,
+	r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	// create/update prometheus server needed roles
+	var expectedRole = new(rbacv1.Role)
+	err := json.Unmarshal([]byte(expectedPrometheusK8RoleJSON), expectedRole)
+	if err != nil {
+		r.Log.Error(err, "an unexpected error occurred while unmarshalling prometheus role")
+		return err
+	}
+	currentRole := new(rbacv1.Role)
+	expectedRole.Name, currentRole.Name = metricsExporterRoleName, metricsExporterRoleName
+	expectedRole.Namespace, currentRole.Namespace = instance.Namespace, instance.Namespace
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, currentRole, func() error {
+		expectedRulesLen := len(expectedRole.Rules)
+		if len(currentRole.Rules) != expectedRulesLen {
+			currentRole.Rules = make([]rbacv1.PolicyRule, expectedRulesLen)
+		}
+		copy(currentRole.Rules, expectedRole.Rules)
+		currentRole.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: instance.APIVersion,
+			Kind:       instance.Kind,
+			Name:       instance.Name,
+			UID:        instance.UID,
+		}}
+		return nil
+	})
+	if err != nil {
+		r.Log.Error(err, "failed to create/update prometheus roles")
+		return err
+	}
+
+	// create/update metrics exporter roles
+	expectedRole = new(rbacv1.Role)
+	err = json.Unmarshal([]byte(expectedMetricExporterRoleJSON), expectedRole)
+	if err != nil {
+		r.Log.Error(err, "an unexpected error occurred while unmarshalling metrics exporter role")
+		return err
+	}
+	currentRole = new(rbacv1.Role)
+	expectedRole.Name, currentRole.Name = metricsExporterName, metricsExporterName
+	expectedRole.Namespace, currentRole.Namespace = instance.Namespace, instance.Namespace
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, currentRole, func() error {
+		expectedRulesLen := len(expectedRole.Rules)
+		if len(currentRole.Rules) != expectedRulesLen {
+			currentRole.Rules = make([]rbacv1.PolicyRule, expectedRulesLen)
+		}
+		copy(currentRole.Rules, expectedRole.Rules)
+		currentRole.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: instance.APIVersion,
+			Kind:       instance.Kind,
+			Name:       instance.Name,
+			UID:        instance.UID,
+		}}
+		return nil
+	})
+
+	return err
+}
+
+const expectedPrometheusK8RoleBindingJSON = `
+{
+	"apiVersion":"rbac.authorization.k8s.io/v1",
+	"kind":"RoleBinding",
+	"metadata":{"name":"ocs-metrics-svc"},
+	"roleRef":{
+		"apiGroup":"rbac.authorization.k8s.io",
+		"kind":"Role",
+		"name":"ocs-metrics-svc"
+	},
+	"subjects":[
+		{
+			"kind":"ServiceAccount",
+			"name":"prometheus-k8s",
+			"namespace":"openshift-monitoring"
+		}
+	]
+}`
+
+// expectedMetricsExporterRoleBindingJSON rolebindings for metrics exporter
+// it doesn't contain 'subject' part, which is added in the create code below
+const expectedMetricsExporterRoleBindingJSON = `
+{
+	"apiVersion":"rbac.authorization.k8s.io/v1",
+	"kind":"RoleBinding",
+	"metadata":{"name":"ocs-metrics-exporter"},
+	"roleRef":{
+		"apiGroup":"rbac.authorization.k8s.io",
+		"kind":"Role",
+		"name":"ocs-metrics-exporter"
+	}
+}`
+
+func createMetricsExporterRolebindings(ctx context.Context,
+	r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	// rolebinding for prometheus
+	var expectedRoleBinding = new(rbacv1.RoleBinding)
+	err := json.Unmarshal([]byte(expectedPrometheusK8RoleBindingJSON), expectedRoleBinding)
+	if err != nil {
+		r.Log.Error(err,
+			"an unexpected error occurred while unmarshalling prometheus rolebinding")
+		return err
+	}
+	currentRoleBinding := new(rbacv1.RoleBinding)
+	expectedRoleBinding.Name, currentRoleBinding.Name = metricsExporterRoleName, metricsExporterRoleName
+	expectedRoleBinding.Namespace, currentRoleBinding.Namespace = instance.Namespace, instance.Namespace
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, currentRoleBinding, func() error {
+		currentRoleBinding.RoleRef.APIGroup = expectedRoleBinding.RoleRef.APIGroup
+		currentRoleBinding.RoleRef.Kind = expectedRoleBinding.RoleRef.Kind
+		currentRoleBinding.RoleRef.Name = expectedRoleBinding.RoleRef.Name
+		expectedSubjectsLen := len(expectedRoleBinding.Subjects)
+		if len(currentRoleBinding.Subjects) != expectedSubjectsLen {
+			currentRoleBinding.Subjects = make([]rbacv1.Subject, expectedSubjectsLen)
+		}
+		copy(currentRoleBinding.Subjects, expectedRoleBinding.Subjects)
+		currentRoleBinding.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: instance.APIVersion,
+			Kind:       instance.Kind,
+			Name:       instance.Name,
+			UID:        instance.UID,
+		}}
+		return nil
+	})
+	if err != nil {
+		r.Log.Error(err, "error while create/update prometheus rolebindings")
+		return err
+	}
+
+	// rolebinding for metrics exporter
+	expectedRoleBinding = new(rbacv1.RoleBinding)
+	err = json.Unmarshal([]byte(expectedMetricsExporterRoleBindingJSON), expectedRoleBinding)
+	if err != nil {
+		r.Log.Error(err,
+			"an unexpected error occurred while unmarshalling metrics exporter rolebinding")
+		return err
+	}
+	currentRoleBinding = new(rbacv1.RoleBinding)
+	expectedRoleBinding.Name, currentRoleBinding.Name = metricsExporterName, metricsExporterName
+	expectedRoleBinding.Namespace, currentRoleBinding.Namespace = instance.Namespace, instance.Namespace
+
+	expectedRoleBinding.Subjects = make([]rbacv1.Subject, 1)
+	expectedRoleBinding.Subjects[0].Kind = "ServiceAccount"
+	expectedRoleBinding.Subjects[0].Name = metricsExporterName
+	expectedRoleBinding.Subjects[0].Namespace = instance.Namespace
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, currentRoleBinding, func() error {
+		currentRoleBinding.RoleRef.APIGroup = expectedRoleBinding.RoleRef.APIGroup
+		currentRoleBinding.RoleRef.Kind = expectedRoleBinding.RoleRef.Kind
+		currentRoleBinding.RoleRef.Name = expectedRoleBinding.RoleRef.Name
+		expectedSubjectsLen := len(expectedRoleBinding.Subjects)
+		if len(currentRoleBinding.Subjects) != expectedSubjectsLen {
+			currentRoleBinding.Subjects = make([]rbacv1.Subject, expectedSubjectsLen)
+		}
+		copy(currentRoleBinding.Subjects, expectedRoleBinding.Subjects)
+		currentRoleBinding.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: instance.APIVersion,
+			Kind:       instance.Kind,
+			Name:       instance.Name,
+			UID:        instance.UID,
+		}}
+		return nil
+	})
+
+	return err
 }

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -38,6 +38,7 @@ func (r *StorageClusterReconciler) initializeImageVars() error {
 	r.images.Ceph = os.Getenv("CEPH_IMAGE")
 	r.images.NooBaaCore = os.Getenv("NOOBAA_CORE_IMAGE")
 	r.images.NooBaaDB = os.Getenv("NOOBAA_DB_IMAGE")
+	r.images.OCSMetricsExporter = os.Getenv("OCS_METRICS_EXPORTER_IMAGE")
 
 	if r.images.Ceph == "" {
 		err := fmt.Errorf("CEPH_IMAGE environment variable not found")
@@ -50,6 +51,10 @@ func (r *StorageClusterReconciler) initializeImageVars() error {
 	} else if r.images.NooBaaDB == "" {
 		err := fmt.Errorf("NOOBAA_DB_IMAGE environment variable not found")
 		r.Log.Error(err, "Missing NOOBAA_DB_IMAGE environment variable for ocs initialization.")
+		return err
+	} else if r.images.OCSMetricsExporter == "" {
+		err := fmt.Errorf("OCS_METRICS_EXPORTER_IMAGE environment variable not found")
+		r.Log.Error(err, "Missing OCS_METRICS_EXPORTER_IMAGE environment variable for ocs initialization.")
 		return err
 	}
 	return nil
@@ -71,9 +76,10 @@ func (r *StorageClusterReconciler) initializeServerVersion() error {
 
 // ImageMap holds mapping information between component image name and the image url
 type ImageMap struct {
-	Ceph       string
-	NooBaaCore string
-	NooBaaDB   string
+	Ceph               string
+	NooBaaCore         string
+	NooBaaDB           string
+	OCSMetricsExporter string
 }
 
 // StorageClusterReconciler reconciles a StorageCluster object

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -286,8 +286,10 @@ spec:
           - events
           - nodes
           - persistentvolumeclaims
+          - persistentvolumes
           - pods
           - secrets
+          - serviceaccounts
           - services
           verbs:
           - '*'
@@ -342,6 +344,15 @@ spec:
           - noobaas
           verbs:
           - '*'
+        - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbucketclaims
+          - objectbuckets
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ocs.openshift.io
           resources:
@@ -428,6 +439,21 @@ spec:
           - clusterresourcequotas
           verbs:
           - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - route.openshift.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2006,8 +2006,10 @@ spec:
           - events
           - nodes
           - persistentvolumeclaims
+          - persistentvolumes
           - pods
           - secrets
+          - serviceaccounts
           - services
           verbs:
           - '*'
@@ -2062,6 +2064,15 @@ spec:
           - noobaas
           verbs:
           - '*'
+        - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbucketclaims
+          - objectbuckets
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ocs.openshift.io
           resources:
@@ -2148,6 +2159,21 @@ spec:
           - clusterresourcequotas
           verbs:
           - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - route.openshift.io
           resources:

--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -67,8 +67,8 @@ spec:
     rules:
     - alert: ObcQuotaBytesAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
-        message: OBC has crossed 80% of the quota(bytes).
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
+        message: OBC has crossed 80% of the quota(bytes) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaBytesAlert.md
         severity_level: warning
         storage_type: RGW
@@ -79,8 +79,8 @@ spec:
         severity: warning
     - alert: ObcQuotaObjectsAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
-        message: OBC has crossed 80% of the quota(object).
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
+        message: OBC has crossed 80% of the quota(object) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: warning
         storage_type: RGW
       expr: |
@@ -90,8 +90,8 @@ spec:
         severity: warning
     - alert: ObcQuotaBytesExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
-        message: OBC reached quota(bytes) limit.
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
+        message: OBC reached quota(bytes) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: RGW
       expr: |
@@ -101,8 +101,8 @@ spec:
         severity: critical
     - alert: ObcQuotaObjectsExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
-        message: OBC reached quota(object) limit.
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
+        message: OBC reached quota(object) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: RGW
       expr: |
@@ -114,8 +114,8 @@ spec:
     rules:
     - alert: ClusterObjectStoreState
       annotations:
-        description: Cluster Object Store is in unhealthy state for more than 15s. Please check Ceph cluster health or RGW connection.
-        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection.
+        description: Cluster Object Store is in unhealthy state for more than 15s. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: RGW
       expr: |
@@ -127,8 +127,8 @@ spec:
     rules:
     - alert: KMSServerConnectionAlert
       annotations:
-        description: Storage Cluster KMS Server is in un-connected state for more than 5s. Please check KMS config.
-        message: Storage Cluster KMS Server is in un-connected state. Please check KMS config.
+        description: Storage Cluster KMS Server is in un-connected state for more than 5s. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Storage Cluster KMS Server is in un-connected state. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: ceph
       expr: |

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -67,8 +67,8 @@ spec:
     rules:
     - alert: OdfMirrorDaemonStatus
       annotations:
-        description: Mirror daemon is in unhealthy status for more than 1m. Mirroring on this cluster is not working as expected.
-        message: Mirror daemon is unhealthy.
+        description: Mirror daemon is in unhealthy status for more than 1m. Mirroring is not working as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Mirror daemon is unhealthy in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfMirrorDaemonStatus.md
         severity_level: error
         storage_type: ceph
@@ -79,8 +79,8 @@ spec:
         severity: critical
     - alert: OdfPoolMirroringImageHealth
       annotations:
-        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state for more than 1m. Mirroring might not work as expected.
-        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state.
+        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state for more than 1m. Mirroring might not work as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfPoolMirroringImageHealth.md
         severity_level: warning
         storage_type: ceph
@@ -92,8 +92,8 @@ spec:
         severity: warning
     - alert: OdfPoolMirroringImageHealth
       annotations:
-        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for more than 1m. Mirroring might not work as expected.
-        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state.
+        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for more than 1m. Mirroring might not work as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: warning
         storage_type: ceph
       expr: |
@@ -104,8 +104,8 @@ spec:
         severity: warning
     - alert: OdfPoolMirroringImageHealth
       annotations:
-        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for more than 10s. Mirroring is not working as expected.
-        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state.
+        description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for more than 10s. Mirroring is not working as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: ceph
       expr: |
@@ -116,8 +116,8 @@ spec:
         severity: critical
     - alert: ODFPersistentVolumeMirrorStatus
       annotations:
-        description: Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }} for more than 1m. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}.
-        message: Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }}.
+        description: Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }} for more than 1m. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}. Please check namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFPersistentVolumeMirrorStatus.md
         severity_level: error
         storage_type: ceph
@@ -128,8 +128,8 @@ spec:
         severity: critical
     - alert: ODFPersistentVolumeMirrorStatus
       annotations:
-        description: Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} to peer site {{ $labels.site_name }} for more than 1m. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}.
-        message: Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} mirroring to peer site {{ $labels.site_name }}.
+        description: Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} to peer site {{ $labels.site_name }} for more than 1m. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}. Please check namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}
+        message: Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} mirroring to peer site {{ $labels.site_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: warning
         storage_type: ceph
       expr: |
@@ -141,8 +141,8 @@ spec:
     rules:
     - alert: ObcQuotaBytesAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
-        message: OBC has crossed 80% of the quota(bytes).
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
+        message: OBC has crossed 80% of the quota(bytes) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaBytesAlert.md
         severity_level: warning
         storage_type: RGW
@@ -153,8 +153,8 @@ spec:
         severity: warning
     - alert: ObcQuotaObjectsAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
-        message: OBC has crossed 80% of the quota(object).
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
+        message: OBC has crossed 80% of the quota(object) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: warning
         storage_type: RGW
       expr: |
@@ -164,8 +164,8 @@ spec:
         severity: warning
     - alert: ObcQuotaBytesExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
-        message: OBC reached quota(bytes) limit.
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
+        message: OBC reached quota(bytes) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: RGW
       expr: |
@@ -175,8 +175,8 @@ spec:
         severity: critical
     - alert: ObcQuotaObjectsExhausedAlert
       annotations:
-        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
-        message: OBC reached quota(object) limit.
+        description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
+        message: OBC reached quota(object) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: RGW
       expr: |
@@ -188,8 +188,8 @@ spec:
     rules:
     - alert: ClusterObjectStoreState
       annotations:
-        description: RGW endpoint of the Ceph object store is in a failure state or one or more Rook Ceph RGW deployments have fewer ready replicas than required for more than 15s. Please check the health of the Ceph cluster and the deployments.
-        message: Cluster Object Store is in unhealthy state or number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas.
+        description: RGW endpoint of the Ceph object store is in a failure state or one or more Rook Ceph RGW deployments have fewer ready replicas than required for more than 15s. Please check the health of the Ceph cluster and the deployments in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Cluster Object Store is in unhealthy state or number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: error
         storage_type: RGW
       expr: |
@@ -203,8 +203,8 @@ spec:
     rules:
     - alert: ODFRBDClientBlocked
       annotations:
-        description: An RBD client might be blocked by Ceph on node {{ $labels.node_name }}. This alert is triggered when the ocs_rbd_client_blocklisted metric reports a value of 1 for the node and there are pods in a CreateContainerError state on the node. This may cause the filesystem for the PVCs to be in a read-only state. Please check the pod description for more details.
-        message: An RBD client might be blocked by Ceph on node {{ $labels.node_name }}.
+        description: An RBD client might be blocked by Ceph on node {{ $labels.node_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. This alert is triggered when the ocs_rbd_client_blocklisted metric reports a value of 1 for the node and there are pods in a CreateContainerError state on the node. This may cause the filesystem for the PVCs to be in a read-only state. Please check the pod description for more details.
+        message: An RBD client might be blocked by Ceph on node {{ $labels.node_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFRBDClientBlocked.md
         severity_level: error
       expr: |
@@ -223,8 +223,8 @@ spec:
     rules:
     - alert: KMSServerConnectionAlert
       annotations:
-        description: Storage Cluster KMS Server is in un-connected state for more than 5s. Please check KMS config.
-        message: Storage Cluster KMS Server is in un-connected state. Please check KMS config.
+        description: Storage Cluster KMS Server is in un-connected state for more than 5s. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Storage Cluster KMS Server is in un-connected state. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/KMSServerConnectionAlert.md
         severity_level: error
         storage_type: ceph
@@ -237,8 +237,8 @@ spec:
     rules:
     - alert: StorageClientHeartbeatMissed
       annotations:
-        description: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 120 (s). Lossy network connectivity might exist
-        message: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 120 (s)
+        description: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 120 (s). Lossy network connectivity might exist in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 120 (s) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: warning
       expr: |
         (time() - 120) > (ocs_storage_client_last_heartbeat > 0)
@@ -246,8 +246,8 @@ spec:
         severity: warning
     - alert: StorageClientHeartbeatMissed
       annotations:
-        description: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 300 (s). Client might have lost internet connectivity
-        message: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 300 (s)
+        description: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 300 (s). Client might have lost internet connectivity in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than 300 (s) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: critical
       expr: |
         (time() - 300) > (ocs_storage_client_last_heartbeat > 0)
@@ -255,8 +255,8 @@ spec:
         severity: critical
     - alert: StorageClientIncompatibleOperatorVersion
       annotations:
-        description: Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by 1 minor version. Client configuration may be incompatible
-        message: Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by 1 minor version
+        description: Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by 1 minor version. Client configuration may be incompatible in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by 1 minor version in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: warning
       expr: |
         floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) == 1
@@ -264,8 +264,8 @@ spec:
         severity: warning
     - alert: StorageClientIncompatibleOperatorVersion
       annotations:
-        description: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version. Client configuration may be incompatible and unsupported
-        message: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version
+        description: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version. Client configuration may be incompatible and unsupported in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        message: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         severity_level: critical
       expr: |
         floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > 1 or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= 1

--- a/metrics/internal/collectors/ceph-block-pool.go
+++ b/metrics/internal/collectors/ceph-block-pool.go
@@ -6,7 +6,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	cephv1listers "github.com/rook/rook/pkg/client/listers/ceph.rook.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -35,7 +34,7 @@ func NewCephBlockPoolCollector(opts *options.Options) *CephBlockPoolCollector {
 		klog.Error(err)
 	}
 
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephblockpools", metav1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephblockpools", searchInNamespace(opts), fields.Everything())
 	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &cephv1.CephBlockPool{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 	return &CephBlockPoolCollector{

--- a/metrics/internal/collectors/ceph-cluster.go
+++ b/metrics/internal/collectors/ceph-cluster.go
@@ -41,7 +41,7 @@ func NewCephClusterCollector(opts *options.Options) *CephClusterCollector {
 		klog.Error(err)
 	}
 
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephclusters", metav1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephclusters", searchInNamespace(opts), fields.Everything())
 	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &cephv1.CephCluster{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 	return &CephClusterCollector{

--- a/metrics/internal/collectors/ceph-object-store.go
+++ b/metrics/internal/collectors/ceph-object-store.go
@@ -6,7 +6,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	cephv1listers "github.com/rook/rook/pkg/client/listers/ceph.rook.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -153,7 +152,7 @@ func CephObjectStoreInformer(opts *options.Options) cache.SharedIndexInformer {
 		return nil
 	}
 
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephobjectstores", metav1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephobjectstores", searchInNamespace(opts), fields.Everything())
 	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &cephv1.CephObjectStore{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	return sharedIndexInformer
 }

--- a/metrics/internal/collectors/cluster-advance-feature-use.go
+++ b/metrics/internal/collectors/cluster-advance-feature-use.go
@@ -8,7 +8,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	cephv1listers "github.com/rook/rook/pkg/client/listers/ceph.rook.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -41,8 +40,8 @@ func (c *CephClusterAdvancedFeatureProvider) AdvancedFeature(namespaces ...strin
 	return 0
 }
 
-func NewCephClusterAdvancedFeatureProvider(client *rookclient.Clientset) AdvancedFeatureProvider {
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephclusters", metav1.NamespaceAll, fields.Everything())
+func NewCephClusterAdvancedFeatureProvider(opts *options.Options, client *rookclient.Clientset) AdvancedFeatureProvider {
+	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephclusters", searchInNamespace(opts), fields.Everything())
 	return &CephClusterAdvancedFeatureProvider{
 		SharedIndexInformer: cache.NewSharedIndexInformer(lw, &cephv1.CephCluster{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
 	}
@@ -66,8 +65,8 @@ func (c *CephObjectStoreAdvancedFeatureProvider) AdvancedFeature(namespaces ...s
 	return 0
 }
 
-func NewCephObjectStoreAdvancedFeatureProvider(client *rookclient.Clientset) AdvancedFeatureProvider {
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephobjectstores", metav1.NamespaceAll, fields.Everything())
+func NewCephObjectStoreAdvancedFeatureProvider(opts *options.Options, client *rookclient.Clientset) AdvancedFeatureProvider {
+	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephobjectstores", searchInNamespace(opts), fields.Everything())
 	return &CephObjectStoreAdvancedFeatureProvider{
 		SharedIndexInformer: cache.NewSharedIndexInformer(lw, &cephv1.CephObjectStore{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
 	}
@@ -88,9 +87,11 @@ func (s *StorageClassAdvancedFeatureProvider) AdvancedFeature(namespaces ...stri
 	return 0
 }
 
-func NewStorageClassAdvancedFeatureProvider(client *kubernetes.Clientset) AdvancedFeatureProvider {
+func NewStorageClassAdvancedFeatureProvider(opts *options.Options, client *kubernetes.Clientset) AdvancedFeatureProvider {
 	storageclassClient := client.StorageV1()
-	lw := cache.NewListWatchFromClient(storageclassClient.RESTClient(), "storageclasses", metav1.NamespaceAll, fields.Everything())
+	// for any cluster-scoped resource,
+	// pass a 'nil' option to 'searchInNamespace()' function to get 'NamespaceAll'
+	lw := cache.NewListWatchFromClient(storageclassClient.RESTClient(), "storageclasses", searchInNamespace(nil), fields.Everything())
 	return &StorageClassAdvancedFeatureProvider{
 		SharedIndexInformer: cache.NewSharedIndexInformer(lw, &storagev1.StorageClass{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
 	}
@@ -111,8 +112,8 @@ func (c *CephRBDMirrorAdvancedFeatureProvider) AdvancedFeature(namespaces ...str
 	return 0
 }
 
-func NewCephRBDMirrorAdvancedFeatureProvider(client *rookclient.Clientset) AdvancedFeatureProvider {
-	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephrbdmirrors", metav1.NamespaceAll, fields.Everything())
+func NewCephRBDMirrorAdvancedFeatureProvider(opts *options.Options, client *rookclient.Clientset) AdvancedFeatureProvider {
+	lw := cache.NewListWatchFromClient(client.CephV1().RESTClient(), "cephrbdmirrors", searchInNamespace(opts), fields.Everything())
 	return &CephRBDMirrorAdvancedFeatureProvider{
 		SharedIndexInformer: cache.NewSharedIndexInformer(lw, &cephv1.CephRBDMirror{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
 	}
@@ -140,14 +141,14 @@ func NewClusterAdvancedFeatureCollector(opts *options.Options) *ClusterAdvanceFe
 	}
 
 	advFeatureProviders := []AdvancedFeatureProvider{
-		NewCephClusterAdvancedFeatureProvider(client),
-		NewCephObjectStoreAdvancedFeatureProvider(client),
-		NewCephRBDMirrorAdvancedFeatureProvider(client),
+		NewCephClusterAdvancedFeatureProvider(opts, client),
+		NewCephObjectStoreAdvancedFeatureProvider(opts, client),
+		NewCephRBDMirrorAdvancedFeatureProvider(opts, client),
 	}
 
 	if k8Client, err := kubernetes.NewForConfig(opts.Kubeconfig); err == nil {
 		advFeatureProviders = append(
-			advFeatureProviders, NewStorageClassAdvancedFeatureProvider(k8Client))
+			advFeatureProviders, NewStorageClassAdvancedFeatureProvider(opts, k8Client))
 	} else { // logging any error occurred
 		klog.Errorf("unable to get K8 Client, no StorageClass information available: %v", err)
 	}

--- a/metrics/internal/collectors/storage-cluster.go
+++ b/metrics/internal/collectors/storage-cluster.go
@@ -2,7 +2,6 @@ package collectors
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -25,7 +24,7 @@ func NewStorageClusterCollector(opts *options.Options) *StorageClusterCollector 
 		klog.Errorf("Unable to get client: %v", err)
 		return nil
 	}
-	lw := cache.NewListWatchFromClient(cl, "storageclusters", metav1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(cl, "storageclusters", searchInNamespace(opts), fields.Everything())
 	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &v1.StorageCluster{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	return &StorageClusterCollector{
 		KMSServerConnectionStatus: prometheus.NewDesc(

--- a/metrics/internal/collectors/storageconsumer.go
+++ b/metrics/internal/collectors/storageconsumer.go
@@ -10,7 +10,6 @@ import (
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/v4/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/metrics/internal/options"
 	"github.com/red-hat-storage/ocs-operator/v4/metrics/internal/version"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -34,7 +33,7 @@ func NewStorageConsumerCollector(opts *options.Options) *StorageConsumerCollecto
 		klog.Error(err)
 		return nil
 	}
-	lw := cache.NewListWatchFromClient(ocsClient, "storageconsumers", metav1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(ocsClient, "storageconsumers", searchInNamespace(opts), fields.Everything())
 	sharedIndexInformer := cache.NewSharedIndexInformer(lw, &ocsv1alpha1.StorageConsumer{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 	return &StorageConsumerCollector{

--- a/metrics/mixin/alerts/blocklist.libsonnet
+++ b/metrics/mixin/alerts/blocklist.libsonnet
@@ -21,8 +21,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'An RBD client might be blocked by Ceph on node {{ $labels.node_name }}.',
-              description: 'An RBD client might be blocked by Ceph on node {{ $labels.node_name }}. This alert is triggered when the ocs_rbd_client_blocklisted metric reports a value of 1 for the node and there are pods in a CreateContainerError state on the node. This may cause the filesystem for the PVCs to be in a read-only state. Please check the pod description for more details.',
+              message: 'An RBD client might be blocked by Ceph on node {{ $labels.node_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'An RBD client might be blocked by Ceph on node {{ $labels.node_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. This alert is triggered when the ocs_rbd_client_blocklisted metric reports a value of 1 for the node and there are pods in a CreateContainerError state on the node. This may cause the filesystem for the PVCs to be in a read-only state. Please check the pod description for more details.',
               severity_level: 'error',
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFRBDClientBlocked.md',
             },

--- a/metrics/mixin/alerts/encryption-external.libsonnet
+++ b/metrics/mixin/alerts/encryption-external.libsonnet
@@ -14,8 +14,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Storage Cluster KMS Server is in un-connected state. Please check KMS config.',
-              description: 'Storage Cluster KMS Server is in un-connected state for more than %s. Please check KMS config.' % $._config.ocsStorageClusterKMSConnectionAlert,
+              message: 'Storage Cluster KMS Server is in un-connected state. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Storage Cluster KMS Server is in un-connected state for more than %s. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.ocsStorageClusterKMSConnectionAlert,
               storage_type: $._config.cephStorageType,
               severity_level: 'error',
             },

--- a/metrics/mixin/alerts/encryption.libsonnet
+++ b/metrics/mixin/alerts/encryption.libsonnet
@@ -14,8 +14,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Storage Cluster KMS Server is in un-connected state. Please check KMS config.',
-              description: 'Storage Cluster KMS Server is in un-connected state for more than %s. Please check KMS config.' % $._config.ocsStorageClusterKMSConnectionAlert,
+              message: 'Storage Cluster KMS Server is in un-connected state. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Storage Cluster KMS Server is in un-connected state for more than %s. Please check KMS config in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.ocsStorageClusterKMSConnectionAlert,
               storage_type: $._config.cephStorageType,
               severity_level: 'error',
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/KMSServerConnectionAlert.md',

--- a/metrics/mixin/alerts/mirroring.libsonnet
+++ b/metrics/mixin/alerts/mirroring.libsonnet
@@ -14,8 +14,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Mirror daemon is unhealthy.',
-              description: 'Mirror daemon is in unhealthy status for more than %s. Mirroring on this cluster is not working as expected.' % $._config.odfMirrorDaemonStatusAlertTime,
+              message: 'Mirror daemon is unhealthy in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Mirror daemon is in unhealthy status for more than %s. Mirroring is not working as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.odfMirrorDaemonStatusAlertTime,
               storage_type: $._config.cephStorageType,
               severity_level: 'error',
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfMirrorDaemonStatus.md',
@@ -32,8 +32,8 @@
               mirroring_image_status: 'unknown',
             },
             annotations: {
-              message: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state.',
-              description: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state for more than %s. Mirroring might not work as expected.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
+              message: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state for more than %s. Mirroring might not work as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
               storage_type: $._config.cephStorageType,
               severity_level: 'warning',
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfPoolMirroringImageHealth.md',
@@ -50,8 +50,8 @@
               mirroring_image_status: 'warning',
             },
             annotations: {
-              message: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state.',
-              description: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for more than %s. Mirroring might not work as expected.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
+              message: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state for more than %s. Mirroring might not work as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
               storage_type: $._config.cephStorageType,
               severity_level: 'warning',
             },
@@ -67,8 +67,8 @@
               mirroring_image_status: 'error',
             },
             annotations: {
-              message: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state.',
-              description: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for more than %s. Mirroring is not working as expected.' % $._config.odfPoolMirroringImageHealthCriticalAlertTime,
+              message: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state for more than %s. Mirroring is not working as expected in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.odfPoolMirroringImageHealthCriticalAlertTime,
               storage_type: $._config.cephStorageType,
               severity_level: 'error',
             },
@@ -83,8 +83,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }}.',
-              description: 'Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }} for more than %s. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
+              message: 'Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Persistent volume {{ $labels.name }}/{{ $labels.namespace }} is not mirrored properly to peer site {{ $labels.site_name }} for more than %s. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}. Please check namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
               storage_type: $._config.cephStorageType,
               severity_level: 'error',
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFPersistentVolumeMirrorStatus.md'
@@ -100,8 +100,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} mirroring to peer site {{ $labels.site_name }}.',
-              description: 'Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} to peer site {{ $labels.site_name }} for more than %s. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}.' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
+              message: 'Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} mirroring to peer site {{ $labels.site_name }} in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Status unknown for Persistent volume {{ $labels.name }}/{{ $labels.namespace }} to peer site {{ $labels.site_name }} for more than %s. RBD image={{ $labels.image }} and CephBlockPool={{ $labels.pool_name }}. Please check namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}' % $._config.odfPoolMirroringImageHealthWarningAlertTime,
               storage_type: $._config.cephStorageType,
               severity_level: 'warning',
             },

--- a/metrics/mixin/alerts/obc.libsonnet
+++ b/metrics/mixin/alerts/obc.libsonnet
@@ -14,8 +14,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'OBC has crossed 80% of the quota(bytes).',
-              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
+              message: 'OBC has crossed 80% of the quota(bytes) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
               storage_type: $._config.objectStorageType,
               severity_level: 'warning',
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaBytesAlert.md',
@@ -31,8 +31,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'OBC has crossed 80% of the quota(object).',
-              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
+              message: 'OBC has crossed 80% of the quota(object) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
               storage_type: $._config.objectStorageType,
               severity_level: 'warning',
             },
@@ -47,8 +47,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'OBC reached quota(bytes) limit.',
-              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
+              message: 'OBC reached quota(bytes) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
             },
@@ -63,8 +63,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'OBC reached quota(object) limit.',
-              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
+              message: 'OBC reached quota(object) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
             },

--- a/metrics/mixin/alerts/services-external.libsonnet
+++ b/metrics/mixin/alerts/services-external.libsonnet
@@ -14,8 +14,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection.',
-              description: 'Cluster Object Store is in unhealthy state for more than %s. Please check Ceph cluster health or RGW connection.' % $._config.clusterObjectStoreStateAlertTime,
+              message: 'Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'Cluster Object Store is in unhealthy state for more than %s. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clusterObjectStoreStateAlertTime,
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
             },

--- a/metrics/mixin/alerts/services.libsonnet
+++ b/metrics/mixin/alerts/services.libsonnet
@@ -16,8 +16,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Cluster Object Store is in unhealthy state or number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas.',
-              description: 'RGW endpoint of the Ceph object store is in a failure state or one or more Rook Ceph RGW deployments have fewer ready replicas than required for more than %s. Please check the health of the Ceph cluster and the deployments.' % $._config.clusterObjectStoreStateAlertTime,
+              message: 'Cluster Object Store is in unhealthy state or number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              description: 'RGW endpoint of the Ceph object store is in a failure state or one or more Rook Ceph RGW deployments have fewer ready replicas than required for more than %s. Please check the health of the Ceph cluster and the deployments in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clusterObjectStoreStateAlertTime,
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
             },

--- a/metrics/mixin/alerts/storage-client.libsonnet
+++ b/metrics/mixin/alerts/storage-client.libsonnet
@@ -13,8 +13,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s)' % $._config.clientCheckinWarnSec,
-              description: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s). Lossy network connectivity might exist' % $._config.clientCheckinWarnSec,
+              message: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientCheckinWarnSec,
+              description: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s). Lossy network connectivity might exist in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientCheckinWarnSec,
               severity_level: 'warning',
             },
           },
@@ -27,8 +27,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s)' % $._config.clientCheckinCritSec,
-              description: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s). Client might have lost internet connectivity' % $._config.clientCheckinCritSec,
+              message: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientCheckinCritSec,
+              description: 'Storage Client ({{ $labels.storage_consumer_name }}) heartbeat missed for more than %d (s). Client might have lost internet connectivity in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientCheckinCritSec,
               severity_level: 'critical',
             },
           },
@@ -43,8 +43,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by %d minor version' % $._config.clientOperatorMinorVerDiff,
-              description: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by %d minor version. Client configuration may be incompatible' % $._config.clientOperatorMinorVerDiff,
+              message: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by %d minor version in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientOperatorMinorVerDiff,
+              description: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) lags by %d minor version. Client configuration may be incompatible in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientOperatorMinorVerDiff,
               severity_level: 'warning',
             },
           },
@@ -60,8 +60,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version' % $._config.clientOperatorMinorVerDiff,
-              description: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version. Client configuration may be incompatible and unsupported' % $._config.clientOperatorMinorVerDiff,
+              message: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientOperatorMinorVerDiff,
+              description: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version. Client configuration may be incompatible and unsupported in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clientOperatorMinorVerDiff,
               severity_level: 'critical',
             },
           },


### PR DESCRIPTION
In a multi storagecluster scenario, both metrics-exporter and PrometheusRules should be enabled on all the namespaces where the StorageClusters are installed.

Follow up PR: #2313 