### PR TITLE
fix: do not return after updating conditions if there is no error

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -514,8 +514,6 @@ func (r *StorageClusterReconciler) reconcilePhases(
 					return reconcile.Result{}, returnErr
 				}
 			}
-			return reconcile.Result{}, nil
-
 		}
 	} else {
 		// If any component operator reports negatively we want to write that to


### PR DESCRIPTION
This bug was intruduced while making the change for updating conditions in the commit 9256514f1b69471fb1134c65a2cdac579121aebb.

It always return after updating the conditions, we should only return if there is an error, otherwise we should continue with reconcile.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>