### PR TITLE
Add alerts for high osd cpu usage

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -265,7 +265,7 @@ spec:
         floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > 1 or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= 1
       labels:
         severity: critical
-  - name: mds-performance-alerts.rules
+  - name: ceph-daemon-performance-alerts.rules
     rules:
     - alert: MDSCacheUsageHigh
       annotations:
@@ -277,3 +277,12 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: OSDCPULoadHigh
+      annotations:
+        description: High CPU usage in the OSD container on pod {{ $labels.pod }}. Please create more OSDs to increase performance
+        message: High CPU usage detected in OSD container on pod {{ $labels.pod}}.
+        severity_level: warning
+      expr: "pod:container_cpu_usage:sum{pod=~\"rook-ceph-osd-.*\"} > 0.35 \n"
+      for: 15m
+      labels:
+        severity: warning

--- a/metrics/mixin/alerts/perf.libsonnet
+++ b/metrics/mixin/alerts/perf.libsonnet
@@ -2,7 +2,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'mds-performance-alerts.rules',
+        name: 'ceph-daemon-performance-alerts.rules',
         rules: [
           {
             alert: 'MDSCacheUsageHigh',
@@ -17,6 +17,21 @@
               message: 'High MDS cache usage for the daemon {{ $labels.ceph_daemon }}.',
               description: 'MDS cache usage for the daemon {{ $labels.ceph_daemon }} has exceeded above 95% of the requested value. Increase the memory request for {{ $labels.ceph_daemon }} pod.',
               severity_level: 'error',
+            }
+          },
+          {
+            alert: 'OSDCPULoadHigh',
+            expr: |||
+              pod:container_cpu_usage:sum{%(osdSelector)s} > 0.35 
+            ||| % $._config,
+            'for': $._config.osdCPULoadHighAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'High CPU usage detected in OSD container on pod {{ $labels.pod}}.',
+              description: 'High CPU usage in the OSD container on pod {{ $labels.pod }}. Please create more OSDs to increase performance',
+              severity_level: 'warning',
             },
           },
         ],

--- a/metrics/mixin/config.libsonnet
+++ b/metrics/mixin/config.libsonnet
@@ -2,6 +2,7 @@
   _config+:: {
     // Selectors are inserted between {} in Prometheus queries.
     ocsExporterSelector: 'job="ocs-metrics-exporter"',
+    osdSelector: 'pod=~"rook-ceph-osd-.*"',
 
     // Duration to raise various Alerts
     clusterObjectStoreStateAlertTime: '15s',
@@ -14,6 +15,7 @@
     blockedRBDClientAlertTime: '10s',
     ocsStorageClusterKMSConnectionAlert: '5s',
     mdsCacheUsageAlertTime: '5m',
+    osdCPULoadHighAlertTime: '15m',
 
     // Constants
     objectStorageType: 'RGW',


### PR DESCRIPTION
This PR adds an alert, OSD is overwhelmed with a lot of performance request. 

There were multiple metrics/values considered to recognise when the cluster is under load. 
1. `util%` for the disks: The value for disk utilization is not very useful for devices with support for multiple queues like ssd and nvme. even if the utilization values are very high, the storage system can "take more work on"

2.  disk latency: we can take a look at an average latency over time, but latency is highly dependent on IO_size

3. CPU usage: on cluster's under high load, the CPU usage of the primary OSD jumps up on a small cluster, increasing the amount of OSDs reduce the cpu usage. 

in the end the PR just adds CPU usage as a factor, with a 35% usage as a threshold, which let's the user know to add more OSDs/increase the cluster size to aleviate the issue