### PR TITLE
add alert for mds cache over use

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -265,3 +265,15 @@ spec:
         floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > 1 or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= 1
       labels:
         severity: critical
+  - name: mds-performance-alerts.rules
+    rules:
+    - alert: MDSCacheUsageHigh
+      annotations:
+        description: MDS cache usage for the daemon {{ $labels.ceph_daemon }} has exceeded above 95% of the requested value. Increase the memory request for {{ $labels.ceph_daemon }} pod.
+        message: High MDS cache usage for the daemon {{ $labels.ceph_daemon }}.
+        severity_level: error
+      expr: |
+        ceph_mds_mem_rss / on(ceph_daemon) group_left(job)(label_replace(kube_pod_container_resource_requests{container="mds", resource="memory"}, "ceph_daemon", "mds.$1", "pod", "rook-ceph-mds-(.*)-(.*)") * .5) > .95
+      for: 5m
+      labels:
+        severity: critical

--- a/metrics/mixin/alerts/alerts.libsonnet
+++ b/metrics/mixin/alerts/alerts.libsonnet
@@ -3,4 +3,5 @@
 (import 'services.libsonnet') +
 (import 'blocklist.libsonnet') +
 (import 'encryption.libsonnet') +
-(import 'storage-client.libsonnet')
+(import 'storage-client.libsonnet') +
+(import 'perf.libsonnet')

--- a/metrics/mixin/alerts/perf.libsonnet
+++ b/metrics/mixin/alerts/perf.libsonnet
@@ -1,0 +1,26 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'mds-performance-alerts.rules',
+        rules: [
+          {
+            alert: 'MDSCacheUsageHigh',
+            expr: |||
+              ceph_mds_mem_rss / on(ceph_daemon) group_left(job)(label_replace(kube_pod_container_resource_requests{container="mds", resource="memory"}, "ceph_daemon", "mds.$1", "pod", "rook-ceph-mds-(.*)-(.*)") * .5) > .95
+            ||| % $._config,
+            'for': $._config.mdsCacheUsageAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'High MDS cache usage for the daemon {{ $labels.ceph_daemon }}.',
+              description: 'MDS cache usage for the daemon {{ $labels.ceph_daemon }} has exceeded above 95% of the requested value. Increase the memory request for {{ $labels.ceph_daemon }} pod.',
+              severity_level: 'error',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/metrics/mixin/config.libsonnet
+++ b/metrics/mixin/config.libsonnet
@@ -13,6 +13,7 @@
     odfPoolMirroringImageHealthCriticalAlertTime: '10s',
     blockedRBDClientAlertTime: '10s',
     ocsStorageClusterKMSConnectionAlert: '5s',
+    mdsCacheUsageAlertTime: '5m',
 
     // Constants
     objectStorageType: 'RGW',


### PR DESCRIPTION
**Background:** 

ODF sets requests/limits of the MDS daemon pod to 8Gi. Rook sets the mds_cache_memory_limit is set to 0.5,  that is,  4Gi
The MDS will try to stay under a reservation of this limit by trimming unused metadata in its cache and recalling cached items in the client caches.
It is possible for the MDS to exceed this limit due to slow recall from clients. 
Ceph sends a health warning message when the cache full threshold (mds_health_cache_threshold) of 150%, that is 6Gi in this case, is breached.

Here, we trigger the alert to the user when MDS cache usage breaches 95% of the `mds_cache_memory_limit`, that is, (mds resource request * 0.5)
