### PR TITLE
[RHSTOR-5075] remove StorageClientIncompatibleOperatorVersion alert at Critical level

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -130,7 +130,6 @@ spec:
         message: Storage Cluster KMS Server is in un-connected state. Please check KMS config.
         severity_level: error
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/KMSServerConnectionAlert.md
       expr: |
         ocs_storagecluster_kms_connection_status{job="ocs-metrics-exporter"} == 1
       for: 5s

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -69,9 +69,9 @@ spec:
       annotations:
         description: Mirror daemon is in unhealthy status for more than 1m. Mirroring on this cluster is not working as expected.
         message: Mirror daemon is unhealthy.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfMirrorDaemonStatus.md
         severity_level: error
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfMirrorDaemonStatus.md
       expr: |
         ((count by(namespace) (ocs_mirror_daemon_count{job="ocs-metrics-exporter"} == 0)) * on(namespace) group_left() (count by(namespace) (ocs_pool_mirroring_status{job="ocs-metrics-exporter"} == 1))) > 0
       for: 1m
@@ -81,9 +81,9 @@ spec:
       annotations:
         description: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state for more than 1m. Mirroring might not work as expected.
         message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Unknown state.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfPoolMirroringImageHealth.md
         severity_level: warning
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfPoolMirroringImageHealth.md
       expr: |
         (ocs_pool_mirroring_image_health{job="ocs-metrics-exporter"}  * on (namespace) group_left() (max by(namespace) (ocs_pool_mirroring_status{job="ocs-metrics-exporter"}))) == 1
       for: 1m
@@ -96,7 +96,6 @@ spec:
         message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Warning state.
         severity_level: warning
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfPoolMirroringImageHealth.md
       expr: |
         (ocs_pool_mirroring_image_health{job="ocs-metrics-exporter"}  * on (namespace) group_left() (max by(namespace) (ocs_pool_mirroring_status{job="ocs-metrics-exporter"}))) == 2
       for: 1m
@@ -109,7 +108,6 @@ spec:
         message: Mirroring image(s) (PV) in the pool {{ $labels.name }} are in Error state.
         severity_level: error
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/OdfPoolMirroringImageHealth.md
       expr: |
         (ocs_pool_mirroring_image_health{job="ocs-metrics-exporter"}  * on (namespace) group_left() (max by(namespace) (ocs_pool_mirroring_status{job="ocs-metrics-exporter"}))) == 3
       for: 10s
@@ -205,8 +203,8 @@ spec:
       annotations:
         description: An RBD client might be blocked by Ceph on node {{ $labels.node_name }}. This alert is triggered when the ocs_rbd_client_blocklisted metric reports a value of 1 for the node and there are pods in a CreateContainerError state on the node. This may cause the filesystem for the PVCs to be in a read-only state. Please check the pod description for more details.
         message: An RBD client might be blocked by Ceph on node {{ $labels.node_name }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFRBDClientBlocked.md
         severity_level: error
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFRBDClientBlocked.md'
       expr: |
         (
           ocs_rbd_client_blocklisted{node=~".+"} == 1
@@ -225,9 +223,9 @@ spec:
       annotations:
         description: Storage Cluster KMS Server is in un-connected state for more than 5s. Please check KMS config.
         message: Storage Cluster KMS Server is in un-connected state. Please check KMS config.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/KMSServerConnectionAlert.md
         severity_level: error
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/KMSServerConnectionAlert.md
       expr: |
         ocs_storagecluster_kms_connection_status{job="ocs-metrics-exporter"} == 1
       for: 5s
@@ -262,15 +260,6 @@ spec:
         floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) == 1
       labels:
         severity: warning
-    - alert: StorageClientIncompatibleOperatorVersion
-      annotations:
-        description: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version. Client configuration may be incompatible and unsupported
-        message: Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than 1 minor version
-        severity_level: critical
-      expr: |
-        floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > 1 or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= 1
-      labels:
-        severity: critical
   - name: ceph-daemon-performance-alerts.rules
     rules:
     - alert: MDSCacheUsageHigh

--- a/metrics/mixin/alerts/storage-client.libsonnet
+++ b/metrics/mixin/alerts/storage-client.libsonnet
@@ -48,23 +48,6 @@
               severity_level: 'warning',
             },
           },
-          {
-            # divide by 1000 here removes patch version
-            # critical if client lags provider by more than one minor version or
-            # client is ahead of provider
-            alert: 'StorageClientIncompatibleOperatorVersion',
-            expr: |||
-              floor((ocs_storage_provider_operator_version>0)/1000) - ignoring(storage_consumer_name) group_right() floor((ocs_storage_client_operator_version>0)/1000) > %(clientOperatorMinorVerDiff)d or floor((ocs_storage_client_operator_version>0)/1000) - ignoring(storage_consumer_name) group_left() floor((ocs_storage_provider_operator_version>0)/1000) >= %(clientOperatorMinorVerDiff)d
-            ||| % $._config,
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version' % $._config.clientOperatorMinorVerDiff,
-              description: 'Storage Client Operator ({{ $labels.storage_consumer_name }}) differs by more than %d minor version. Client configuration may be incompatible and unsupported' % $._config.clientOperatorMinorVerDiff,
-              severity_level: 'critical',
-            },
-          },
         ],
       },
     ],


### PR DESCRIPTION
- This alert is initially raised if client operator is outside of support matrix b/n ODF Provider and ODF Client
- With #2308 and #2311 we are enforcing the onboard and upgrade
- So, this alert can be removed now