### PR TITLE
Add 'runbook_url' link to alerts' annotation

### DIFF
--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -41,6 +41,7 @@ spec:
         message: Storage metrics collector service not available anymore.
         severity_level: critical
         storage_type: ceph
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMgrIsAbsent.md
       expr: |
         label_replace((up{job="rook-ceph-mgr"} == 0 or absent(up{job="rook-ceph-mgr"})), "namespace", "openshift-storage", "", "")
       for: 5m
@@ -52,6 +53,7 @@ spec:
         message: Storage metrics collector service doesn't have required no of replicas.
         severity_level: warning
         storage_type: ceph
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMgrIsMissingReplicas.md
       expr: |
         sum by (namespace) (kube_deployment_spec_replicas{deployment=~"rook-ceph-mgr-.*"}) < 1
       for: 5m
@@ -65,6 +67,7 @@ spec:
         message: Insufficient replicas for storage metadata service.
         severity_level: warning
         storage_type: ceph
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMdsMissingReplicas.md
       expr: |
         sum by (namespace) (ceph_mds_metadata{job="rook-ceph-mgr"} == 1) < 2
       for: 5m
@@ -78,6 +81,7 @@ spec:
         message: Storage quorum at risk
         severity_level: error
         storage_type: ceph
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMonQuorumAtRisk.md
       expr: |
         count by (namespace) (ceph_mon_quorum_status{job="rook-ceph-mgr"} == 1) <= (floor(count by (namespace) (ceph_mon_metadata{job="rook-ceph-mgr"}) / 2) + 1)
       for: 15m
@@ -87,6 +91,7 @@ spec:
       annotations:
         description: Storage cluster quorum is lost. Contact Support.
         message: Storage quorum is lost
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMonQuorumLost.md
         severity_level: critical
         storage_type: ceph
       expr: |
@@ -100,6 +105,7 @@ spec:
         message: Storage Cluster has seen many leader changes recently.
         severity_level: warning
         storage_type: ceph
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMonHighNumberOfLeaderChanges.md
       expr: |
         (ceph_mon_metadata{job="rook-ceph-mgr"} * on (ceph_daemon, namespace) group_left() (rate(ceph_mon_num_elections{job="rook-ceph-exporter"}[5m]) * 60)) > 0.95
       for: 5m
@@ -111,6 +117,7 @@ spec:
       annotations:
         description: Storage node {{ $labels.node }} went down. Please check the node immediately.
         message: Storage node {{ $labels.node }} went down
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephNodeDown.md
         severity_level: error
         storage_type: ceph
       expr: |
@@ -124,6 +131,7 @@ spec:
       annotations:
         description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class type {{ $labels.device_class }} has crossed 80% on host {{ $labels.hostname }}. Immediately free up some space or add capacity of type {{ $labels.device_class }}.
         message: Back-end storage device is critically full.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephOSDCriticallyFull.md
         severity_level: error
         storage_type: ceph
       expr: |

--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -81,6 +81,7 @@ spec:
       annotations:
         description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
         message: OBC has crossed 80% of the quota(object) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaObjectsAlert.md
         severity_level: warning
         storage_type: RGW
       expr: |
@@ -92,6 +93,7 @@ spec:
       annotations:
         description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
         message: OBC reached quota(bytes) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaBytesExhausedAlert.md
         severity_level: error
         storage_type: RGW
       expr: |
@@ -103,6 +105,7 @@ spec:
       annotations:
         description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
         message: OBC reached quota(object) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaObjectsExhausedAlert.md
         severity_level: error
         storage_type: RGW
       expr: |
@@ -116,6 +119,7 @@ spec:
       annotations:
         description: Cluster Object Store is in unhealthy state for more than 15s. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         message: Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ClusterObjectStoreState.md
         severity_level: error
         storage_type: RGW
       expr: |

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -158,6 +158,7 @@ spec:
       annotations:
         description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.
         message: OBC has crossed 80% of the quota(object) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaObjectsAlert.md
         severity_level: warning
         storage_type: RGW
       expr: |
@@ -169,6 +170,7 @@ spec:
       annotations:
         description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
         message: OBC reached quota(bytes) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaBytesExhausedAlert.md
         severity_level: error
         storage_type: RGW
       expr: |
@@ -180,6 +182,7 @@ spec:
       annotations:
         description: ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.
         message: OBC reached quota(object) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaObjectsExhausedAlert.md
         severity_level: error
         storage_type: RGW
       expr: |
@@ -193,6 +196,7 @@ spec:
       annotations:
         description: RGW endpoint of the Ceph object store is in a failure state or one or more Rook Ceph RGW deployments have fewer ready replicas than required for more than 15s. Please check the health of the Ceph cluster and the deployments in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
         message: Cluster Object Store is in unhealthy state or number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ClusterObjectStoreState.md
         severity_level: error
         storage_type: RGW
       expr: |

--- a/metrics/mixin/alerts/obc.libsonnet
+++ b/metrics/mixin/alerts/obc.libsonnet
@@ -32,6 +32,7 @@
             },
             annotations: {
               message: 'OBC has crossed 80% of the quota(object) in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaObjectsAlert.md',
               description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource.',
               storage_type: $._config.objectStorageType,
               severity_level: 'warning',
@@ -48,6 +49,7 @@
             },
             annotations: {
               message: 'OBC reached quota(bytes) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaBytesExhausedAlert.md',
               description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(bytes) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
               storage_type: $._config.objectStorageType,
               severity_level: 'error',
@@ -64,6 +66,7 @@
             },
             annotations: {
               message: 'OBC reached quota(object) limit in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ObcQuotaObjectsExhausedAlert.md',
               description: 'ObjectBucketClaim {{ $labels.objectbucketclaim }} has crossed the limit set by the quota(objects) and will be read-only now in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}. Increase the quota in the {{ $labels.objectbucketclaim }} OBC custom resource immediately.',
               storage_type: $._config.objectStorageType,
               severity_level: 'error',

--- a/metrics/mixin/alerts/services-external.libsonnet
+++ b/metrics/mixin/alerts/services-external.libsonnet
@@ -15,6 +15,7 @@
             },
             annotations: {
               message: 'Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ClusterObjectStoreState.md',
               description: 'Cluster Object Store is in unhealthy state for more than %s. Please check Ceph cluster health or RGW connection in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clusterObjectStoreStateAlertTime,
               storage_type: $._config.objectStorageType,
               severity_level: 'error',

--- a/metrics/mixin/alerts/services.libsonnet
+++ b/metrics/mixin/alerts/services.libsonnet
@@ -17,6 +17,7 @@
             },
             annotations: {
               message: 'Cluster Object Store is in unhealthy state or number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.',
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ClusterObjectStoreState.md',
               description: 'RGW endpoint of the Ceph object store is in a failure state or one or more Rook Ceph RGW deployments have fewer ready replicas than required for more than %s. Please check the health of the Ceph cluster and the deployments in namespace:cluster {{ $labels.namespace }}:{{ $labels.managedBy }}.' % $._config.clusterObjectStoreStateAlertTime,
               storage_type: $._config.objectStorageType,
               severity_level: 'error',


### PR DESCRIPTION
Adding 'runbook_url' link to following alerts,

CephMgrIsAbsent
CephMgrIsMissingReplicas
CephMdsMissingReplicas
CephMonQuorumAtRisk
CephMonQuorumLost
CephMonHighNumberOfLeaderChanges
CephNodeDown
CephOSDCriticallyFull

ObcQuotaObjectsAlert
ObcQuotaBytesExhausedAlert
ObcQuotaObjectsExhausedAlert
ClusterObjectStoreState