### PR TITLE
remove ocs-operator-ci make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ CONTROLLER_GEN=$(LOCALBIN)/controller-gen
 	shellcheck-test \
 	golangci-lint \
 	update-generated \
-	ocs-operator-ci \
 	unit-test \
 	deps-update
 
@@ -125,8 +124,6 @@ lint: ## Run golangci-lint inside a container
 unit-test:
 	@echo "Executing unit tests"
 	hack/unit-test.sh
-
-ocs-operator-ci: shellcheck-test golangci-lint unit-test verify-deps verify-generated verify-latest-csv verify-operator-bundle verify-latest-deploy-yaml
 
 # Generate code
 generate: controller-gen


### PR DESCRIPTION
ocs-operator-ci is no longer used to execute tests as it is redundant with github action based tests.

CI test removed by openshift/release/pull/46832