### PR TITLE
[release-4.13] Use exact ceph image version v17.2.6 instead of v17

### DIFF
--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2893,7 +2893,7 @@ spec:
                 - name: ROOK_CEPH_IMAGE
                   value: docker.io/rook/ceph:v1.11.4
                 - name: CEPH_IMAGE
-                  value: quay.io/ceph/ceph:v17
+                  value: quay.io/ceph/ceph:v17.2.6
                 - name: NOOBAA_CORE_IMAGE
                   value: quay.io/noobaa/noobaa-core:master-20230306
                 - name: NOOBAA_DB_IMAGE
@@ -3424,7 +3424,7 @@ spec:
   relatedImages:
   - image: docker.io/rook/ceph:v1.11.4
     name: rook-container
-  - image: quay.io/ceph/ceph:v17
+  - image: quay.io/ceph/ceph:v17.2.6
     name: ceph-container
   - image: quay.io/csiaddons/k8s-sidecar:v0.6.0
     name: csiaddons-sidecar

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -54,7 +54,7 @@ LATEST_ROOK_IMAGE="docker.io/rook/ceph:v1.11.4"
 LATEST_NOOBAA_IMAGE="quay.io/noobaa/noobaa-operator:master-20230306"
 LATEST_NOOBAA_CORE_IMAGE="quay.io/noobaa/noobaa-core:master-20230306"
 LATEST_NOOBAA_DB_IMAGE="centos/postgresql-12-centos7"
-LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v17"
+LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v17.2.6"
 LATEST_ROOK_CSIADDONS_IMAGE="quay.io/csiaddons/k8s-sidecar:v0.6.0"
 # TODO: change image once the quay repo is changed
 LATEST_MUST_GATHER_IMAGE="quay.io/ocs-dev/ocs-must-gather:latest"


### PR DESCRIPTION
Manual backport of https://github.com/red-hat-storage/ocs-operator/pull/2245

Using the tag v17 pulls the latest image from the v17 tag, and the latest image is v17.2.7. This image is problematic and causes the osd-prepare pods to fail. So use the exact version v17.2.6.

BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2247313