### PR TITLE
[release-4.12] Use exact ceph image version v17.2.6 instead of v17

### DIFF
--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2798,7 +2798,7 @@ spec:
                 - name: ROOK_CEPH_IMAGE
                   value: rook/ceph:v1.10.0
                 - name: CEPH_IMAGE
-                  value: quay.io/ceph/ceph:v17
+                  value: quay.io/ceph/ceph:v17.2.6
                 - name: NOOBAA_CORE_IMAGE
                   value: noobaa/noobaa-core:master-20220916
                 - name: NOOBAA_DB_IMAGE
@@ -3270,7 +3270,7 @@ spec:
   relatedImages:
   - image: rook/ceph:v1.10.0
     name: rook-container
-  - image: quay.io/ceph/ceph:v17
+  - image: quay.io/ceph/ceph:v17.2.6
     name: ceph-container
   - image: quay.io/csiaddons/k8s-sidecar:v0.5.0
     name: csiaddons-sidecar

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -54,7 +54,7 @@ LATEST_ROOK_IMAGE="rook/ceph:v1.10.0"
 LATEST_NOOBAA_IMAGE="noobaa/noobaa-operator:master-20220916"
 LATEST_NOOBAA_CORE_IMAGE="noobaa/noobaa-core:master-20220916"
 LATEST_NOOBAA_DB_IMAGE="centos/postgresql-12-centos7"
-LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v17"
+LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v17.2.6"
 LATEST_ROOK_CSIADDONS_IMAGE="csiaddons/k8s-sidecar:v0.5.0"
 
 DEFAULT_IMAGE_REGISTRY="quay.io"


### PR DESCRIPTION
Manual backport of https://github.com/red-hat-storage/ocs-operator/pull/2245

Using the tag v17 pulls the latest image from the v17 tag, and the latest image is v17.2.7. This image is problematic and causes the osd-prepare pods to fail. So use the exact version v17.2.6.

BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2247313