### PR TITLE
skip checking osd store type for external clusters

### DIFF
--- a/controllers/storagecluster/clusterclaims.go
+++ b/controllers/storagecluster/clusterclaims.go
@@ -103,10 +103,15 @@ func (obj *ocsClusterClaim) ensureCreated(r *StorageClusterReconciler, instance 
 		return reconcile.Result{}, err
 	}
 
-	isDROptimized, err := creator.getIsDROptimized(r.serverVersion)
-	if err != nil {
-		r.Log.Error(err, "failed to get cephcluster status. retrying again")
-		return reconcile.Result{}, err
+	var isDROptimized = "false"
+	// Set isDROptmized to "false" in case of external clusters as we currently don't have to way to determine
+	// if external cluster OSDs are using bluestore-rdr
+	if !instance.Spec.ExternalStorage.Enable {
+		isDROptimized, err = creator.getIsDROptimized(r.serverVersion)
+		if err != nil {
+			r.Log.Error(err, "failed to get cephcluster status. retrying again")
+			return reconcile.Result{}, err
+		}
 	}
 
 	err = creator.setStorageClusterCount(strconv.Itoa(storageClusterCount)).


### PR DESCRIPTION
Currently there is no way to determine if external clusters are optimized for DR, that is, they are bluestore-rdr.  So we should skip checking for the OSD store type in the cephCluster status in case of a external cluster. 

Note: We would want to revisit this in future once we start supporting external clusters for RDR. 
