### PR TITLE
Set current mon count value in StorageCluster CR

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -514,6 +514,9 @@ type StorageClusterStatus struct {
 
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
+
+	// CurrentMonCount holds the value of ceph mons configured in ceph cluster.
+	CurrentMonCount int `json:"currentMonCount,omitempty"`
 }
 
 // ImagesStatus maps every component image name it's reconciliation status information

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -6340,6 +6340,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentMonCount:
+                description: CurrentMonCount holds the value of ceph mons configured
+                  in ceph cluster.
+                type: integer
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -343,6 +343,11 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		}
 	}
 
+	// Update the currentMonCount field in StoragCluster status from the cephCluster CR
+	if !sc.Spec.ExternalStorage.Enable {
+		sc.Status.CurrentMonCount = cephCluster.Spec.Mon.Count
+	}
+
 	// Create the prometheus rules if required by the cephcluster CR
 	if err := createPrometheusRules(r, sc, cephCluster); err != nil {
 		r.Log.Error(err, "Unable to create or update prometheus rules.", "CephCluster", klog.KRef(found.Namespace, found.Name))

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -6340,6 +6340,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentMonCount:
+                description: CurrentMonCount holds the value of ceph mons configured
+                  in ceph cluster.
+                type: integer
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -6339,6 +6339,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentMonCount:
+                description: CurrentMonCount holds the value of ceph mons configured
+                  in ceph cluster.
+                type: integer
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -514,6 +514,9 @@ type StorageClusterStatus struct {
 
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
+
+	// CurrentMonCount holds the value of ceph mons configured in ceph cluster.
+	CurrentMonCount int `json:"currentMonCount,omitempty"`
 }
 
 // ImagesStatus maps every component image name it's reconciliation status information


### PR DESCRIPTION
Added a new field under Status of StorageCluster CR named `CurrentMonCount` that will hold the the mon count set for
the cluster, and this value is updated based on the mon count value set in CephCluster CR