### PR TITLE
remove rbd-mirror metrics already exported by ceph

### DIFF
--- a/metrics/internal/cache/rbd-mirror.go
+++ b/metrics/internal/cache/rbd-mirror.go
@@ -87,14 +87,6 @@ type RBDMirrorPeerSite struct {
 	LastUpdate  string `json:"last_update"`
 }
 
-type RBDMirrorPeerSiteDescription struct {
-	BytesPerSecond          float64 `json:"bytes_per_second"`
-	BytesPerSnapshot        float64 `json:"bytes_per_snapshot"`
-	LocalSnapshotTimestamp  int64   `json:"local_snapshot_timestamp"`
-	RemoteSnapshotTimestamp int64   `json:"remote_snapshot_timestamp"`
-	ReplayState             string  `json:"replay_state"`
-}
-
 type csiClusterConfig struct {
 	ClusterID string   `json:"clusterID"`
 	Monitors  []string `json:"monitors"`

--- a/metrics/internal/collectors/rbd-mirror.go
+++ b/metrics/internal/collectors/rbd-mirror.go
@@ -1,7 +1,6 @@
 package collectors
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,12 +28,8 @@ type RBDMirrorCollector struct {
 	RBDMirrorStore        *internalcache.RBDMirrorStore
 	PersistentVolumeStore *internalcache.PersistentVolumeStore
 	// Metric descriptors
-	MirrorDaemonHealth         *prometheus.Desc
-	ImageStatusState           *prometheus.Desc
-	PrimarySnapshotTimestamp   *prometheus.Desc
-	SecondarySnapshotTimestamp *prometheus.Desc
-	ImageBytes                 *prometheus.Desc
-	ImageSnapshotBytes         *prometheus.Desc
+	MirrorDaemonHealth *prometheus.Desc
+	ImageStatusState   *prometheus.Desc
 }
 
 func NewRBDMirrorCollector(mirrorStore *internalcache.RBDMirrorStore, pvStore *internalcache.PersistentVolumeStore) *RBDMirrorCollector {
@@ -55,30 +50,6 @@ func NewRBDMirrorCollector(mirrorStore *internalcache.RBDMirrorStore, pvStore *i
 			commonRBDMirrorLabels,
 			nil,
 		),
-		PrimarySnapshotTimestamp: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, rbdMirrorSubsystem, "image_primary_snapshot_timestamp"),
-			"Snapshot timestamp of primary image",
-			commonRBDMirrorLabels,
-			nil,
-		),
-		SecondarySnapshotTimestamp: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, rbdMirrorSubsystem, "image_secondary_snapshot_timestamp"),
-			"Snapshot timestamp of secondary image",
-			commonRBDMirrorLabels,
-			nil,
-		),
-		ImageBytes: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, rbdMirrorSubsystem, "image_bytes"),
-			"Bytes of image transferred per second",
-			commonRBDMirrorLabels,
-			nil,
-		),
-		ImageSnapshotBytes: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, rbdMirrorSubsystem, "image_snapshot_bytes"),
-			"Bytes of image snapshot transferred per second",
-			commonRBDMirrorLabels,
-			nil,
-		),
 	}
 }
 
@@ -87,10 +58,6 @@ func (c *RBDMirrorCollector) Describe(ch chan<- *prometheus.Desc) {
 	ds := []*prometheus.Desc{
 		c.MirrorDaemonHealth,
 		c.ImageStatusState,
-		c.PrimarySnapshotTimestamp,
-		c.SecondarySnapshotTimestamp,
-		c.ImageBytes,
-		c.ImageSnapshotBytes,
 	}
 
 	for _, d := range ds {
@@ -162,40 +129,6 @@ func (c *RBDMirrorCollector) Collect(ch chan<- prometheus.Metric) {
 					default:
 						klog.Errorf("Unknown state %q of image %q", site.State, image.Name)
 					}
-				}
-				if image.Description == "local image is primary" {
-					// site.Description can have values like "replaying,{...}" "split-brain" etc.
-					siteDescription := strings.SplitN(site.Description, ", ", 2)
-					if len(siteDescription) != 2 {
-						klog.Errorf("Unexpected mirror peer site description %q of image %q to site %q.", site.Description, image.Name, site.SiteName)
-						continue
-					}
-					description := siteDescription[1]
-					desc := internalcache.RBDMirrorPeerSiteDescription{}
-					err := json.Unmarshal([]byte(description), &desc)
-					if err != nil {
-						klog.Errorf("Failed to unmarshal description of image %q from site %q: %v", image.Name, site.SiteName, err)
-						continue
-					}
-					// LocalSnapshotTimestamp could be unavailable for a while during image resync.
-					if desc.LocalSnapshotTimestamp > 0 {
-						ch <- prometheus.MustNewConstMetric(
-							c.PrimarySnapshotTimestamp, prometheus.GaugeValue, float64(desc.LocalSnapshotTimestamp),
-							image.Name, poolData.PoolName, site.SiteName,
-						)
-					}
-					ch <- prometheus.MustNewConstMetric(
-						c.SecondarySnapshotTimestamp, prometheus.GaugeValue, float64(desc.RemoteSnapshotTimestamp),
-						image.Name, poolData.PoolName, site.SiteName,
-					)
-					ch <- prometheus.MustNewConstMetric(
-						c.ImageBytes, prometheus.GaugeValue, float64(desc.BytesPerSecond),
-						image.Name, poolData.PoolName, site.SiteName,
-					)
-					ch <- prometheus.MustNewConstMetric(
-						c.ImageSnapshotBytes, prometheus.GaugeValue, float64(desc.BytesPerSnapshot),
-						image.Name, poolData.PoolName, site.SiteName,
-					)
 				}
 			}
 		}


### PR DESCRIPTION
The PR removes the metrics
```
ocs_rbd_mirror_image_primary_snapshot_timestamp
ocs_rbd_mirror_image_secondary_snapshot_timestamp
ocs_rbd_mirror_image_image_bytes
ocs_rbd_mirror_image_image_snapshot_bytes
```

as corresponding metrics already exist in ceph
```
ceph_rbd_mirror_snapshot_image_local_timestamp
ceph_rbd_mirror_snapshot_image_remote_timestamp
ceph_rbd_mirror_snapshot_image_last_sync_bytes
```

`image_bytes` and snapshot bytes can be calculated by `sync_time` and `sync_bytes` metrics exported by ceph
```
ocs_rbd_mirror_image_image_bytes :  ceph_rbd_mirror_snapshot_image_last_sync_bytes / ceph_rbd_mirror_snapshot_image_last_sync_time
```