### PR TITLE
Fixed wrong runbook link for CephMonLowNumber alert

### DIFF
--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -305,7 +305,7 @@ spec:
         message: The current number of Ceph monitors can be increased in order to improve cluster resilience
         severity_level: info
         storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/CephMonLowNumber.md
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMonLowNumber.md
       expr: |
         (count(ceph_mon_metadata)) < (count(count by (label_failure_domain_beta_kubernetes_io_zone, label_provider_id) (ocs_node_labels))) and (count(count by (label_failure_domain_beta_kubernetes_io_zone, label_provider_id) (ocs_node_labels))) >= 5
       labels:


### PR DESCRIPTION
Fixes: #2257634
https://bugzilla.redhat.com/show_bug.cgi?id=2257634