### PR TITLE
Adding 'ClusterRole' and 'ClusterRoleBinding' to rook-ceph-mgr

### DIFF
--- a/deploy/ocs-operator/manifests/rook-monitor-mgr-role.yaml
+++ b/deploy/ocs-operator/manifests/rook-monitor-mgr-role.yaml
@@ -1,4 +1,5 @@
-kind: Role
+---
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-monitor-mgr
@@ -12,3 +13,37 @@ rules:
   - list
   - create
   - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---

--- a/deploy/ocs-operator/manifests/rook-monitor-mgr-role_binding.yaml
+++ b/deploy/ocs-operator/manifests/rook-monitor-mgr-role_binding.yaml
@@ -1,11 +1,14 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rook-ceph-monitor-mgr
+  name: rook-ceph-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rook-ceph-monitor-mgr
+  kind: ClusterRole
+  name: rook-ceph-metrics
 subjects:
-- kind: ServiceAccount
-  name: rook-ceph-mgr
+  - kind: ServiceAccount
+    # change to the serviceaccount and namespace to use for monitoring
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+

--- a/rbac/rook-monitor-mgr-role.yaml
+++ b/rbac/rook-monitor-mgr-role.yaml
@@ -1,4 +1,5 @@
-kind: Role
+---
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-monitor-mgr
@@ -12,3 +13,37 @@ rules:
   - list
   - create
   - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---

--- a/rbac/rook-monitor-mgr-role_binding.yaml
+++ b/rbac/rook-monitor-mgr-role_binding.yaml
@@ -1,11 +1,14 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rook-ceph-monitor-mgr
+  name: rook-ceph-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rook-ceph-monitor-mgr
+  kind: ClusterRole
+  name: rook-ceph-metrics
 subjects:
-- kind: ServiceAccount
-  name: rook-ceph-mgr
+  - kind: ServiceAccount
+    # change to the serviceaccount and namespace to use for monitoring
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+


### PR DESCRIPTION
In a multicluster mode, rook operator pod is throwing following exception,
```
failed to enable external service monitor.
service monitor could not be enabled: failed to retrieve servicemonitor.
servicemonitors.monitoring.coreos.com "rook-ceph-mgr" is forbidden:
User "system:serviceaccount:openshift-storage:rook-ceph-system" cannot
get resource "servicemonitors" in API group "monitoring.coreos.com" in
the namespace "openshift-storage-extended"
```

Adding cluster wide role and rolebinding to rook-ceph-mgr serviceaccount.