### PR TITLE
RBD mirror daemon count validation

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -258,6 +258,8 @@ type ManageCephToolbox struct {
 type ManageCephRBDMirror struct {
 	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
 	DaemonCount int `json:"daemonCount,omitempty"`
 }
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -774,6 +774,8 @@ spec:
                     properties:
                       daemonCount:
                         default: 1
+                        maximum: 1
+                        minimum: 0
                         type: integer
                       reconcileStrategy:
                         type: string

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -774,6 +774,8 @@ spec:
                     properties:
                       daemonCount:
                         default: 1
+                        maximum: 1
+                        minimum: 0
                         type: integer
                       reconcileStrategy:
                         type: string

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -773,6 +773,8 @@ spec:
                     properties:
                       daemonCount:
                         default: 1
+                        maximum: 1
+                        minimum: 0
                         type: integer
                       reconcileStrategy:
                         type: string

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -258,6 +258,8 @@ type ManageCephToolbox struct {
 type ManageCephRBDMirror struct {
 	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
 	DaemonCount int `json:"daemonCount,omitempty"`
 }
 


### PR DESCRIPTION
RBD mirror daemon count was defaulted to 1 with no min or max limit.
This could be problematic if users set unexpected values. So, this
commit adds a minimum of 0 and maximum of 1 as valid values and retains
the default value of 1.