### PR TITLE
Enable ceph client and collectors for multicluster case

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -325,7 +325,10 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Args:    []string{"--namespaces", instance.Namespace},
+						Args: []string{
+							"--namespaces", instance.Namespace,
+							"--ceph-auth-namespace", r.OperatorNamespace,
+						},
 						Command: []string{"/usr/local/bin/metrics-exporter"},
 						Image:   r.images.OCSMetricsExporter,
 						Name:    metricsExporterName,

--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -488,6 +488,12 @@ func updateMetricsExporterClusterRoles(ctx context.Context, r *StorageClusterRec
 
 		currentClusterRole.Rules = []rbacv1.PolicyRule{
 			{
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				Verbs:         []string{"get"},
+				ResourceNames: []string{"rook-ceph-csi-config"},
+			},
+			{
 				APIGroups: []string{""},
 				Resources: []string{"persistentvolumes", "persistentvolumeclaims", "pods", "nodes"},
 				Verbs:     []string{"get", "list", "watch"},

--- a/metrics/internal/cache/pv.go
+++ b/metrics/internal/cache/pv.go
@@ -32,13 +32,14 @@ type PersistentVolumeStore struct {
 	// Store is a map of PV UID to PersistentVolumeAttributes
 	Store map[types.UID]PersistentVolumeAttributes
 	// RBDClientMap is a map of RBD client addresses to the names of the nodes whose images had this client as a watcher
-	RBDClientMap      map[string][]string
-	monitorConfig     cephMonitorConfig
-	kubeClient        clientset.Interface
-	allowedNamespaces []string
+	RBDClientMap         map[string][]string
+	monitorConfig        cephMonitorConfig
+	kubeClient           clientset.Interface
+	cephClusterNamespace string
+	cephAuthNamespace    string
 
 	// Functions to make testing easier
-	initCephFn         func(kubeclient clientset.Interface, allowedNamespaces []string) (cephMonitorConfig, error)
+	initCephFn         func(kubeclient clientset.Interface, cephClusterNamespace, cephAuthNamespace string) (cephMonitorConfig, error)
 	runCephRBDStatusFn func(config *cephMonitorConfig, pool, image string) (Clients, error)
 	// TODO: Use fake k8s client instead
 	getNodeNameForPVFn func(pv *corev1.PersistentVolume, kubeClient clientset.Interface) (string, error)
@@ -64,14 +65,15 @@ type PersistentVolumeAttributes struct {
 
 func NewPersistentVolumeStore(opts *options.Options) *PersistentVolumeStore {
 	return &PersistentVolumeStore{
-		Store:              map[types.UID]PersistentVolumeAttributes{},
-		RBDClientMap:       map[string][]string{},
-		kubeClient:         clientset.NewForConfigOrDie(opts.Kubeconfig),
-		monitorConfig:      cephMonitorConfig{},
-		allowedNamespaces:  opts.AllowedNamespaces,
-		initCephFn:         initCeph,
-		runCephRBDStatusFn: runCephRBDStatus,
-		getNodeNameForPVFn: getNodeNameForPV,
+		Store:                map[types.UID]PersistentVolumeAttributes{},
+		RBDClientMap:         map[string][]string{},
+		kubeClient:           clientset.NewForConfigOrDie(opts.Kubeconfig),
+		monitorConfig:        cephMonitorConfig{},
+		cephClusterNamespace: opts.AllowedNamespaces[0],
+		cephAuthNamespace:    opts.CephAuthNamespace,
+		initCephFn:           initCeph,
+		runCephRBDStatusFn:   runCephRBDStatus,
+		getNodeNameForPVFn:   getNodeNameForPV,
 	}
 }
 
@@ -141,7 +143,7 @@ func (p *PersistentVolumeStore) add(pv *corev1.PersistentVolume) error {
 
 	if (p.monitorConfig == cephMonitorConfig{}) {
 		var err error
-		p.monitorConfig, err = p.initCephFn(p.kubeClient, p.allowedNamespaces)
+		p.monitorConfig, err = p.initCephFn(p.kubeClient, p.cephClusterNamespace, p.cephAuthNamespace)
 		if err != nil {
 			return fmt.Errorf("failed to initialize ceph: %v", err)
 		}

--- a/metrics/internal/cache/pv.go
+++ b/metrics/internal/cache/pv.go
@@ -149,6 +149,10 @@ func (p *PersistentVolumeStore) add(pv *corev1.PersistentVolume) error {
 		}
 	}
 
+	if p.monitorConfig.clusterID != pv.Spec.CSI.VolumeAttributes["clusterID"] {
+		return nil
+	}
+
 	p.Store[pv.GetUID()] = PersistentVolumeAttributes{
 		PersistentVolumeName:           pv.Name,
 		PersistentVolumeClaimName:      pv.Spec.ClaimRef.Name,

--- a/metrics/internal/cache/pv_test.go
+++ b/metrics/internal/cache/pv_test.go
@@ -15,7 +15,8 @@ var _ = Describe("PersistentVolume Cache", func() {
 	defer GinkgoRecover()
 	opts := &options.Options{
 		Kubeconfig:        &rest.Config{},
-		AllowedNamespaces: []string{},
+		AllowedNamespaces: []string{""},
+		CephAuthNamespace: "",
 	}
 
 	When("new cache is requested", func() {
@@ -28,7 +29,7 @@ var _ = Describe("PersistentVolume Cache", func() {
 
 	When("PV is added", func() {
 		pvStore := NewPersistentVolumeStore(opts)
-		pvStore.initCephFn = func(kubeclient kubernetes.Interface, allowedNamespaces []string) (cephMonitorConfig, error) {
+		pvStore.initCephFn = func(kubeclient kubernetes.Interface, cephClusterNamespace, cephAuthNamespace string) (cephMonitorConfig, error) {
 			return cephMonitorConfig{}, nil
 		}
 		pvStore.runCephRBDStatusFn = func(config *cephMonitorConfig, pool, image string) (Clients, error) {

--- a/metrics/internal/cache/rbd-mirror.go
+++ b/metrics/internal/cache/rbd-mirror.go
@@ -13,9 +13,9 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -90,6 +90,7 @@ type RBDMirrorPeerSite struct {
 type csiClusterConfig struct {
 	ClusterID string   `json:"clusterID"`
 	Monitors  []string `json:"monitors"`
+	Namespace string   `json:"namespace"`
 }
 
 // Cache mirror data for all CephBlockPools with mirroring enabled
@@ -104,38 +105,29 @@ type RBDMirrorStore struct {
 	Store map[types.UID]RBDMirrorPoolStatusVerbose
 	// rbdCommandInput is a struct that contains the input for the rbd command
 	// for each AllowdNamespaces
-	rbdCommandInput   map[string]*cephMonitorConfig
-	kubeclient        clientset.Interface
-	allowedNamespaces []string
+	rbdCommandInput      map[string]*cephMonitorConfig
+	kubeclient           clientset.Interface
+	cephClusterNamespace string
+	cephAuthNamespace    string
 	// Functions to make testing easier
-	initCephFn       func(kubeclient clientset.Interface, allowedNamespaces []string) (cephMonitorConfig, error)
+	initCephFn       func(kubeclient clientset.Interface, cephClusterNamespace, cephAuthNamespace string) (cephMonitorConfig, error)
 	rbdImageStatusFn func(config *cephMonitorConfig, poolName string) (RBDMirrorStatusVerbose, error)
 }
 
 func NewRBDMirrorStore(opts *options.Options) *RBDMirrorStore {
 	return &RBDMirrorStore{
-		Store:             map[types.UID]RBDMirrorPoolStatusVerbose{},
-		rbdCommandInput:   map[string]*cephMonitorConfig{},
-		kubeclient:        clientset.NewForConfigOrDie(opts.Kubeconfig),
-		allowedNamespaces: opts.AllowedNamespaces,
-		initCephFn:        initCeph,
-		rbdImageStatusFn:  rbdImageStatus,
+		Store:                map[types.UID]RBDMirrorPoolStatusVerbose{},
+		rbdCommandInput:      map[string]*cephMonitorConfig{},
+		kubeclient:           clientset.NewForConfigOrDie(opts.Kubeconfig),
+		cephClusterNamespace: opts.AllowedNamespaces[0],
+		cephAuthNamespace:    opts.CephAuthNamespace,
+		initCephFn:           initCeph,
+		rbdImageStatusFn:     rbdImageStatus,
 	}
 }
 
 func (s *RBDMirrorStore) WithRBDCommandInput(namespace string) error {
-	var allow bool
-	for _, item := range s.allowedNamespaces {
-		if item == namespace {
-			allow = true
-			break
-		}
-	}
-	if !allow {
-		return fmt.Errorf("rbd-mirror metrics collection from namespace %q is not allowed", namespace)
-	}
-
-	input, err := s.initCephFn(s.kubeclient, []string{namespace})
+	input, err := s.initCephFn(s.kubeclient, namespace, s.cephAuthNamespace)
 	if err != nil {
 		return err
 	}
@@ -145,31 +137,34 @@ func (s *RBDMirrorStore) WithRBDCommandInput(namespace string) error {
 	return nil
 }
 
-func initCeph(kubeclient clientset.Interface, allowedNamespaces []string) (cephMonitorConfig, error) {
+func initCeph(kubeclient clientset.Interface, cephClusterNamespace, cephAuthNamespace string) (cephMonitorConfig, error) {
 	var err error
 	var namespace string
 	var secret *corev1.Secret
-	// find a namespace which has the expected secret
-	for _, currentNamespace := range allowedNamespaces {
-		secret, err = kubeclient.CoreV1().Secrets(currentNamespace).Get(context.TODO(), "rook-ceph-mon", v1.GetOptions{})
-		// if we are successful, collect the namespace and break
-		if err == nil {
-			namespace = currentNamespace
-			break
+
+	secret, err = kubeclient.CoreV1().Secrets(cephClusterNamespace).Get(context.TODO(), "ocs-metrics-exporter-ceph-auth", metav1.GetOptions{})
+	if err != nil && !apierror.IsNotFound(err) {
+		return cephMonitorConfig{}, err
+	}
+
+	if apierror.IsNotFound(err) {
+		secret, err = kubeclient.CoreV1().Secrets(cephClusterNamespace).Get(context.TODO(), "rook-csi-rbd-provisioner", metav1.GetOptions{})
+		if err != nil {
+			return cephMonitorConfig{}, err
 		}
 	}
-	// under any of these circumstances we should not proceed
-	if err != nil || secret == nil || namespace == "" {
-		return cephMonitorConfig{}, fmt.Errorf("failed to get secret in any of these namespaces %+v: %v",
-			allowedNamespaces, err)
-	}
-	key, ok := secret.Data["ceph-secret"]
-	if !ok {
-		return cephMonitorConfig{}, fmt.Errorf("failed to get client key from secret in namespace %q", namespace)
-	}
-	id := "admin"
 
-	configmap, err := kubeclient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "rook-ceph-csi-config", v1.GetOptions{})
+	id, ok := secret.Data["userID"]
+	if !ok {
+		return cephMonitorConfig{}, fmt.Errorf("failed to get ceph user id in namespace %q", namespace)
+	}
+
+	key, ok := secret.Data["userKey"]
+	if !ok {
+		return cephMonitorConfig{}, fmt.Errorf("failed to get ceph user key in namespace %q", namespace)
+	}
+
+	configmap, err := kubeclient.CoreV1().ConfigMaps(cephAuthNamespace).Get(context.TODO(), "rook-ceph-csi-config", metav1.GetOptions{})
 	if err != nil {
 		return cephMonitorConfig{}, fmt.Errorf("failed to get configmap in namespace %q: %v", namespace, err)
 	}
@@ -179,23 +174,35 @@ func initCeph(kubeclient clientset.Interface, allowedNamespaces []string) (cephM
 		return cephMonitorConfig{}, fmt.Errorf("failed to get CSI cluster config from configmap in namespace %q", namespace)
 	}
 
-	var clusterConfig []csiClusterConfig
-	err = json.Unmarshal([]byte(data), &clusterConfig)
+	var clusterConfigs []csiClusterConfig
+	err = json.Unmarshal([]byte(data), &clusterConfigs)
 	if err != nil {
 		return cephMonitorConfig{}, fmt.Errorf("failed to unmarshal csi-cluster-config-json in namespace %q: %v", namespace, err)
 	}
 
-	if len(clusterConfig) == 0 {
+	if len(clusterConfigs) == 0 {
 		return cephMonitorConfig{}, fmt.Errorf("expected 1 or more CSI cluster config but found 0 from configmap in namespace %q", namespace)
 	}
-	if len(clusterConfig[0].Monitors) == 0 {
+
+	var clusterConfig csiClusterConfig
+	for idx := range clusterConfigs {
+		if clusterConfigs[idx].Namespace == cephClusterNamespace {
+			clusterConfig = clusterConfigs[idx]
+			break
+		}
+	}
+
+	if len(clusterConfig.Monitors) == 0 {
 		return cephMonitorConfig{}, fmt.Errorf("expected 1 or more monitors but found 0 from configmap in namespace %q", namespace)
 	}
 
 	input := cephMonitorConfig{}
-	input.monitor = clusterConfig[0].Monitors[0]
-	input.id = id
+	input.clusterID = clusterConfig.ClusterID
+	input.cephClusterNamespace = clusterConfig.Namespace
+	input.monitor = clusterConfig.Monitors[0]
+	input.id = string(id)
 	input.key = string(key)
+
 	return input, nil
 }
 
@@ -335,7 +342,7 @@ func CreateCephBlockPoolListWatch(cephClient rookclient.Interface, namespace, fi
 /* RBD CLI Commands */
 
 type cephMonitorConfig struct {
-	monitor, id, key string
+	clusterID, cephClusterNamespace, monitor, id, key string
 }
 
 func rbdImageStatus(config *cephMonitorConfig, poolName string) (RBDMirrorStatusVerbose, error) {

--- a/metrics/internal/cache/rbd_mirror_test.go
+++ b/metrics/internal/cache/rbd_mirror_test.go
@@ -7,7 +7,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -15,7 +15,8 @@ var _ = Describe("RBDMirror Cache", func() {
 	defer GinkgoRecover()
 	opts := &options.Options{
 		Kubeconfig:        &rest.Config{},
-		AllowedNamespaces: []string{},
+		AllowedNamespaces: []string{""},
+		CephAuthNamespace: "",
 	}
 
 	When("new cache is requested", func() {
@@ -28,13 +29,14 @@ var _ = Describe("RBDMirror Cache", func() {
 
 	When("new CephBlockPool is added", func() {
 		rbdMirrorStore := NewRBDMirrorStore(opts)
-		rbdMirrorStore.initCephFn = func(kubeclient kubernetes.Interface, allowedNamespaces []string) (cephMonitorConfig, error) {
+		rbdMirrorStore.initCephFn = func(kubeclient clientset.Interface, cephClusterNamespace, cephAuthNamespace string) (cephMonitorConfig, error) {
 			return cephMonitorConfig{}, nil
 		}
 		rbdMirrorStore.rbdImageStatusFn = func(config *cephMonitorConfig, poolName string) (RBDMirrorStatusVerbose, error) {
 			return RBDMirrorStatusVerbose{}, nil
 		}
-		rbdMirrorStore.allowedNamespaces = []string{"test-namespace"}
+		rbdMirrorStore.cephClusterNamespace = "test-namespace"
+		rbdMirrorStore.cephAuthNamespace = "test-namespace"
 
 		When("CephBlockPool mirroring is not enabled", func() {
 			pool := cephv1.CephBlockPool{

--- a/metrics/internal/options/options.go
+++ b/metrics/internal/options/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	ExporterPort      int
 	Help              bool
 	AllowedNamespaces []string
+	CephAuthNamespace string
 	IsDevelopment     bool
 
 	flags      *pflag.FlagSet
@@ -55,6 +56,7 @@ func (o *Options) AddFlags() {
 	o.flags.IntVar(&o.ExporterPort, "exporter-port", exporterMetricsPort, "Port to expose exporter self metrics on.")
 	o.flags.BoolVar(&o.Help, "help", false, "To display Usage information.")
 	o.flags.StringArrayVar(&o.AllowedNamespaces, "namespaces", []string{"openshift-storage"}, "List of namespaces to be monitored.")
+	o.flags.StringVar(&o.CephAuthNamespace, "ceph-auth-namespace", "openshift-storage", "Namespace to fetch the Ceph auth from.")
 	o.flags.BoolVar(&o.IsDevelopment, "development", false, "If we are running in development mode")
 }
 


### PR DESCRIPTION
Users can define custom auth via "ocs-metrics-exporter-ceph-auth" secret or fallback to "rook-csi-rbd-provisioner" which has the auth we need. It will work for all modes of deployment.