### PR TITLE
fix PV cache error conditions

### DIFF
--- a/metrics/internal/cache/pv.go
+++ b/metrics/internal/cache/pv.go
@@ -165,6 +165,10 @@ func (p *PersistentVolumeStore) add(pv *corev1.PersistentVolume) error {
 		return fmt.Errorf("failed to get node name for pod: %v", err)
 	}
 
+	if nodeName == "" {
+		return nil
+	}
+
 	for _, client := range clients.Watchers {
 		p.RBDClientMap[client.Address] = appendIfNotExists(p.RBDClientMap[client.Address], nodeName)
 	}
@@ -173,8 +177,8 @@ func (p *PersistentVolumeStore) add(pv *corev1.PersistentVolume) error {
 }
 
 func getNodeNameForPV(pv *corev1.PersistentVolume, kubeClient clientset.Interface) (string, error) {
-	if pv.Spec.ClaimRef == nil {
-		return "", fmt.Errorf("persistent volume %s is not bound to any claim", pv.Name)
+	if pv.Status.Phase != corev1.VolumeBound {
+		return "", nil
 	}
 
 	pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(context.Background(), pv.Spec.ClaimRef.Name, metav1.GetOptions{})
@@ -201,7 +205,7 @@ func getNodeNameForPV(pv *corev1.PersistentVolume, kubeClient clientset.Interfac
 		}
 	}
 
-	return "", fmt.Errorf("no pod is using PVC %s/%s", pvc.Namespace, pvc.Name)
+	return "", nil
 }
 
 // Update updates the existing entry in the PersistentVolumeStore.


### PR DESCRIPTION
For cases where PV exists without PVC, or PV/PVC exists but is not used by any Pod etc, we skip caching those PVs instead of returning an error as these neither provide any meaningful data nor have any impact on monitoring.