### PR TITLE
add CSI_DRIVER_NAME_PREFIX to Rook config

### DIFF
--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -115,8 +115,8 @@ func generateNameForSnapshotClass(initData *ocsv1.StorageCluster, snapshotType S
 	return fmt.Sprintf("%s-%splugin-snapclass", initData.Name, snapshotType)
 }
 
-func generateNameForSnapshotClassDriver(initData *ocsv1.StorageCluster, snapshotType SnapshotterType) string {
-	return fmt.Sprintf("%s.%s.csi.ceph.com", initData.Namespace, snapshotType)
+func generateNameForSnapshotClassDriver(snapshotType SnapshotterType) string {
+	return fmt.Sprintf("%s.%s.csi.ceph.com", csiDriverNamePrefix, snapshotType)
 }
 
 func generateNameForSnapshotClassSecret(instance *ocsv1.StorageCluster, snapshotType SnapshotterType) string {

--- a/controllers/storagecluster/volumesnapshotterclasses.go
+++ b/controllers/storagecluster/volumesnapshotterclasses.go
@@ -46,7 +46,7 @@ func newVolumeSnapshotClass(instance *ocsv1.StorageCluster, snapShotterType Snap
 		ObjectMeta: metav1.ObjectMeta{
 			Name: generateNameForSnapshotClass(instance, snapShotterType),
 		},
-		Driver: generateNameForSnapshotClassDriver(instance, snapShotterType),
+		Driver: generateNameForSnapshotClassDriver(snapShotterType),
 		Parameters: map[string]string{
 			"clusterID":                instance.Namespace,
 			snapshotterSecretName:      generateNameForSnapshotClassSecret(instance, snapShotterType),

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -3196,6 +3196,8 @@ spec:
                     configMapKeyRef:
                       key: CSI_CLUSTER_NAME
                       name: ocs-operator-config
+                - name: CSI_DRIVER_NAME_PREFIX
+                  value: openshift-storage
                 - name: CSI_ENABLE_TOPOLOGY
                   valueFrom:
                     configMapKeyRef:

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -276,6 +276,10 @@ func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 				},
 			},
 			{
+				Name:  "CSI_DRIVER_NAME_PREFIX",
+				Value: "openshift-storage",
+			},
+			{
 				Name: "CSI_ENABLE_TOPOLOGY",
 				ValueFrom: &corev1.EnvVarSource{
 					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{


### PR DESCRIPTION
The current practice is to prefix the names of CephCSI drivers with the namespace name of the deployed Rook operator. However, if Rook is deployed in a different namespace (e.g. "xyz"), then the CephCSI driver name will also be prefixed with "xyz". This is not desirable, as we always want to use "openshift-storage" as the prefix, regardless of the namespace where Rook is deployed. This PR sets the CSI_DRIVER_NAME_PREFIX to a static value, i.e. "openshift-storage" for all CephCSI drivers.