### PR TITLE
Add 'managedBy' label to rook-ceph-exporter metrics

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -478,10 +478,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *v
 			ContinueUpgradeAfterChecksEvenIfNotHealthy: sc.Spec.ResourceProfile == sc.Status.LastAppliedResourceProfile,
 			LogCollector: logCollector,
 			Labels: rookCephv1.LabelsSpec{
-				rookCephv1.KeyMgr:        rookCephv1.Labels{defaults.ODFResourceProfileKey: sc.Spec.ResourceProfile},
-				rookCephv1.KeyMon:        rookCephv1.Labels{defaults.ODFResourceProfileKey: sc.Spec.ResourceProfile},
-				rookCephv1.KeyOSD:        rookCephv1.Labels{defaults.ODFResourceProfileKey: sc.Spec.ResourceProfile},
-				rookCephv1.KeyMonitoring: getCephClusterMonitoringLabels(*sc),
+				rookCephv1.KeyMgr:          rookCephv1.Labels{defaults.ODFResourceProfileKey: sc.Spec.ResourceProfile},
+				rookCephv1.KeyMon:          rookCephv1.Labels{defaults.ODFResourceProfileKey: sc.Spec.ResourceProfile},
+				rookCephv1.KeyOSD:          rookCephv1.Labels{defaults.ODFResourceProfileKey: sc.Spec.ResourceProfile},
+				rookCephv1.KeyMonitoring:   getCephClusterMonitoringLabels(*sc),
+				rookCephv1.KeyCephExporter: getCephClusterMonitoringLabels(*sc),
 			},
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: getReadAffinityOptions(sc),
@@ -640,7 +641,8 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, monitoringIP, monitoringPo
 			Monitoring: monitoringSpec,
 			Network:    getNetworkSpec(*sc),
 			Labels: rookCephv1.LabelsSpec{
-				rookCephv1.KeyMonitoring: getCephClusterMonitoringLabels(*sc),
+				rookCephv1.KeyMonitoring:   getCephClusterMonitoringLabels(*sc),
+				rookCephv1.KeyCephExporter: getCephClusterMonitoringLabels(*sc),
 			},
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: getReadAffinityOptions(sc),


### PR DESCRIPTION
Currently we add the 'managedBy' label to ceph metrics, similarly we need to add 'managedBy' label to ceph exporter metrics.