### PR TITLE
split rook monitoring rbac into multiple files

### DIFF
--- a/deploy/ocs-operator/manifests/rook-ceph-metrics-role.yaml
+++ b/deploy/ocs-operator/manifests/rook-ceph-metrics-role.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/ocs-operator/manifests/rook-ceph-monitor-role.yaml
+++ b/deploy/ocs-operator/manifests/rook-ceph-monitor-role.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/deploy/ocs-operator/manifests/rook-monitor-mgr-role.yaml
+++ b/deploy/ocs-operator/manifests/rook-monitor-mgr-role.yaml
@@ -1,4 +1,3 @@
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,37 +12,3 @@ rules:
   - list
   - create
   - update
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: rook-ceph-monitor
-rules:
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - delete
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: rook-ceph-metrics
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - endpoints
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
----

--- a/rbac/rook-ceph-metrics-role.yaml
+++ b/rbac/rook-ceph-metrics-role.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/rbac/rook-ceph-monitor-role.yaml
+++ b/rbac/rook-ceph-monitor-role.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/rbac/rook-monitor-mgr-role.yaml
+++ b/rbac/rook-monitor-mgr-role.yaml
@@ -1,4 +1,3 @@
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,37 +12,3 @@ rules:
   - list
   - create
   - update
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: rook-ceph-monitor
-rules:
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - delete
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: rook-ceph-metrics
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - endpoints
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
----


### PR DESCRIPTION
Some build tools do not work well with multiple yaml in same file. This
causes operator bundle builds to fail.