### PR TITLE
stop CephMonLowNumber alert when MON count is 5

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -290,7 +290,7 @@ spec:
         severity_level: info
         storage_type: ceph
       expr: |
-        ((count by (managedBy, namespace) (ceph_mon_metadata)) - on(managedBy,namespace) group_right() (ocs_storagecluster_failure_domain_count>=5)) < 0
+        ((count by (managedBy, namespace) (ceph_mon_metadata)<5) - on(managedBy,namespace) group_right() (ocs_storagecluster_failure_domain_count>=5)) < 0
       labels:
         severity: info
   - name: ceph-daemon-performance-alerts.rules

--- a/metrics/mixin/alerts/storage-cluster.libsonnet
+++ b/metrics/mixin/alerts/storage-cluster.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'CephMonLowNumber',
             expr: |||
-              ((count by (managedBy, namespace) (ceph_mon_metadata)) - on(managedBy,namespace) group_right() (ocs_storagecluster_failure_domain_count>=5)) < 0
+              ((count by (managedBy, namespace) (ceph_mon_metadata)<5) - on(managedBy,namespace) group_right() (ocs_storagecluster_failure_domain_count>=5)) < 0
             |||,
             labels: {
               severity: 'info',


### PR DESCRIPTION
Even when number of MONs were increased from 3 to 5, the alert was not stopping. This is because the query did not check if Mon count is already >=5. This PR adds that check to ensure we stop alerting when MON count is 5 or more.