### PR TITLE
Enable externalPgSSLRequired only when tlssecret exists

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -199,10 +199,10 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 		nb.Spec.DisableLoadBalancerService = sc.Spec.MultiCloudGateway.DisableLoadBalancerService
 
 		if sc.Spec.MultiCloudGateway.ExternalPgConfig != nil && sc.Spec.MultiCloudGateway.ExternalPgConfig.PGSecretName != "" {
-			nb.Spec.ExternalPgSSLRequired = true
 			nb.Spec.ExternalPgSecret = &corev1.SecretReference{Name: sc.Spec.MultiCloudGateway.ExternalPgConfig.PGSecretName, Namespace: sc.Namespace}
 			nb.Spec.ExternalPgSSLUnauthorized = sc.Spec.MultiCloudGateway.ExternalPgConfig.AllowSelfSignedCerts
 			if sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName != "" {
+				nb.Spec.ExternalPgSSLRequired = true
 				nb.Spec.ExternalPgSSLSecret = &corev1.SecretReference{Name: sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName, Namespace: sc.Namespace}
 			}
 		}


### PR DESCRIPTION
This is a small fix where we need to enable SSL only when tlsSecretName is present.

https://bugzilla.redhat.com/show_bug.cgi?id=2257982#c12