### PR TITLE
[fusion-hci-4.14] storageClassRequest: move away from status as source of truth

### DIFF
--- a/controllers/util/slices.go
+++ b/controllers/util/slices.go
@@ -1,0 +1,13 @@
+package util
+
+// Filter returns all the entry matching the function "f" or else return nil
+func Filter[T any](list []T, f func(item *T) bool) []*T {
+	var ret []*T
+	for idx := range list {
+		elm := &list[idx]
+		if f(elm) {
+			ret = append(ret, elm)
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
manual cherry-pick of one commit from #2449. the diff from #2449  is we aren't taking the unit test file which doesn't exist in fusion-hci-4.14 branch and different pr introduced that in main.

this also contains two commits from #2249 which was a refactor of function signature and logging update.