### PR TITLE
Fix cephCluster invalid spec error in replica-1 due to misspelled field

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -213,7 +213,7 @@ type ManageCephNonResilientPools struct {
 	Enable bool `json:"enable,omitempty"`
 	// Count is the number of devices in this set
 	// +kubebuilder:validation:Minimum=1
-	// +kubeBuilder:default=1
+	// +kubebuilder:default=1
 	Count int `json:"count,omitempty"`
 	// ResourceRequirements (requests/limits) for the devices
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -747,6 +747,7 @@ spec:
                       ceph non-resilient pools
                     properties:
                       count:
+                        default: 1
                         description: Count is the number of devices in this set
                         minimum: 1
                         type: integer

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -747,6 +747,7 @@ spec:
                       ceph non-resilient pools
                     properties:
                       count:
+                        default: 1
                         description: Count is the number of devices in this set
                         minimum: 1
                         type: integer

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -746,6 +746,7 @@ spec:
                       ceph non-resilient pools
                     properties:
                       count:
+                        default: 1
                         description: Count is the number of devices in this set
                         minimum: 1
                         type: integer

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -213,7 +213,7 @@ type ManageCephNonResilientPools struct {
 	Enable bool `json:"enable,omitempty"`
 	// Count is the number of devices in this set
 	// +kubebuilder:validation:Minimum=1
-	// +kubeBuilder:default=1
+	// +kubebuilder:default=1
 	Count int `json:"count,omitempty"`
 	// ResourceRequirements (requests/limits) for the devices
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`


### PR DESCRIPTION
While defining the default for the field it should have been
kubebuilder in all small letters, but earlier it was defined as
kubeBuilder which was causing the error. As the default 1 was not being
set, 0 was being passed as the count to the cephcluster which was reporting
invalid spec error.
Ref-https://bugzilla.redhat.com/show_bug.cgi?id=2263319