### PR TITLE
Adds spec changes to enable TLS on external Postgresql server

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -407,6 +407,9 @@ type ExternalPGSpec struct {
 	// AllowSelfSignedCerts will allow the Postgres server to use self signed certificates to authenticate
 	// +optional
 	AllowSelfSignedCerts bool `json:"allowSelfSignedCerts,omitempty"`
+	// EnableTLS will allow the postgres server to connect via TLS/SSL
+	// +optional
+	EnableTLS bool `json:"enableTls,omitempty"`
 	// TLSSecret stores the secret name which contains the client side certificates if enabled
 	// +optional
 	TLSSecretName string `json:"tlsSecretName,omitempty"`

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -1793,6 +1793,10 @@ spec:
                         description: AllowSelfSignedCerts will allow the Postgres
                           server to use self signed certificates to authenticate
                         type: boolean
+                      enableTls:
+                        description: EnableTLS will allow the postgres server to connect
+                          via TLS/SSL
+                        type: boolean
                       pgSecretName:
                         description: PGSecret stores the secret name which contains
                           connection string of the Postgres server

--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -201,11 +201,16 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 		if sc.Spec.MultiCloudGateway.ExternalPgConfig != nil && sc.Spec.MultiCloudGateway.ExternalPgConfig.PGSecretName != "" {
 			nb.Spec.ExternalPgSecret = &corev1.SecretReference{Name: sc.Spec.MultiCloudGateway.ExternalPgConfig.PGSecretName, Namespace: sc.Namespace}
 			nb.Spec.ExternalPgSSLUnauthorized = sc.Spec.MultiCloudGateway.ExternalPgConfig.AllowSelfSignedCerts
-			if sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName != "" {
-				nb.Spec.ExternalPgSSLRequired = true
+			nb.Spec.ExternalPgSSLRequired = sc.Spec.MultiCloudGateway.ExternalPgConfig.EnableTLS
+			if sc.Spec.MultiCloudGateway.ExternalPgConfig.EnableTLS && sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName != "" {
 				nb.Spec.ExternalPgSSLSecret = &corev1.SecretReference{Name: sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName, Namespace: sc.Namespace}
 			}
+
+			if !sc.Spec.MultiCloudGateway.ExternalPgConfig.EnableTLS && sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName != "" {
+				return fmt.Errorf("Failed to create Noobaa system: tlsSecretName is a non-nil value while enableTls is disabled. Please set spec.multiCloudGateway.externalPgConfig.enableTls to true and retry again. enableTls: %v and tlsSecretName: %v", sc.Spec.MultiCloudGateway.ExternalPgConfig.EnableTLS, sc.Spec.MultiCloudGateway.ExternalPgConfig.TLSSecretName)
+			}
 		}
+
 	}
 
 	// Add KMS details to Noobaa spec, only if

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -1793,6 +1793,10 @@ spec:
                         description: AllowSelfSignedCerts will allow the Postgres
                           server to use self signed certificates to authenticate
                         type: boolean
+                      enableTls:
+                        description: EnableTLS will allow the postgres server to connect
+                          via TLS/SSL
+                        type: boolean
                       pgSecretName:
                         description: PGSecret stores the secret name which contains
                           connection string of the Postgres server

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -1792,6 +1792,10 @@ spec:
                         description: AllowSelfSignedCerts will allow the Postgres
                           server to use self signed certificates to authenticate
                         type: boolean
+                      enableTls:
+                        description: EnableTLS will allow the postgres server to connect
+                          via TLS/SSL
+                        type: boolean
                       pgSecretName:
                         description: PGSecret stores the secret name which contains
                           connection string of the Postgres server

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -407,6 +407,9 @@ type ExternalPGSpec struct {
 	// AllowSelfSignedCerts will allow the Postgres server to use self signed certificates to authenticate
 	// +optional
 	AllowSelfSignedCerts bool `json:"allowSelfSignedCerts,omitempty"`
+	// EnableTLS will allow the postgres server to connect via TLS/SSL
+	// +optional
+	EnableTLS bool `json:"enableTls,omitempty"`
 	// TLSSecret stores the secret name which contains the client side certificates if enabled
 	// +optional
 	TLSSecretName string `json:"tlsSecretName,omitempty"`


### PR DESCRIPTION
This commit adds changes to enable TLS on external postgresql server independent of whether the client passes certificates or not. Certificates are optional requirement and TLS can be enabled without them.