### PR TITLE
fix csv generation. 

### DIFF
--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -461,10 +461,7 @@ func marshallObject(obj interface{}, writer io.Writer, modifyUnstructuredFunc fu
 		return err
 	}
 
-	// fix double quoted strings by removing unneeded single quotes...
 	s := string(yamlBytes)
-	s = strings.Replace(s, " '\"", " \"", -1)
-	s = strings.Replace(s, "\"'\n", "\"\n", -1)
 
 	yamlBytes = []byte(s)
 


### PR DESCRIPTION
The csv-merger tool contained code intended to replace allegedly unnecessary single quotes with double quotes in component crds.

This could sometimes result in broken csvs where ending quotes were simply removed

This change fixes these breakages by removing the culprit replacement code.