### PR TITLE
Increase mgr resources to avoid mgr OOMKilled

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -73,8 +73,8 @@ var (
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("0.5"),
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},
 		"mon": {
@@ -126,8 +126,8 @@ var (
 				corev1.ResourceMemory: resource.MustParse("1.5Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("1.5Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
 			},
 		},
 		"mon": {
@@ -175,12 +175,12 @@ var (
 	PerformanceDaemonResources = map[string]corev1.ResourceRequirements{
 		"mgr": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceCPU:    resource.MustParse("1.5"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
 		"mon": {


### PR DESCRIPTION
Ref-https://bugzilla.redhat.com/show_bug.cgi?id=2258357#c13

We had reduced the mgr resources to minimal possible values during the introduction of the resource profiles. But recently we have observed that the mgr is getting OOMKilled in some of the setups during some actions.