### PR TITLE
make ".spec.allowRemoteStorageConsumers" immutable on creation

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -92,6 +92,8 @@ type StorageClusterSpec struct {
 
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="AllowRemoteStorageConsumers is immutable"
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -56,10 +56,14 @@ spec:
             description: StorageClusterSpec defines the desired state of StorageCluster
             properties:
               allowRemoteStorageConsumers:
+                default: false
                 description: AllowRemoteStorageConsumers Indicates that the OCS cluster
                   should deploy the needed components to enable connections from remote
                   consumers.
                 type: boolean
+                x-kubernetes-validations:
+                - message: AllowRemoteStorageConsumers is immutable
+                  rule: self == oldSelf
               arbiter:
                 description: ArbiterSpec specifies the storage cluster options related
                   to arbiter. If Arbiter is enabled, ArbiterLocation in the NodeTopologies

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -56,10 +56,14 @@ spec:
             description: StorageClusterSpec defines the desired state of StorageCluster
             properties:
               allowRemoteStorageConsumers:
+                default: false
                 description: AllowRemoteStorageConsumers Indicates that the OCS cluster
                   should deploy the needed components to enable connections from remote
                   consumers.
                 type: boolean
+                x-kubernetes-validations:
+                - message: AllowRemoteStorageConsumers is immutable
+                  rule: self == oldSelf
               arbiter:
                 description: ArbiterSpec specifies the storage cluster options related
                   to arbiter. If Arbiter is enabled, ArbiterLocation in the NodeTopologies

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -55,10 +55,14 @@ spec:
             description: StorageClusterSpec defines the desired state of StorageCluster
             properties:
               allowRemoteStorageConsumers:
+                default: false
                 description: AllowRemoteStorageConsumers Indicates that the OCS cluster
                   should deploy the needed components to enable connections from remote
                   consumers.
                 type: boolean
+                x-kubernetes-validations:
+                - message: AllowRemoteStorageConsumers is immutable
+                  rule: self == oldSelf
               arbiter:
                 description: ArbiterSpec specifies the storage cluster options related
                   to arbiter. If Arbiter is enabled, ArbiterLocation in the NodeTopologies

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -92,6 +92,8 @@ type StorageClusterSpec struct {
 
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="AllowRemoteStorageConsumers is immutable"
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.


### PR DESCRIPTION
We have a switch that differentiates whether we are running in provider mode or not. However as this switch isn't immutable there's always a possibility to flip it (un/)intentionally.

This commit forces the switch to be immutable on creation which guarantees the field to be source of truth for provider mode.