### PR TITLE
Prevent ObcQuotaObjectsAlert overlapping with ObcQuotaObjectsExhausedAlert

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -93,7 +93,7 @@ spec:
         severity_level: warning
         storage_type: RGW
       expr: |
-        (ocs_objectbucketclaim_info * on (namespace, objectbucket, managedBy) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket, managedBy) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80 < 1
       for: 10s
       labels:
         severity: warning
@@ -110,7 +110,7 @@ spec:
         severity_level: warning
         storage_type: RGW
       expr: |
-        (ocs_objectbucketclaim_info * on (namespace, managedBy, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80
+        (ocs_objectbucketclaim_info * on (namespace, managedBy, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80 < 1
       for: 10s
       labels:
         severity: warning

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -194,7 +194,7 @@ spec:
         severity_level: warning
         storage_type: RGW
       expr: |
-        (ocs_objectbucketclaim_info * on (namespace, objectbucket, managedBy) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket, managedBy) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80 < 1
       for: 10s
       labels:
         severity: warning
@@ -211,7 +211,7 @@ spec:
         severity_level: warning
         storage_type: RGW
       expr: |
-        (ocs_objectbucketclaim_info * on (namespace, managedBy, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80
+        (ocs_objectbucketclaim_info * on (namespace, managedBy, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80 < 1
       for: 10s
       labels:
         severity: warning


### PR DESCRIPTION
Since queries for both ObcQuotaObjectsAlert and
ObcQuotaObjectsExhausedAlert are same, we don't require both the alerts to be fired at the same time.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2257949