### PR TITLE
cephblockpool: allow updation of mirroring field from different components

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -85,7 +85,9 @@ type StorageClusterSpec struct {
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
 	// Mirroring specifies data mirroring configuration for the storage cluster.
 	// This configuration will only be applied to resources managed by the operator.
-	Mirroring MirroringSpec `json:"mirroring,omitempty"`
+	// +nullable
+	// +optional
+	Mirroring *MirroringSpec `json:"mirroring,omitempty"`
 	// OverprovisionControl specifies the allowed hard-limit PVs overprovisioning relative to
 	// the effective usable storage capacity.
 	OverprovisionControl []OverprovisionControlSpec `json:"overprovisionControl,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -874,7 +874,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Arbiter.DeepCopyInto(&out.Arbiter)
-	in.Mirroring.DeepCopyInto(&out.Mirroring)
+	if in.Mirroring != nil {
+		in, out := &in.Mirroring, &out.Mirroring
+		*out = new(MirroringSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OverprovisionControl != nil {
 		in, out := &in.OverprovisionControl, &out.OverprovisionControl
 		*out = make([]OverprovisionControlSpec, len(*in))

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -1789,6 +1789,7 @@ spec:
                 description: Mirroring specifies data mirroring configuration for
                   the storage cluster. This configuration will only be applied to
                   resources managed by the operator.
+                nullable: true
                 properties:
                   enabled:
                     description: If true, data mirroring is enabled for the StorageCluster.

--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -81,6 +81,13 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 				},
 			},
 		},
+		{
+			label:                "test-mirroring-is-not-set",
+			createRuntimeObjects: false,
+			spec: &api.StorageClusterSpec{
+				Mirroring: nil,
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -96,6 +103,8 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 		assert.NoError(t, err)
 		if c.label == "test-injecting-peer-token-to-cephblockpool" {
 			assertCephBlockPools(t, reconciler, cr, request, true, true)
+		} else if c.label == "test-mirroring-is-not-set" {
+			assertCephBlockPools(t, reconciler, cr, request, false, true)
 		} else {
 			assertCephBlockPools(t, reconciler, cr, request, true, false)
 		}

--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -55,7 +55,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			label:                "test-injecting-peer-token-to-cephblockpool",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{testPeerSecretName},
 				},
@@ -65,7 +65,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			label:                "test-injecting-empty-peer-token-to-cephblockpool",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{},
 				},
@@ -75,7 +75,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			label:                "test-injecting-invalid-peer-token-cephblockpool",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{"wrong-secret-name"},
 				},

--- a/controllers/storagecluster/cephrbdmirrors_test.go
+++ b/controllers/storagecluster/cephrbdmirrors_test.go
@@ -24,7 +24,7 @@ func TestCephRbdMirror(t *testing.T) {
 			label:                "create-ceph-rbd-mirror",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{testPeerSecretName},
 				},
@@ -34,7 +34,7 @@ func TestCephRbdMirror(t *testing.T) {
 			label:                "delete-ceph-rbd-mirror",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled: false,
 				},
 			},

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -1789,6 +1789,7 @@ spec:
                 description: Mirroring specifies data mirroring configuration for
                   the storage cluster. This configuration will only be applied to
                   resources managed by the operator.
+                nullable: true
                 properties:
                   enabled:
                     description: If true, data mirroring is enabled for the StorageCluster.

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -1788,6 +1788,7 @@ spec:
                 description: Mirroring specifies data mirroring configuration for
                   the storage cluster. This configuration will only be applied to
                   resources managed by the operator.
+                nullable: true
                 properties:
                   enabled:
                     description: If true, data mirroring is enabled for the StorageCluster.

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -85,7 +85,9 @@ type StorageClusterSpec struct {
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
 	// Mirroring specifies data mirroring configuration for the storage cluster.
 	// This configuration will only be applied to resources managed by the operator.
-	Mirroring MirroringSpec `json:"mirroring,omitempty"`
+	// +nullable
+	// +optional
+	Mirroring *MirroringSpec `json:"mirroring,omitempty"`
 	// OverprovisionControl specifies the allowed hard-limit PVs overprovisioning relative to
 	// the effective usable storage capacity.
 	OverprovisionControl []OverprovisionControlSpec `json:"overprovisionControl,omitempty"`

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -874,7 +874,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Arbiter.DeepCopyInto(&out.Arbiter)
-	in.Mirroring.DeepCopyInto(&out.Mirroring)
+	if in.Mirroring != nil {
+		in, out := &in.Mirroring, &out.Mirroring
+		*out = new(MirroringSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OverprovisionControl != nil {
 		in, out := &in.OverprovisionControl, &out.OverprovisionControl
 		*out = make([]OverprovisionControlSpec, len(*in))

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -85,7 +85,9 @@ type StorageClusterSpec struct {
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
 	// Mirroring specifies data mirroring configuration for the storage cluster.
 	// This configuration will only be applied to resources managed by the operator.
-	Mirroring MirroringSpec `json:"mirroring,omitempty"`
+	// +nullable
+	// +optional
+	Mirroring *MirroringSpec `json:"mirroring,omitempty"`
 	// OverprovisionControl specifies the allowed hard-limit PVs overprovisioning relative to
 	// the effective usable storage capacity.
 	OverprovisionControl []OverprovisionControlSpec `json:"overprovisionControl,omitempty"`

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -874,7 +874,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Arbiter.DeepCopyInto(&out.Arbiter)
-	in.Mirroring.DeepCopyInto(&out.Mirroring)
+	if in.Mirroring != nil {
+		in, out := &in.Mirroring, &out.Mirroring
+		*out = new(MirroringSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OverprovisionControl != nil {
 		in, out := &in.OverprovisionControl, &out.OverprovisionControl
 		*out = make([]OverprovisionControlSpec, len(*in))


### PR DESCRIPTION
When ocs-operator reconciles the cephblockpool object, it resets the mirroring field irrespective of whether mirroring is being used in the storageCluster API. This PR aims to modify the storageCluster API and allow us to enable mirroring on cephblockpool from StorageClusterPeer/API Server (required for RDR for Provider Mode).

After this PR,
When the mirroring object is nil, other components can set/unset the mirroringSpec on the cephBlockPool.
When the mirroring object is not nil, mirroring on the pools will be set based on the value of MirroringSpec in the storageCluster.