### PR TITLE
add support for Azure key vault

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -185,6 +185,8 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 				sc.Status.KMSServerConnection.KMSServerConnectionError = ""
 				if kmsConfigMap.Data["KMS_PROVIDER"] == "vault" {
 					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["VAULT_ADDR"]
+				} else if kmsConfigMap.Data["KMS_PROVIDER"] == AzureKSMProvider {
+					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["AZURE_VAULT_URL"]
 				}
 				if err = reachKMSProvider(kmsConfigMap); err != nil {
 					sc.Status.KMSServerConnection.KMSServerConnectionError = err.Error()

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -704,7 +704,13 @@ func createDummyKMSConfigMap(kmsProvider, kmsAddr string, kmsAuthMethod string) 
 		cm.Data["IBM_KP_SECRET_NAME"] = "my-kms-key"
 		cm.Data["IBM_KP_BASE_URL"] = "my-base-url"
 		cm.Data["IBM_KP_TOKEN_URL"] = "my-token-url"
+	case AzureKSMProvider:
+		cm.Data["AZURE_CLIENT_ID"] = "azure-client-id"
+		cm.Data["AZURE_TENANT_ID"] = "azure-tenant-id"
+		cm.Data["AZURE_VAULT_URL"] = kmsAddr
+		cm.Data["AZURE_CERT_SECRET_NAME"] = "cert-secret"
 	}
+
 	return cm
 }
 
@@ -736,6 +742,8 @@ func TestKMSConfigChanges(t *testing.T) {
 		{testLabel: "case 7", kmsProvider: VaultKMSProvider,
 			enabled: true, kmsAddress: "http://localhost:5678", authMethod: VaultSAAuthMethod},
 		{testLabel: "case 8", kmsProvider: ThalesKMSProvider,
+			clusterWideEncryption: true, kmsAddress: "http://localhost:5671"},
+		{testLabel: "case 9", kmsProvider: AzureKSMProvider,
 			clusterWideEncryption: true, kmsAddress: "http://localhost:5671"},
 	}
 	for _, kmsArgs := range validKMSArgs {

--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -35,6 +35,8 @@ const (
 	IbmKeyProtectKMSProvider = "ibmkeyprotect"
 	// ThalesKMSProvider a constant to represent Thales (using KMIP) KMS provider
 	ThalesKMSProvider = "kmip"
+	// AzureKSMProvider represents the Azure Key vault.
+	AzureKSMProvider = "azure-kv"
 )
 
 var (


### PR DESCRIPTION
EPIC: https://issues.redhat.com/browse/RHSTOR-5466

Tested the changes to see if cephCluster is getting the KMS settings correctly
``` security:
      keyRotation:
        enabled: false
        schedule: '@weekly'
      kms:
        connectionDetails:
          AZURE_CERT_SECRET_NAME: azure-ocs-ffwc9o1j
          AZURE_CLIENT_ID: az-client-id1
          AZURE_TENANT_ID: az-tenant-id1
          AZURE_VAULT_URL: https://sapillai-kv2.vault.azure.net
          KMS_PROVIDER: azure-kv
    storage:
```

