### PR TITLE
Adding a monitoring interval for cephcluster

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -3,6 +3,7 @@ package storagecluster
 import (
 	// The embed package is required for the prometheus rule files
 	_ "embed"
+	"time"
 
 	"bytes"
 	"context"
@@ -452,7 +453,8 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *v
 				SSL:     sc.Spec.ManagedResources.CephDashboard.SSL,
 			},
 			Monitoring: rookCephv1.MonitoringSpec{
-				Enabled: true,
+				Enabled:  true,
+				Interval: &metav1.Duration{Duration: 30 * time.Second},
 			},
 			Storage: rookCephv1.StorageScopeSpec{
 				StorageClassDeviceSets:       newStorageClassDeviceSets(sc, serverVersion),


### PR DESCRIPTION
We need to increase monitoring interval of cephcluster. Rook-operator will read the monitoring -> interval from cephcluster CR and intern increase the rook ceph-exporter and ceph-mgr intervals.

Refer BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2269354