### PR TITLE
disable holder pods in greenfield clusters

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -273,6 +273,7 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 		util.EnableTopologyKey:           r.getEnableTopologyKeyValue(),
 		util.TopologyDomainLabelsKey:     r.getTopologyDomainLabelsKeyValue(),
 		util.EnableNFSKey:                r.getEnableNFSKeyValue(),
+		util.DisableHolderKey:            "true", // disable holder pods for all greenfield clusters
 	}
 
 	ocsOperatorConfig := &corev1.ConfigMap{

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -37,6 +37,7 @@ const (
 	EnableTopologyKey           = "CSI_ENABLE_TOPOLOGY"
 	TopologyDomainLabelsKey     = "CSI_TOPOLOGY_DOMAIN_LABELS"
 	EnableNFSKey                = "ROOK_CSI_ENABLE_NFS"
+	DisableHolderKey            = "CSI_REMOVE_HOLDER_PODS"
 )
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes


### PR DESCRIPTION
When deploying new StorageClusters, ocs-operator should apply the new Rook operator config `CSI_REMOVE_HOLDER_PODS: "true"`. This reflects the new config and default value that Rook specifies in example manifests here: https://github.com/rook/rook/pull/13890

This new value should be applied to the `rook-ceph-operator-config` only during installation of new (greenfield) StorageClusters.

It is required that ocs-operator **should not** update this value in existing (brownfield) clusters.