### PR TITLE
enable sse-s3 setting for rgw when cluster-wide-encryption enabled

### DIFF
--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -259,6 +259,10 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 						TokenSecretName:   KMSTokenSecretName,
 					},
 				},
+				ServerSideEncryptionS3: cephv1.KeyManagementServiceSpec{
+					ConnectionDetails: rgwConnDetails,
+					TokenSecretName:   KMSTokenSecretName,
+				},
 			}
 		}
 	}


### PR DESCRIPTION
Currently only sse-kms settings are enabled.