### PR TITLE
add ROOK_OBC_PROVISIONER_NAME_PREFIX to Rook Config

### DIFF
--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -116,7 +116,7 @@ func generateNameForSnapshotClass(initData *ocsv1.StorageCluster, snapshotType S
 }
 
 func generateNameForSnapshotClassDriver(snapshotType SnapshotterType) string {
-	return fmt.Sprintf("%s.%s.csi.ceph.com", csiDriverNamePrefix, snapshotType)
+	return fmt.Sprintf("%s.%s.csi.ceph.com", storageclassDriverNamePrefix, snapshotType)
 }
 
 func generateNameForSnapshotClassSecret(instance *ocsv1.StorageCluster, snapshotType SnapshotterType) string {

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 
@@ -27,14 +26,15 @@ const (
 	storageClassSkippedError      = "some StorageClasses were skipped while waiting for pre-requisites to be met"
 	defaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-	//csi driver name prefix
-	csiDriverNamePrefix = "openshift-storage"
+	//storage class driver name prefix
+	storageclassDriverNamePrefix = "openshift-storage"
 )
 
 var (
-	rbdDriverName    = csiDriverNamePrefix + ".rbd.csi.ceph.com"
-	cephFSDriverName = csiDriverNamePrefix + ".cephfs.csi.ceph.com"
-	nfsDriverName    = csiDriverNamePrefix + ".nfs.csi.ceph.com"
+	rbdDriverName    = storageclassDriverNamePrefix + ".rbd.csi.ceph.com"
+	cephFSDriverName = storageclassDriverNamePrefix + ".cephfs.csi.ceph.com"
+	nfsDriverName    = storageclassDriverNamePrefix + ".nfs.csi.ceph.com"
+	obcDriverName    = storageclassDriverNamePrefix + ".ceph.rook.io/bucket"
 )
 
 // StorageClassConfiguration provides configuration options for a StorageClass.
@@ -426,7 +426,7 @@ func newCephOBCStorageClassConfiguration(initData *ocsv1.StorageCluster) Storage
 					"description": "Provides Object Bucket Claims (OBCs)",
 				},
 			},
-			Provisioner:   fmt.Sprintf("%s.ceph.rook.io/bucket", os.Getenv(util.OperatorNamespaceEnvVar)),
+			Provisioner:   obcDriverName,
 			ReclaimPolicy: &reclaimPolicy,
 			Parameters: map[string]string{
 				"objectStoreNamespace": initData.Namespace,


### PR DESCRIPTION
Similar to CSI_DRIVER_NAME_PREFIX for obc provisioner so that the obc provisioner always checks for storageclass with name
 `openshift-storage.ceph.rook.io/bucket`