### PR TITLE
toolbox: add default service account to toolbox

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -683,7 +683,8 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration) *ap
 					},
 				},
 				Spec: corev1.PodSpec{
-					DNSPolicy: corev1.DNSClusterFirstWithHostNet,
+					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+					ServiceAccountName: "rook-ceph-default",
 					Containers: []corev1.Container{
 						{
 							Name:    name,

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -683,7 +683,8 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration) *ap
 					},
 				},
 				Spec: corev1.PodSpec{
-					DNSPolicy: corev1.DNSClusterFirstWithHostNet,
+					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+					ServiceAccountName: "rook-ceph-default",
 					Containers: []corev1.Container{
 						{
 							Name:    name,


### PR DESCRIPTION
currently scc are updated to remove the k8s default service account, so toolbox should start with rook-ceph-default service account