### PR TITLE
add suffix for external ceph client secret name during gRPC response

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -570,7 +570,10 @@ func (s *OCSProviderServer) GetStorageClassClaimConfig(ctx context.Context, req 
 				keyProp = "adminKey"
 			}
 			extR = append(extR, &pb.ExternalResource{
-				Name: clientSecretName,
+				// a common suffix '.csi' is being added to distinguish secrets that are created
+				// by ocs-client-operator vs rook-operator when both these operators are deployed in same namespace
+				// TODO: need to transform existing secrets during migration manually
+				Name: clientSecretName + ".csi",
 				Kind: "Secret",
 				Data: mustMarshal(map[string]string{
 					idProp:  cephRes.Name,

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
@@ -841,6 +842,10 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 			name = fmt.Sprintf("%s-volumesnapshotclass", name)
 		} else if extResource.Kind == "StorageClass" {
 			name = fmt.Sprintf("%s-storageclass", name)
+		} else if extResource.Kind == "Secret" {
+			var found bool
+			name, found = strings.CutSuffix(name, ".csi")
+			assert.True(t, found)
 		}
 		mockResoruce, ok := mockBlockPoolClaimExtR[name]
 		assert.True(t, ok)
@@ -849,7 +854,12 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, string(extResource.Data), string(data))
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
-		assert.Equal(t, extResource.Name, mockResoruce.Name)
+		if extResource.Kind == "Secret" {
+			name, _ := strings.CutSuffix(name, ".csi")
+			assert.Equal(t, name, mockResoruce.Name)
+		} else {
+			assert.Equal(t, extResource.Name, mockResoruce.Name)
+		}
 	}
 
 	// get the storage class request config for share filesystem
@@ -868,6 +878,10 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 			name = fmt.Sprintf("%s-volumesnapshotclass", name)
 		} else if extResource.Kind == "StorageClass" {
 			name = fmt.Sprintf("%s-storageclass", name)
+		} else if extResource.Kind == "Secret" {
+			var found bool
+			name, found = strings.CutSuffix(name, ".csi")
+			assert.True(t, found)
 		}
 		mockResoruce, ok := mockShareFilesystemClaimExtR[name]
 		assert.True(t, ok)
@@ -876,7 +890,12 @@ func TestOCSProviderServerGetStorageClassClaimConfig(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, string(extResource.Data), string(data))
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
-		assert.Equal(t, extResource.Name, mockResoruce.Name)
+		if extResource.Kind == "Secret" {
+			name, _ := strings.CutSuffix(name, ".csi")
+			assert.Equal(t, name, mockResoruce.Name)
+		} else {
+			assert.Equal(t, extResource.Name, mockResoruce.Name)
+		}
 	}
 
 	// When ceph resources is empty


### PR DESCRIPTION
when provider & client are running in same namespace the cephclient secret name clashes and as the contents will be different we'll add a suffix ".csi" to the secret which wll be managed by client.

Part of [RHSTOR-5487]