### PR TITLE
Add CSI_REMOVE_HOLDER_PODS key and its value in the ocs configmap

### DIFF
--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -35,6 +35,7 @@ const (
 	EnableTopologyKey           = "CSI_ENABLE_TOPOLOGY"
 	TopologyDomainLabelsKey     = "CSI_TOPOLOGY_DOMAIN_LABELS"
 	EnableNFSKey                = "ROOK_CSI_ENABLE_NFS"
+	CsiRemoveHolderPodsKey      = "CSI_REMOVE_HOLDER_PODS"
 )
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes


### PR DESCRIPTION
set the CSI_REMOVE_HOLDER_PODS to true for new users on version 4.16 onwards and set it to false for older/upgraded user to give them time to migrate manually.

with version 4.17 we will make the CSI_REMOVE_HOLDER_PODS to true for all customers older and new both.

If the configmap is being created for the first time we are considering it as a new install.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Jira: https://issues.redhat.com/browse/RHSTOR-5340?focusedId=24357013&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24357013