### PR TITLE
Set values in ocs-operator-config CM for replica-1 in external mode

### DIFF
--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -88,13 +88,6 @@ func generateNameForCephBlockPoolVirtualizationSC(initData *ocsv1.StorageCluster
 	return fmt.Sprintf("%s-ceph-rbd-virtualization", initData.Name)
 }
 
-func generateNameForNonResilientCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
-	if initData.Spec.ManagedResources.CephNonResilientPools.StorageClassName != "" {
-		return initData.Spec.ManagedResources.CephNonResilientPools.StorageClassName
-	}
-	return fmt.Sprintf("%s-ceph-non-resilient-rbd", initData.Name)
-}
-
 func generateNameForEncryptedCephBlockPoolSC(initData *ocsv1.StorageCluster) string {
 	if initData.Spec.Encryption.StorageClassName != "" {
 		return initData.Spec.Encryption.StorageClassName

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -339,7 +339,7 @@ func newNonResilientCephBlockPoolStorageClassConfiguration(initData *ocsv1.Stora
 	return StorageClassConfiguration{
 		storageClass: &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: generateNameForNonResilientCephBlockPoolSC(initData),
+				Name: util.GenerateNameForNonResilientCephBlockPoolSC(initData),
 				Annotations: map[string]string{
 					"description": "Ceph Non Resilient Pools : Provides RWO Filesystem volumes, and RWO and RWX Block volumes",
 				},


### PR DESCRIPTION
In external mode the replica-1 feature is not enabled via the
storageCluster CR. So detect the feature is enabled by checking if the
replica-1 storageClass exists. In external mode the failure domain is
not set in the storageCluster CR, so determine the failure domain key
by using the parameter of the storageClass. Also add a watch for
storageClass in the ocsinitialization controller to detect the
storageClass creation. Accordingly set the values in the CM.