### PR TITLE
use ROOK_CSI_DISABLE_DRIVER for disabling CSI in provider mode

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -458,13 +458,7 @@ func (r *OCSInitializationReconciler) ensureOcsOperatorConfigExists(initialData 
 		allowConsumers := slices.ContainsFunc(r.clusters.GetInternalStorageClusters(), func(sc ocsv1.StorageCluster) bool {
 			return sc.Spec.AllowRemoteStorageConsumers
 		})
-		if allowConsumers {
-			ocsOperatorConfigData[util.CsiEnableCephFSKey] = "false"
-			ocsOperatorConfigData[util.CsiEnableRBDKey] = "false"
-		} else {
-			ocsOperatorConfigData[util.CsiEnableCephFSKey] = "true"
-			ocsOperatorConfigData[util.CsiEnableRBDKey] = "true"
-		}
+		ocsOperatorConfigData[util.DisableCSIDriverKey] = strconv.FormatBool(allowConsumers)
 
 		if !reflect.DeepEqual(ocsOperatorConfig.Data, ocsOperatorConfigData) {
 			r.Log.Info("Updating ocs-operator-config configmap")

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -38,8 +38,7 @@ const (
 	TopologyDomainLabelsKey     = "CSI_TOPOLOGY_DOMAIN_LABELS"
 	EnableNFSKey                = "ROOK_CSI_ENABLE_NFS"
 	CsiRemoveHolderPodsKey      = "CSI_REMOVE_HOLDER_PODS"
-	CsiEnableCephFSKey          = "ROOK_CSI_ENABLE_CEPHFS"
-	CsiEnableRBDKey             = "ROOK_CSI_ENABLE_RBD"
+	DisableCSIDriverKey         = "ROOK_CSI_DISABLE_DRIVER"
 
 	// This is the name for the OwnerUID FieldIndex
 	OwnerUIDIndexName = "ownerUID"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -91,7 +91,7 @@ UX_BACKEND_OAUTH_FULL_IMAGE_NAME="${UX_BACKEND_OAUTH_FULL_IMAGE_NAME:-${DEFAULT_
 CSI_ADDONS_CATALOG_FULL_IMAGE_NAME="quay.io/ocs-dev/csi-addons-catalog:v0.7.0"
 OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/ocs-client-operator-bundle:v4.15.0"
 NOOBAA_BUNDLE_FULL_IMAGE_NAME="quay.io/noobaa/noobaa-operator-bundle:master-20231217"
-ROOK_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/rook-ceph-operator-bundle:master-5afe4a0"
+ROOK_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/rook-ceph-operator-bundle:master-50334e894"
 
 OCS_OPERATOR_INSTALL="${OCS_OPERATOR_INSTALL:-false}"
 OCS_CLUSTER_UNINSTALL="${OCS_CLUSTER_UNINSTALL:-false}"

--- a/hack/install-rook.sh
+++ b/hack/install-rook.sh
@@ -27,8 +27,7 @@ data:
   CSI_TOPOLOGY_DOMAIN_LABELS: "test"
   ROOK_CSI_ENABLE_NFS: "false"
   CSI_REMOVE_HOLDER_PODS: "true"
-  ROOK_CSI_ENABLE_CEPHFS: "true"
-  ROOK_CSI_ENABLE_RBD: "true"
+  ROOK_CSI_DISABLE_DRIVER: "false"
 EOF
 
 "$OPERATOR_SDK" run bundle "$ROOK_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"


### PR DESCRIPTION
when ocs is running in provider mode ocs-client-operator manages CSI and this commit adds a key/value for rook to make sure that rook doesn't reconcile CSI at all.

Depends on red-hat-storage/rook#600, red-hat-storage/rook#601

fixes: #2526  