### PR TITLE
storageclassrequest: set controller ownerref

### DIFF
--- a/controllers/storageclassrequest/storageclassrequest_controller.go
+++ b/controllers/storageclassrequest/storageclassrequest_controller.go
@@ -648,7 +648,7 @@ func (r *StorageClassRequestReconciler) list(obj client.ObjectList, listOptions 
 
 func (r *StorageClassRequestReconciler) own(resource metav1.Object) error {
 	// Ensure StorageClassRequest ownership on a resource
-	return controllerutil.SetOwnerReference(r.StorageClassRequest, resource, r.Scheme)
+	return controllerutil.SetControllerReference(r.StorageClassRequest, resource, r.Scheme)
 }
 
 func (r *StorageClassRequestReconciler) getNamespacedName() string {


### PR DESCRIPTION
The `own()` method was no setting a controller ownerref on objects created by the controller, which meant that updates to the created resources would not trigger reconciliation when using `Owns()` for the reconciler.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>