### PR TITLE
make provider mode deployment w/ CI and manual testing

### DIFF
--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -18,7 +18,7 @@ schema: olm.channel
 package: ocs-client-operator
 name: alpha
 entries:
-  - name: ocs-client-operator.v4.15.0
+  - name: ocs-client-operator.v4.16.0
 
 ---
 defaultChannel: alpha

--- a/deploy/deploy-with-olm.yaml
+++ b/deploy/deploy-with-olm.yaml
@@ -7,6 +7,14 @@ metadata:
   name: openshift-storage
 spec: {}
 ---
+apiVersion: v1
+data:
+  DEPLOY_CSI: "false"
+kind: ConfigMap
+metadata:
+  name: ocs-client-operator-config
+  namespace: openshift-storage
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/deploy/single-node-storagecluster-provider.yaml
+++ b/deploy/single-node-storagecluster-provider.yaml
@@ -1,0 +1,124 @@
+---
+# NB: this storagecluster spec doesn't provide you the ability to onboard
+# external clients as they require "hostNetwork: true", however setting that
+# makes mon to come up on three nodes which is obviously not possible in sno.
+# No testing is performed with "hostNetwork: true" and mon set to 1 and if
+# that works, external clients can be onboarded (after opening required ports).
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster-prov
+  namespace: openshift-storage
+spec:
+  flexibleScaling: true
+  allowRemoteStorageConsumers: true
+  providerAPIServerServiceType: ClusterIP
+  monPVCTemplate:
+    spec:
+      # change the base storageclassname if required
+      storageClassName: gp3-csi
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 3Gi
+  storageDeviceSets:
+    - config: {}
+      name: test
+      dataPVCTemplate:
+        metadata: {}
+        spec:
+          # change the base storageclassname if required
+          storageClassName: gp3-csi
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 3
+          volumeMode: Block
+      count: 3
+      placement: {}
+      replica: 1
+      deviceClass: ssd
+      resources:
+        requests:
+          cpu: 125m
+          memory: 128Mi
+  encryption:
+    kms: {}
+  mirroring: {}
+  multiCloudGateway:
+    # uncomment below line if you are not interested in MCG
+    # reconcileStrategy: ignore
+    disableLoadBalancerService: true
+  managedResources:
+    cephBlockPools:
+      disableSnapshotClass: true
+      disableStorageClass: true
+    cephFilesystems:
+      disableSnapshotClass: true
+      disableStorageClass: true
+    cephObjectStores:
+      hostNetwork: false
+    cephCluster: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephObjectStoreUsers: {}
+  arbiter: {}
+  nodeTopologies: {}
+  externalStorage: {}
+  placement:
+    mon: {}
+    mds: {}
+    mgr: {}
+    rbd-mirror: {}
+    rgw: {}
+    nfs: {}
+    noobaa-core: {}
+    noobaa-standalone: {}
+    osd: {}
+    osd-prepare: {}
+  resources:
+    mon:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    mds:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    mgr:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    mgr-sidecar:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    nfs:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    noobaa-core:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    noobaa-db:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    noobaa-db-vol:
+      requests:
+        storage: 10Gi
+    noobaa-endpoint:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    rbd-mirror:
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    rgw:
+      requests:
+        cpu: 125m
+        memory: 128Mi

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -89,7 +89,7 @@ METRICS_EXPORTER_FULL_IMAGE_NAME="${METRICS_EXPORTER_FULL_IMAGE_NAME:-${DEFAULT_
 UX_BACKEND_OAUTH_FULL_IMAGE_NAME="${UX_BACKEND_OAUTH_FULL_IMAGE_NAME:-${DEFAULT_UX_BACKEND_OAUTH_FULL_IMAGE_NAME}}"
 
 CSI_ADDONS_CATALOG_FULL_IMAGE_NAME="quay.io/ocs-dev/csi-addons-catalog:v0.7.0"
-OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/ocs-client-operator-bundle:v4.15.0"
+OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/ocs-client-operator-bundle:main-a79f241"
 NOOBAA_BUNDLE_FULL_IMAGE_NAME="quay.io/noobaa/noobaa-operator-bundle:master-20231217"
 ROOK_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/rook-ceph-operator-bundle:master-9e5499216"
 

--- a/hack/install-ocs-client.sh
+++ b/hack/install-ocs-client.sh
@@ -14,6 +14,18 @@ else
     oc create ns "$INSTALL_NAMESPACE"
 fi
 
+# Ensure position independent make targets in release CI, explicitly setting the values ensures client-op doesn't deploy CSI
+# when storagecluster is configured for remoteconsumers, controllers set this value to "true"
+cat <<EOF | oc create -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocs-client-operator-config
+  namespace: openshift-storage
+data:
+  DEPLOY_CSI: "false"
+EOF
+
 "$OPERATOR_SDK" run bundle "$OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE" --index-image "$CSI_ADDONS_CATALOG_FULL_IMAGE_NAME"
 
 oc wait --timeout=5m --for condition=Available -n "$INSTALL_NAMESPACE" deployment ocs-client-operator-controller-manager


### PR DESCRIPTION
update ocs-client-operator bundle for 4.16 and make ocs-client-operator install position independent if deployed along w/ ocs-operator by explicitly informing ocs-client-op not to deploy csi.

add an example for deploying provider mode in single node cluster.