### PR TITLE
controllers: do not cache all the CRDs in the cluster

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -17,7 +17,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
@@ -175,14 +174,8 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&ocsclientv1a1.StorageClient{}).
 		Watches(&ocsv1.StorageProfile{}, enqueueStorageClusterRequest).
-		Watches(
-			&extv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "virtualmachines.kubevirt.io",
-				},
-			},
-			enqueueStorageClusterRequest,
-		).
+		// Using builder.OnlyMetadata as we are only interested in the presence and not getting this resource anywhere
+		Watches(&extv1.CustomResourceDefinition{}, enqueueStorageClusterRequest, builder.OnlyMetadata).
 		Watches(&ocsv1alpha1.StorageConsumer{}, enqueueStorageClusterRequest, builder.WithPredicates(ocsClientOperatorVersionPredicate))
 	if os.Getenv("SKIP_NOOBAA_CRD_WATCH") != "true" {
 		builder.Owns(&nbv1.NooBaa{})

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -155,7 +156,15 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "ab76f4c9.openshift.io",
 		LeaderElectionNamespace: operatorNamespace,
-		Cache:                   cache.Options{DefaultNamespaces: defaultNamespaces},
+		Cache: cache.Options{
+			DefaultNamespaces: defaultNamespaces,
+			ByObject: map[apiclient.Object]cache.ByObject{
+				&extv1.CustomResourceDefinition{}: {
+					// cache only virtualmachine crd
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": "virtualmachines.kubevirt.io"}),
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
first argument to `Watches` is only used to refer the `Kind` of the resource to watch, existing mechanism will list & cache all the resources and send reconciles for all events for all CRDs.

this commit solves above by indicating `manager` to only listen for `virtualmachines` CRD if and when it exists and also create metadata cache for that specific CRD as we are interested only to get a reconcile event.