### PR TITLE
remove ceph resorces forcefully when client is deleted

### DIFF
--- a/services/ux-backend/handlers/cleanupconsumer/handler.go
+++ b/services/ux-backend/handlers/cleanupconsumer/handler.go
@@ -1,0 +1,83 @@
+package cleanupconsumer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func HandleMessage(w http.ResponseWriter, r *http.Request, cl client.Client) {
+	switch r.Method {
+	case "DELETE":
+		consumerName := r.URL.Query().Get("consumerName")
+		handleDelete(r.Context(), w, cl, consumerName)
+	default:
+		handleUnsupportedMethod(w, r)
+	}
+}
+
+func handleDelete(ctx context.Context, w http.ResponseWriter, cl client.Client, consumerName string) {
+	klog.Info("Delete method on /cleanup-consumer endpoint is invoked")
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	if message, err := removeStorageConsumer(ctx, cl, consumerName); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+
+		if _, err := w.Write([]byte("Failed to delete resources")); err != nil {
+			klog.Errorf("failed write data to response writer, %v", err)
+		}
+	} else {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+
+		if _, err = w.Write([]byte(message)); err != nil {
+			klog.Errorf("failed write data to response writer: %v", err)
+		}
+	}
+
+}
+
+func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
+	klog.Info("Only Delete method should be used to send data to this endpoint /cleanup-consumer")
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	w.Header().Set("Allow", "DELETE")
+
+	if _, err := w.Write([]byte(fmt.Sprintf("Unsupported method : %s", r.Method))); err != nil {
+		klog.Errorf("failed to write data to response writer: %v", err)
+	}
+}
+
+func removeStorageConsumer(ctx context.Context, cl client.Client, consumerName string) (string, error) {
+	storageconsumer := &ocsv1alpha1.StorageConsumer{}
+	storageconsumer.Name = consumerName
+	storageconsumer.Namespace = handlers.GetPodNamespace()
+	var err error
+	err = cl.Get(ctx, client.ObjectKeyFromObject(storageconsumer), storageconsumer)
+	if err != nil {
+		return "", fmt.Errorf("failed to get storage consumer with name: %v", err)
+	}
+
+	if storageconsumer.Annotations == nil {
+		storageconsumer.Annotations = make(map[string]string)
+	}
+	storageconsumer.Annotations[handlers.RookCephResourceForceDeleteAnnotation] = "true"
+	// Clean up of resource is part of respective controller
+	err = cl.Update(ctx, storageconsumer)
+	if err != nil {
+		return "", fmt.Errorf("failed to update storage consumer: %v", err)
+	}
+
+	// Trigger delete for cleaning up resources
+	err = cl.Delete(ctx, storageconsumer)
+	if err != nil {
+		return "", fmt.Errorf("failed to delete storage consumer: %v", err)
+	}
+
+	return "Successfully deleted the storage consumer", nil
+}

--- a/services/ux-backend/handlers/common.go
+++ b/services/ux-backend/handlers/common.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	ContentTypeTextPlain = "text/plain"
+	ContentTypeTextPlain                  = "text/plain"
+	RookCephResourceForceDeleteAnnotation = "ocs.openshift.io.storageconsumer/force-deletion"
 )
 
 var namespace string


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/RHSTOR-5698
- In the case of HCP, a cluster can be deleted on the fly, and PVs can remain on the provider's side, so we need to remove them forcefully.
- What API do internally
  1. This API takes the name of the storage consumer as input, adds an annotation to the storage consumer resource, and deletes the storage consumer.
  2. Storage Consumer is responsible for reconciling based on the added annotation and it then adds annotation back to the storage request.
  3. Storage Request is responsible for reconciling based on the added annotation and adding an annotation to Ceph resources. That forcefully cleans the resources.
