### PR TITLE
Specify pg & pgm num to distribute data across OSDs for replica-1 pools

### DIFF
--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -84,6 +84,10 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 						PoolSpec: cephv1.PoolSpec{
 							DeviceClass:   failureDomainValue,
 							FailureDomain: getFailureDomain(initData),
+							Parameters: map[string]string{
+								"pg_num":  "16",
+								"pgp_num": "16",
+							},
 							Replicated: cephv1.ReplicatedSpec{
 								Size:                   1,
 								RequireSafeReplicaSize: false,


### PR DESCRIPTION
We support adding additional OSDs for each replica-1 pool. But as the pg & pgm num always stays at 1, the data always gets stored in the same OSD. Ideally we would want the data to be distributed across all the OSDs for a particular cephblockpool for a failure domain.