### PR TITLE
bundle: add rook as a dependency to allow upgrades from 4.15 to 4.16

### DIFF
--- a/config/dependencies/dependencies.yaml
+++ b/config/dependencies/dependencies.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- type: olm.package
+  value:
+    packageName: rook-ceph-operator
+    version: ">=4.15.0 <=4.16.0"

--- a/deploy/ocs-operator/metadata/dependencies.yaml
+++ b/deploy/ocs-operator/metadata/dependencies.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- type: olm.package
+  value:
+    packageName: rook-ceph-operator
+    version: ">=4.15.0 <=4.16.0"

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -47,6 +47,7 @@ function gen_ocs_csv() {
 	$KUSTOMIZE build config/manifests/ocs-operator | $OPERATOR_SDK generate bundle -q --overwrite=false --output-dir deploy/ocs-operator --kustomize-dir config/manifests/ocs-operator --package ocs-operator --version "$CSV_VERSION" --extra-service-accounts=ux-backend-server
 	mv deploy/ocs-operator/manifests/*clusterserviceversion.yaml $OCS_CSV
 	cp config/crd/bases/* $ocs_crds_outdir
+	cp config/dependencies/dependencies.yaml deploy/ocs-operator/metadata/dependencies.yaml
 }
 
 gen_ocs_csv


### PR DESCRIPTION
In older clusters, upgrading the odf channel from 4.15 to 4.16 tries to bring the rook-operator, leading to conflicts with ocs-operator 4.15, which already contains all Rook components in its 4.15 CSV. This conflict results in upgrade failures.

To address this issue, the Rook dependency is removed from the odf-operator and added to the ocs-operator. This solution ensures a smooth upgrade process, as changing the ocs-operator channel will now bring Rook along with ocs-operator 4.16 without encountering conflicts.

This commit should be reverted in 4.17 as 4.16 will feature different CSVs. In 4.17, removing Rook as a dependency in ocs and adding it in the odf should facilitate smooth installations and upgrades.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=2275456
https://bugzilla.redhat.com/show_bug.cgi?id=2275484