### PR TITLE
change storagerequest spec.type to be either block or sharedfile

### DIFF
--- a/api/v1alpha1/storagerequest_types.go
+++ b/api/v1alpha1/storagerequest_types.go
@@ -24,7 +24,7 @@ import (
 
 // StorageRequestSpec defines the desired state of StorageRequest
 type StorageRequestSpec struct {
-	//+kubebuilder:validation:Enum=blockpool;sharedfilesystem
+	//+kubebuilder:validation:Enum=block;sharedfile
 	Type             string `json:"type"`
 	EncryptionMethod string `json:"encryptionMethod,omitempty"`
 	StorageProfile   string `json:"storageProfile,omitempty"`

--- a/config/crd/bases/ocs.openshift.io_storagerequests.yaml
+++ b/config/crd/bases/ocs.openshift.io_storagerequests.yaml
@@ -48,8 +48,8 @@ spec:
                 type: string
               type:
                 enum:
-                - blockpool
-                - sharedfilesystem
+                - block
+                - sharedfile
                 type: string
             required:
             - type

--- a/config/manifests/ocs-operator/bases/ocs-operator.clusterserviceversion.yaml
+++ b/config/manifests/ocs-operator/bases/ocs-operator.clusterserviceversion.yaml
@@ -15,11 +15,6 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: StorageRequest is the Schema for the StorageRequests API
-      displayName: Storage Request
-      kind: StorageRequest
-      name: storagerequests.ocs.openshift.io
-      version: v1alpha1
     - description: OCSInitialization represents the initial data to be created when
         the operator is installed.
       displayName: OCS Initialization
@@ -49,6 +44,11 @@ spec:
       kind: StorageProfile
       name: storageprofiles.ocs.openshift.io
       version: v1
+    - description: StorageRequest is the Schema for the StorageRequests API
+      displayName: Storage Request
+      kind: StorageRequest
+      name: storagerequests.ocs.openshift.io
+      version: v1alpha1
   description: |
     **Red Hat OpenShift Container Storage** deploys three operators.
 

--- a/controllers/storagerequest/storagerequest_controller.go
+++ b/controllers/storagerequest/storagerequest_controller.go
@@ -213,7 +213,7 @@ func (r *StorageRequestReconciler) initPhase() error {
 	}
 
 	// check request status already contains the name of the resource. if not, add it.
-	if r.StorageRequest.Spec.Type == "blockpool" {
+	if r.StorageRequest.Spec.Type == "block" {
 		// initialize in-memory structs
 		r.cephRadosNamespace = &rookCephv1.CephBlockPoolRadosNamespace{}
 		r.cephRadosNamespace.Namespace = r.OperatorNamespace
@@ -243,7 +243,7 @@ func (r *StorageRequestReconciler) initPhase() error {
 		} else {
 			return fmt.Errorf("invalid number of CephBlockPoolRadosNamespaces for storage consumer %q: found %d, expecting 0 or 1", r.storageConsumer.Name, rnsItemsLen)
 		}
-	} else if r.StorageRequest.Spec.Type == "sharedfilesystem" {
+	} else if r.StorageRequest.Spec.Type == "sharedfile" {
 		r.cephFilesystemSubVolumeGroup = &rookCephv1.CephFilesystemSubVolumeGroup{}
 		r.cephFilesystemSubVolumeGroup.Namespace = r.OperatorNamespace
 
@@ -303,7 +303,7 @@ func (r *StorageRequestReconciler) reconcilePhases() (reconcile.Result, error) {
 				return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %v", err)
 			}
 		}
-		if r.StorageRequest.Spec.Type == "blockpool" {
+		if r.StorageRequest.Spec.Type == "block" {
 
 			if err := r.reconcileCephClientRBDProvisioner(); err != nil {
 				return reconcile.Result{}, err
@@ -317,7 +317,7 @@ func (r *StorageRequestReconciler) reconcilePhases() (reconcile.Result, error) {
 				return reconcile.Result{}, err
 			}
 
-		} else if r.StorageRequest.Spec.Type == "sharedfilesystem" {
+		} else if r.StorageRequest.Spec.Type == "sharedfile" {
 			if err := r.reconcileCephClientCephFSProvisioner(); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -639,7 +639,7 @@ func (r *StorageRequestReconciler) setCephResourceStatus(name string, kind strin
 }
 
 func (r *StorageRequestReconciler) deletionPhase() error {
-	if r.StorageRequest.Spec.Type == "blockpool" {
+	if r.StorageRequest.Spec.Type == "block" {
 		if err := r.get(r.cephRadosNamespace); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get CephRadosNamespace: %v", err)
 		} else if err == nil && util.AddAnnotation(r.cephRadosNamespace, forceDeletionAnnotationKey, "true") {
@@ -647,7 +647,7 @@ func (r *StorageRequestReconciler) deletionPhase() error {
 				return fmt.Errorf("failed to annotate CephRadosNamespace: %v", err)
 			}
 		}
-	} else if r.StorageRequest.Spec.Type == "sharedfilesystem" {
+	} else if r.StorageRequest.Spec.Type == "sharedfile" {
 		if err := r.get(r.cephFilesystemSubVolumeGroup); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get CephFileSystemSubVolumeGroup: %v", err)
 		} else if err == nil && util.AddAnnotation(r.cephFilesystemSubVolumeGroup, forceDeletionAnnotationKey, "true") {

--- a/controllers/storagerequest/storagerequest_controller_test.go
+++ b/controllers/storagerequest/storagerequest_controller_test.go
@@ -284,7 +284,7 @@ func TestCephBlockPool(t *testing.T) {
 
 		r := createFakeReconciler(t)
 		r.StorageRequest.Status.CephResources = c.cephResources
-		r.StorageRequest.Spec.Type = "blockpool"
+		r.StorageRequest.Spec.Type = "block"
 
 		c.createObjects = append(c.createObjects, fakeStorageConsumer)
 		c.createObjects = append(c.createObjects, r.StorageRequest)
@@ -381,7 +381,7 @@ func TestCephFsSubVolGroup(t *testing.T) {
 		fmt.Println(caseLabel)
 
 		r := createFakeReconciler(t)
-		r.StorageRequest.Spec.Type = "sharedfilesystem"
+		r.StorageRequest.Spec.Type = "sharedfile"
 
 		c.createObjects = append(c.createObjects, fakeCephFs)
 		c.createObjects = append(c.createObjects, fakeStorageConsumer)
@@ -411,7 +411,7 @@ func TestCephFsSubVolGroup(t *testing.T) {
 	fmt.Println(caseLabel)
 
 	r := createFakeReconciler(t)
-	r.StorageRequest.Spec.Type = "sharedfilesystem"
+	r.StorageRequest.Spec.Type = "sharedfile"
 	fakeClient := newFakeClientBuilder(r.Scheme).
 		WithRuntimeObjects(fakeStorageConsumer, r.StorageRequest)
 	r.Client = fakeClient.Build()

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storagerequests.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storagerequests.yaml
@@ -48,8 +48,8 @@ spec:
                 type: string
               type:
                 enum:
-                - blockpool
-                - sharedfilesystem
+                - block
+                - sharedfile
                 type: string
             required:
             - type

--- a/deploy/ocs-operator/manifests/storagerequest.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagerequest.crd.yaml
@@ -47,8 +47,8 @@ spec:
                 type: string
               type:
                 enum:
-                - blockpool
-                - sharedfilesystem
+                - block
+                - sharedfile
                 type: string
             required:
             - type

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storagerequest_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storagerequest_types.go
@@ -24,7 +24,7 @@ import (
 
 // StorageRequestSpec defines the desired state of StorageRequest
 type StorageRequestSpec struct {
-	//+kubebuilder:validation:Enum=blockpool;sharedfilesystem
+	//+kubebuilder:validation:Enum=block;sharedfile
 	Type             string `json:"type"`
 	EncryptionMethod string `json:"encryptionMethod,omitempty"`
 	StorageProfile   string `json:"storageProfile,omitempty"`

--- a/services/provider/client/client.go
+++ b/services/provider/client/client.go
@@ -123,7 +123,7 @@ type StorageType uint
 
 const (
 	StorageTypeBlock StorageType = iota
-	StorageTypeSharedfile
+	StorageTypeSharedFile
 )
 
 func (cc *OCSProviderClient) FulfillStorageClaim(
@@ -138,7 +138,7 @@ func (cc *OCSProviderClient) FulfillStorageClaim(
 		return nil, fmt.Errorf("provider client is closed")
 	}
 	var st pb.FulfillStorageClaimRequest_StorageType
-	if storageType == StorageTypeSharedfile {
+	if storageType == StorageTypeSharedFile {
 		st = pb.FulfillStorageClaimRequest_SHAREDFILE
 	} else if storageType == StorageTypeBlock {
 		st = pb.FulfillStorageClaimRequest_BLOCK

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -487,9 +487,9 @@ func (s *OCSProviderServer) FulfillStorageClaim(ctx context.Context, req *pb.Ful
 	var storageType string
 	switch req.StorageType {
 	case pb.FulfillStorageClaimRequest_BLOCK:
-		storageType = "blockpool"
+		storageType = "block"
 	case pb.FulfillStorageClaimRequest_SHAREDFILE:
-		storageType = "sharedfilesystem"
+		storageType = "sharedfile"
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "encountered an unknown storage type, %s", storageType)
 	}
@@ -569,7 +569,7 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 
 			idProp := "userID"
 			keyProp := "userKey"
-			if storageRequest.Spec.Type == "sharedfilesystem" {
+			if storageRequest.Spec.Type == "sharedfile" {
 				idProp = "adminID"
 				keyProp = "adminKey"
 			}

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -614,7 +614,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Namespace: serverNamespace,
 			},
 			Spec: ocsv1alpha1.StorageRequestSpec{
-				Type: "sharedfilesystem",
+				Type: "sharedfile",
 			},
 			Status: ocsv1alpha1.StorageRequestStatus{
 				CephResources: []*ocsv1alpha1.CephResourcesSpec{

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storagerequest_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storagerequest_types.go
@@ -24,7 +24,7 @@ import (
 
 // StorageRequestSpec defines the desired state of StorageRequest
 type StorageRequestSpec struct {
-	//+kubebuilder:validation:Enum=blockpool;sharedfilesystem
+	//+kubebuilder:validation:Enum=block;sharedfile
 	Type             string `json:"type"`
 	EncryptionMethod string `json:"encryptionMethod,omitempty"`
 	StorageProfile   string `json:"storageProfile,omitempty"`


### PR DESCRIPTION
change the request types from `sharedfilesystem` to `sharedfile` and `blockpool` to `block`, at the other end storageclaims correspond to this naming and when these are listed if names doesn't corresponding it'll not be a good experience.

the new names are at the correct abstraction level wrt the type of storage that is being claimed.