### PR TITLE
change forcedeletion annotation key for cleanup of ceph resources

### DIFF
--- a/controllers/storagerequest/storagerequest_controller.go
+++ b/controllers/storagerequest/storagerequest_controller.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	storageRequestFinalizer    = "ocs.openshift.io.storagerequest"
-	forceDeletionAnnotationKey = "ceph.rook.io/force-deletion"
+	forceDeletionAnnotationKey = "rook.io/force-deletion"
 )
 
 // StorageRequestReconciler reconciles a StorageRequest object


### PR DESCRIPTION
As per Rook [docs](https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/ceph-teardown.md#force-delete-resources), the annotation to be set on ceph resources for force cleanup is changed from `ceph.rook.io/force-deletion` to `rook.io/force-deletion`.