### PR TITLE
skip annotating ARO namespace

### DIFF
--- a/controllers/namespace/namespace_controller.go
+++ b/controllers/namespace/namespace_controller.go
@@ -133,6 +133,11 @@ func (r *NamespaceReconciler) annotateNamespaces(opNs []corev1.Namespace) (bool,
 
 // shouldSkipAnnotation checks if we should skip adding new annotations to the namespace
 func shouldSkipAnnotation(ns corev1.Namespace) bool {
+	// skip annotating ARO created namespaces from reclaimspace operation.
+	if ns.Name == "openshift-azure-logging" || ns.Name == "openshift-azure" {
+		return true
+	}
+	
 	if !ns.GetDeletionTimestamp().IsZero() || ns.Annotations["skipReclaimspaceSchedule"] == "true" ||
 		ns.Annotations["reclaimspace.csiaddons.openshift.io/schedule"] != "" {
 		return true


### PR DESCRIPTION
with EPIC [1] we have started annotating all the namespaces that starts with namespace openshift-* to reclaim RBD space reclaim but with ARO created namespace we are getting into problem [2] with that as its trying to remove the annotation we have added, For now we are skipping annotating that namespace so that we will not consider it for automated reclaimspace operation.

[1] https://issues.redhat.com/browse/RHSTOR-4468
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2276135