### PR TITLE
Bug 2276824: [release-4.15] Add waitTimeoutForHealthyOSDInMinutes field in the storagecluster CR

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"os"
+	"time"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -176,6 +177,14 @@ type ManageCephCluster struct {
 	MgrCount int `json:"mgrCount,omitempty"`
 	// +kubebuilder:validation:Enum=3;5
 	MonCount int `json:"monCount,omitempty"`
+	// WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
+	// If `continueUpgradeAfterChecksEvenIfNotHealthy` is `false` and the timeout exceeds and OSD is not ok to stop, then the operator
+	// would skip upgrade for the current OSD and proceed with the next one.
+	// If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would continue with the upgrade of an OSD even if its
+	// not ok to stop after the timeout.
+	// This timeout won't be applied if `skipUpgradeChecks` is `true`.
+	// The default wait timeout is 10 minutes.
+	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -692,6 +692,19 @@ spec:
                         type: integer
                       reconcileStrategy:
                         type: string
+                      waitTimeoutForHealthyOSDInMinutes:
+                        description: WaitTimeoutForHealthyOSDInMinutes defines the
+                          time the operator would wait before an OSD can be stopped
+                          for upgrade or restart. If `continueUpgradeAfterChecksEvenIfNotHealthy`
+                          is `false` and the timeout exceeds and OSD is not ok to
+                          stop, then the operator would skip upgrade for the current
+                          OSD and proceed with the next one. If `continueUpgradeAfterChecksEvenIfNotHealthy`
+                          is `true`, then operator would continue with the upgrade
+                          of an OSD even if its not ok to stop after the timeout.
+                          This timeout won't be applied if `skipUpgradeChecks` is
+                          `true`. The default wait timeout is 10 minutes.
+                        format: int64
+                        type: integer
                     type: object
                   cephConfig:
                     description: ManageCephConfig defines how to reconcile the Ceph

--- a/controllers/defaults/defaults.go
+++ b/controllers/defaults/defaults.go
@@ -2,6 +2,8 @@
 // options of a StorageCluster
 package defaults
 
+import "time"
+
 const (
 	// NodeAffinityKey is the node label to determine which nodes belong
 	// to a storage cluster
@@ -52,4 +54,7 @@ var (
 	// ArbiterReplicasPerFailureDomain is the default replica count in the failure domain when arbiter is enabled
 	// This maps to the ReplicasPerFailureDomain in the CephReplicatedSpec when creating the CephBlockPools
 	ArbiterReplicasPerFailureDomain = 2
+	// DefaultWaitTimeoutForHealthyOSD is the default time for which the operator would wait before an OSD can be stopped
+	// for an upgrade or restart
+	DefaultWaitTimeoutForHealthyOSD = 10 * time.Minute
 )

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -3,6 +3,7 @@ package storagecluster
 import (
 	// The embed package is required for the prometheus rule files
 	_ "embed"
+	"time"
 
 	"bytes"
 	"context"
@@ -482,6 +483,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *v
 					KernelMountOptions: getCephFSKernelMountOptions(sc),
 				},
 			},
+			WaitTimeoutForHealthyOSDInMinutes: getWaitTimeoutForHealthOSD(sc),
 		},
 	}
 
@@ -1322,4 +1324,12 @@ func getOsdCount(sc *ocsv1.StorageCluster, serverVersion *version.Info) int {
 		osdCount += ds.Count
 	}
 	return osdCount
+}
+
+func getWaitTimeoutForHealthOSD(sc *ocsv1.StorageCluster) time.Duration {
+	if sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes != 0 {
+		return sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes
+	}
+
+	return defaults.DefaultWaitTimeoutForHealthyOSD
 }

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -692,6 +692,19 @@ spec:
                         type: integer
                       reconcileStrategy:
                         type: string
+                      waitTimeoutForHealthyOSDInMinutes:
+                        description: WaitTimeoutForHealthyOSDInMinutes defines the
+                          time the operator would wait before an OSD can be stopped
+                          for upgrade or restart. If `continueUpgradeAfterChecksEvenIfNotHealthy`
+                          is `false` and the timeout exceeds and OSD is not ok to
+                          stop, then the operator would skip upgrade for the current
+                          OSD and proceed with the next one. If `continueUpgradeAfterChecksEvenIfNotHealthy`
+                          is `true`, then operator would continue with the upgrade
+                          of an OSD even if its not ok to stop after the timeout.
+                          This timeout won't be applied if `skipUpgradeChecks` is
+                          `true`. The default wait timeout is 10 minutes.
+                        format: int64
+                        type: integer
                     type: object
                   cephConfig:
                     description: ManageCephConfig defines how to reconcile the Ceph

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -691,6 +691,19 @@ spec:
                         type: integer
                       reconcileStrategy:
                         type: string
+                      waitTimeoutForHealthyOSDInMinutes:
+                        description: WaitTimeoutForHealthyOSDInMinutes defines the
+                          time the operator would wait before an OSD can be stopped
+                          for upgrade or restart. If `continueUpgradeAfterChecksEvenIfNotHealthy`
+                          is `false` and the timeout exceeds and OSD is not ok to
+                          stop, then the operator would skip upgrade for the current
+                          OSD and proceed with the next one. If `continueUpgradeAfterChecksEvenIfNotHealthy`
+                          is `true`, then operator would continue with the upgrade
+                          of an OSD even if its not ok to stop after the timeout.
+                          This timeout won't be applied if `skipUpgradeChecks` is
+                          `true`. The default wait timeout is 10 minutes.
+                        format: int64
+                        type: integer
                     type: object
                   cephConfig:
                     description: ManageCephConfig defines how to reconcile the Ceph

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"os"
+	"time"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -176,6 +177,14 @@ type ManageCephCluster struct {
 	MgrCount int `json:"mgrCount,omitempty"`
 	// +kubebuilder:validation:Enum=3;5
 	MonCount int `json:"monCount,omitempty"`
+	// WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
+	// If `continueUpgradeAfterChecksEvenIfNotHealthy` is `false` and the timeout exceeds and OSD is not ok to stop, then the operator
+	// would skip upgrade for the current OSD and proceed with the next one.
+	// If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would continue with the upgrade of an OSD even if its
+	// not ok to stop after the timeout.
+	// This timeout won't be applied if `skipUpgradeChecks` is `true`.
+	// The default wait timeout is 10 minutes.
+	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration


### PR DESCRIPTION
This is a manual backport of #2579 