### PR TITLE
Remove support TSC check & always use TSCs for osd placements

### DIFF
--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -45,34 +45,12 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					getWeightedPodAffinityTerm(100, "rook-ceph-osd"),
-				},
-			},
-		},
-
-		"osd-prepare": {
-			Tolerations: []corev1.Toleration{
-				getOcsToleration(),
-			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					getWeightedPodAffinityTerm(100, "rook-ceph-osd-prepare"),
-				},
-			},
-		},
-
-		"osd-tsc": {
-			Tolerations: []corev1.Toleration{
-				getOcsToleration(),
-			},
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 				getTopologySpreadConstraintsSpec(1, []string{osdLabelSelector}),
 			},
 		},
 
-		"osd-prepare-tsc": {
+		"osd-prepare": {
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
@@ -195,12 +194,12 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 					return reconcile.Result{}, err
 				}
 			}
-			cephCluster, err = newCephCluster(sc, r.images.Ceph, r.serverVersion, kmsConfigMap, r.Log)
+			cephCluster, err = newCephCluster(sc, r.images.Ceph, kmsConfigMap, r.Log)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
 		} else {
-			cephCluster, err = newCephCluster(sc, r.images.Ceph, r.serverVersion, nil, r.Log)
+			cephCluster, err = newCephCluster(sc, r.images.Ceph, nil, r.Log)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -409,7 +408,7 @@ func getCephClusterMonitoringLabels(sc ocsv1.StorageCluster) map[string]string {
 }
 
 // newCephCluster returns a CephCluster object.
-func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *version.Info, kmsConfigMap *corev1.ConfigMap, reqLogger logr.Logger) (*rookCephv1.CephCluster, error) {
+func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *corev1.ConfigMap, reqLogger logr.Logger) (*rookCephv1.CephCluster, error) {
 	labels := map[string]string{
 		"app": sc.Name,
 	}
@@ -459,7 +458,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *v
 				Interval: &metav1.Duration{Duration: 30 * time.Second},
 			},
 			Storage: rookCephv1.StorageScopeSpec{
-				StorageClassDeviceSets:       newStorageClassDeviceSets(sc, serverVersion),
+				StorageClassDeviceSets:       newStorageClassDeviceSets(sc),
 				Store:                        osdStore,
 				FlappingRestartIntervalHours: 24,
 			},
@@ -749,15 +748,11 @@ func getMonCount(sc *ocsv1.StorageCluster) int {
 }
 
 // newStorageClassDeviceSets converts a list of StorageDeviceSets into a list of Rook StorageClassDeviceSets
-func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.Info) []rookCephv1.StorageClassDeviceSet {
+func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rookCephv1.StorageClassDeviceSet {
 	storageDeviceSets := sc.Spec.StorageDeviceSets
 	topologyMap := sc.Status.NodeTopologies
 
 	var storageClassDeviceSets []rookCephv1.StorageClassDeviceSet
-
-	// For kube server version 1.19 and above, topology spread constraints are used for OSD placements.
-	// For kube server version below 1.19, NodeAffinity and PodAntiAffinity are used for OSD placements.
-	supportTSC := serverVersion.Major >= defaults.KubeMajorTopologySpreadConstraints && serverVersion.Minor >= defaults.KubeMinorTopologySpreadConstraints
 
 	for _, ds := range storageDeviceSets {
 		resources := ds.Resources
@@ -770,13 +765,8 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 		topologyKey := ds.TopologyKey
 		topologyKeyValues := []string{}
 
-		noPlacement := ds.Placement.NodeAffinity == nil && ds.Placement.PodAffinity == nil && ds.Placement.PodAntiAffinity == nil
-		noPreparePlacement := ds.PreparePlacement.NodeAffinity == nil && ds.PreparePlacement.PodAffinity == nil && ds.PreparePlacement.PodAntiAffinity == nil
-
-		if supportTSC {
-			noPlacement = noPlacement && ds.Placement.TopologySpreadConstraints == nil
-			noPreparePlacement = noPreparePlacement && ds.PreparePlacement.TopologySpreadConstraints == nil
-		}
+		noPlacement := ds.Placement.NodeAffinity == nil && ds.Placement.PodAffinity == nil && ds.Placement.PodAntiAffinity == nil && ds.Placement.TopologySpreadConstraints == nil
+		noPreparePlacement := ds.PreparePlacement.NodeAffinity == nil && ds.PreparePlacement.PodAffinity == nil && ds.PreparePlacement.PodAntiAffinity == nil && ds.PreparePlacement.TopologySpreadConstraints == nil
 
 		if noPlacement {
 			if topologyKey == "" {
@@ -798,47 +788,29 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			preparePlacement := rookCephv1.Placement{}
 
 			if noPlacement {
-				if supportTSC {
-					in := getPlacement(sc, "osd-tsc")
-					(&in).DeepCopyInto(&placement)
+				in := getPlacement(sc, "osd")
+				(&in).DeepCopyInto(&placement)
 
+				if noPreparePlacement {
+					in := getPlacement(sc, "osd-prepare")
+					(&in).DeepCopyInto(&preparePlacement)
+				}
+
+				if len(topologyKeyValues) >= getMinDeviceSetReplica(sc) {
+					// Hard constraints are set in OSD placement for portable volumes with rack failure domain
+					// domain as there is no node affinity in PVs. This restricts the movement of OSDs
+					// between failure domain.
+					if portable && !strings.Contains(topologyKey, "zone") {
+						addStrictFailureDomainTSC(&placement, topologyKey)
+					}
+					// If topologyKey is not host, append additional topology spread constraint to the
+					// default preparePlacement. This serves even distribution at the host level
+					// within a failure domain (zone/rack).
 					if noPreparePlacement {
-						in := getPlacement(sc, "osd-prepare-tsc")
-						(&in).DeepCopyInto(&preparePlacement)
-					}
-
-					if len(topologyKeyValues) >= getMinDeviceSetReplica(sc) {
-						// Hard constraints are set in OSD placement for portable volumes with rack failure domain
-						// domain as there is no node affinity in PVs. This restricts the movement of OSDs
-						// between failure domain.
-						if portable && !strings.Contains(topologyKey, "zone") {
-							addStrictFailureDomainTSC(&placement, topologyKey)
-						}
-						// If topologyKey is not host, append additional topology spread constraint to the
-						// default preparePlacement. This serves even distribution at the host level
-						// within a failure domain (zone/rack).
-						if noPreparePlacement {
-							if topologyKey != corev1.LabelHostname {
-								addStrictFailureDomainTSC(&preparePlacement, topologyKey)
-							} else {
-								preparePlacement.TopologySpreadConstraints[0].TopologyKey = topologyKey
-							}
-						}
-					}
-				} else {
-					in := getPlacement(sc, "osd")
-					(&in).DeepCopyInto(&placement)
-
-					if noPreparePlacement {
-						in := getPlacement(sc, "osd-prepare")
-						(&in).DeepCopyInto(&preparePlacement)
-					}
-
-					if len(topologyKeyValues) >= getMinDeviceSetReplica(sc) {
-						topologyIndex := i % len(topologyKeyValues)
-						setTopologyForAffinity(&placement, topologyKeyValues[topologyIndex], topologyKey)
-						if noPreparePlacement {
-							setTopologyForAffinity(&preparePlacement, topologyKeyValues[topologyIndex], topologyKey)
+						if topologyKey != corev1.LabelHostname {
+							addStrictFailureDomainTSC(&preparePlacement, topologyKey)
+						} else {
+							preparePlacement.TopologySpreadConstraints[0].TopologyKey = topologyKey
 						}
 					}
 				}
@@ -1349,8 +1321,8 @@ func isBluestore(store rookCephv1.OSDStore) bool {
 	return false
 }
 
-func getOsdCount(sc *ocsv1.StorageCluster, serverVersion *version.Info) int {
-	storageClassDeviceSets := newStorageClassDeviceSets(sc, serverVersion)
+func getOsdCount(sc *ocsv1.StorageCluster) int {
+	storageClassDeviceSets := newStorageClassDeviceSets(sc)
 	osdCount := 0
 	for _, ds := range storageClassDeviceSets {
 		osdCount += ds.Count

--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -370,7 +369,6 @@ func createFakeInitializationStorageClusterReconciler(t *testing.T, obj ...runti
 	return StorageClusterReconciler{
 		Client:            client,
 		Scheme:            scheme,
-		serverVersion:     &version.Info{},
 		OperatorCondition: newStubOperatorCondition(),
 		Log:               logf.Log.WithName("controller_storagecluster_test"),
 	}

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -138,15 +138,3 @@ type MatchingLabelsSelector struct {
 func (m MatchingLabelsSelector) ApplyToList(opts *client.ListOptions) {
 	opts.LabelSelector = m
 }
-
-// setTopologyForAffinity assigns topology related values to the affinity placements
-func setTopologyForAffinity(placement *rookCephv1.Placement, selectorValue string, topologyKey string) {
-	placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey = topologyKey
-
-	nodeZoneSelector := corev1.NodeSelectorRequirement{
-		Key:      topologyKey,
-		Operator: corev1.NodeSelectorOpIn,
-		Values:   []string{selectorValue},
-	}
-	appendNodeRequirements(placement, nodeZoneSelector)
-}

--- a/controllers/storagecluster/resourceprofile.go
+++ b/controllers/storagecluster/resourceprofile.go
@@ -52,7 +52,7 @@ func (r *StorageClusterReconciler) ensureResourceProfileChangeApplied(sc *ocsv1.
 	}
 
 	// Verify if expected number of osd pods with the current resource profile label are running
-	if err := r.verifyDaemonWithResourceProfile(sc.Namespace, map[string]string{"app": "rook-ceph-osd", defaults.ODFResourceProfileKey: currentResourceProfile}, getOsdCount(sc, r.serverVersion)); err != nil {
+	if err := r.verifyDaemonWithResourceProfile(sc.Namespace, map[string]string{"app": "rook-ceph-osd", defaults.ODFResourceProfileKey: currentResourceProfile}, getOsdCount(sc)); err != nil {
 		return err
 	}
 

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -20,12 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -62,20 +59,6 @@ func (r *StorageClusterReconciler) initializeImageVars() error {
 	return nil
 }
 
-func (r *StorageClusterReconciler) initializeServerVersion() error {
-	clientset, err := kubernetes.NewForConfig(config.GetConfigOrDie())
-	if err != nil {
-		r.Log.Error(err, "Failed creation of clientset for determining serverversion.")
-		return err
-	}
-	r.serverVersion, err = clientset.Discovery().ServerVersion()
-	if err != nil {
-		r.Log.Error(err, "Failed getting the serverversion.")
-		return err
-	}
-	return nil
-}
-
 // ImageMap holds mapping information between component image name and the image url
 type ImageMap struct {
 	Ceph               string
@@ -91,7 +74,6 @@ type StorageClusterReconciler struct {
 	ctx                       context.Context
 	Log                       logr.Logger
 	Scheme                    *runtime.Scheme
-	serverVersion             *version.Info
 	conditions                []conditionsv1.Condition
 	phase                     string
 	nodeCount                 int
@@ -107,10 +89,6 @@ type StorageClusterReconciler struct {
 // SetupWithManager sets up a controller with manager
 func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := r.initializeImageVars(); err != nil {
-		return err
-	}
-
-	if err := r.initializeServerVersion(); err != nil {
 		return err
 	}
 

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -38,7 +38,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	k8sVersion "k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -1139,7 +1138,6 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 		Client:            client,
 		Scheme:            scheme,
 		OperatorCondition: newStubOperatorCondition(),
-		serverVersion:     &k8sVersion.Info{},
 		Log:               logf.Log.WithName("controller_storagecluster_test"),
 		clusters:          clusters,
 		OperatorNamespace: operatorNamespace,
@@ -1294,9 +1292,8 @@ func TestStorageClusterOnMultus(t *testing.T) {
 }
 
 func assertCephClusterNetwork(t assert.TestingT, reconciler StorageClusterReconciler, cr *api.StorageCluster, request reconcile.Request) {
-	serverVersion := &k8sVersion.Info{}
 	request.Name = "ocsinit-cephcluster"
-	cephCluster, err := newCephCluster(cr, "", serverVersion, nil, log)
+	cephCluster, err := newCephCluster(cr, "", nil, log)
 	assert.NoError(t, err)
 	err = reconciler.Client.Get(context.TODO(), request.NamespacedName, cephCluster)
 	assert.NoError(t, err)

--- a/controllers/storagecluster/storagequota_test.go
+++ b/controllers/storagecluster/storagequota_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sVersion "k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -121,10 +120,9 @@ func createFakeStorageClusterWithQuotaReconciler(t *testing.T, obj ...runtime.Ob
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj...).WithStatusSubresource(sc).Build()
 
 	return &StorageClusterReconciler{
-		Client:        client,
-		Scheme:        scheme,
-		serverVersion: &k8sVersion.Info{},
-		Log:           logf.Log.WithName("storagequota_test"),
+		Client: client,
+		Scheme: scheme,
+		Log:    logf.Log.WithName("storagequota_test"),
 	}
 }
 


### PR DESCRIPTION
Topology Spread Constraints have been supported since kube version 1.19. It's a cleaner way of spreading osds compared to podAffinity and podAntiAffinity. So we should always use TSCs for osd placements.