### PR TITLE
Bug 2213757: external: separate rgw endpoint validation from cephfs and rbd storage…

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -284,6 +284,7 @@ func (obj *ocsExternalResources) ensureDeleted(_ *StorageClusterReconciler, _ *o
 func (r *StorageClusterReconciler) createExternalStorageClusterResources(instance *ocsv1.StorageCluster) error {
 
 	var err error
+	var rgwEndpoint string
 
 	ownerRef := metav1.OwnerReference{
 		UID:        instance.UID,
@@ -390,22 +391,17 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 					return err
 				}
 			} else if d.Name == cephRgwStorageClassName {
-				rgwEndpoint := d.Data[externalCephRgwEndpointKey]
-				if err := checkEndpointReachable(rgwEndpoint, 5*time.Second); err != nil {
-					r.Log.Error(err, "RGW endpoint is not reachable.", "RGWEndpoint", rgwEndpoint)
-					return err
-				}
-				extCephObjectStores, err = r.newExternalCephObjectStoreInstances(instance, rgwEndpoint)
-				if err != nil {
-					return err
-				}
+				rgwEndpoint = d.Data[externalCephRgwEndpointKey]
 				// rgw-endpoint is no longer needed in the 'd.Data' dictionary,
 				// and can be deleted
 				// created an issue in rook to add `CephObjectStore` type directly in the JSON output
 				// https://github.com/rook/rook/issues/6165
 				delete(d.Data, externalCephRgwEndpointKey)
 
-				scc = newCephOBCStorageClassConfiguration(instance)
+				// do not create the rgw storageclass if the endpoint is not reachable
+				if err := checkEndpointReachable(rgwEndpoint, 5*time.Second); err != nil {
+					scc = newCephOBCStorageClassConfiguration(instance)
+				}
 			}
 			// now sc is pointing to appropriate StorageClass,
 			// whose parameters have to be updated
@@ -426,9 +422,21 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 		r.Log.Error(err, "Failed to set RookEnableCephFSCSIKey to EnableRookCSICephFS.", "RookEnableCephFSCSIKey", rookEnableCephFSCSIKey, "EnableRookCSICephFS", enableRookCSICephFS)
 		return err
 	}
-	if extCephObjectStores != nil {
-		if err = r.createCephObjectStores(extCephObjectStores, instance); err != nil {
+
+	if rgwEndpoint != "" {
+		if err := checkEndpointReachable(rgwEndpoint, 5*time.Second); err != nil {
+			r.Log.Error(err, "RGW endpoint is not reachable.", "RGWEndpoint", rgwEndpoint)
 			return err
+		}
+
+		extCephObjectStores, err = r.newExternalCephObjectStoreInstances(instance, rgwEndpoint)
+		if err != nil {
+			return err
+		}
+		if extCephObjectStores != nil {
+			if err = r.createCephObjectStores(extCephObjectStores, instance); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
…class

currently if the rgw endpoint is not reachable
all the storageclass creation fails
Fix will make the rgw endpoint validation separate and will create rbd and cephfs storageclasses if rgw endpoints validation fails