### PR TITLE
cleanup: Remove dual imports and fix go-staticchecks

### DIFF
--- a/controllers/storagecluster/backingstorageclasses.go
+++ b/controllers/storagecluster/backingstorageclasses.go
@@ -10,7 +10,6 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/platform"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,7 +26,7 @@ type backingStorageClasses struct{}
 // ensureCreated ensures that backing storageclasses are created for the StorageCluster
 func (obj *backingStorageClasses) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
 
-	existingBackingStorageClasses := &v1.StorageClassList{}
+	existingBackingStorageClasses := &storagev1.StorageClassList{}
 	err := r.Client.List(
 		r.ctx,
 		existingBackingStorageClasses,
@@ -39,7 +38,7 @@ func (obj *backingStorageClasses) ensureCreated(r *StorageClusterReconciler, sc 
 		return reconcile.Result{}, err
 	}
 
-	existingStorageClassesByName := map[string]*v1.StorageClass{}
+	existingStorageClassesByName := map[string]*storagev1.StorageClass{}
 	for i := range existingBackingStorageClasses.Items {
 		storageClass := &existingBackingStorageClasses.Items[i]
 		existingStorageClassesByName[storageClass.Name] = storageClass
@@ -84,7 +83,7 @@ func createOrUpdateBackingStorageclass(r *StorageClusterReconciler, bsc *ocsv1.B
 
 	pvReclaimPolicy := corev1.PersistentVolumeReclaimDelete
 	allowVolumeExpansion := true
-	volumeBindingMode := v1.VolumeBindingWaitForFirstConsumer
+	volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 
 	desiredStorageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -137,7 +136,7 @@ func createOrUpdateBackingStorageclass(r *StorageClusterReconciler, bsc *ocsv1.B
 
 // ensureDeleted deletes the backing storageclasses
 func (obj *backingStorageClasses) ensureDeleted(r *StorageClusterReconciler, _ *ocsv1.StorageCluster) (reconcile.Result, error) {
-	existingBackingStorageClasses := &v1.StorageClassList{}
+	existingBackingStorageClasses := &storagev1.StorageClassList{}
 	err := r.Client.List(
 		r.ctx,
 		existingBackingStorageClasses,

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -14,14 +14,12 @@ import (
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
-	v1 "github.com/openshift/api/config/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/platform"
-	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	statusutil "github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -217,7 +215,7 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		return reconcile.Result{}, err
 	}
 
-	if platform == v1.IBMCloudPlatformType {
+	if platform == configv1.IBMCloudPlatformType {
 		r.Log.Info("Increasing Mon failover timeout to 15m.", "Platform", platform)
 		cephCluster.Spec.HealthCheck.DaemonHealth.Monitor.Timeout = "15m"
 	}
@@ -562,7 +560,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 		cephCluster.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfigMap.Data
 	}
 
-	isEnabled, rotationSchedule := util.GetKeyRotationSpec(sc)
+	isEnabled, rotationSchedule := statusutil.GetKeyRotationSpec(sc)
 	cephCluster.Spec.Security.KeyRotation.Enabled = isEnabled
 	cephCluster.Spec.Security.KeyRotation.Schedule = rotationSchedule
 

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -147,6 +147,7 @@ func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string)
 
 	crs.Size = getCephPoolReplicatedSize(initData)
 	crs.ReplicasPerFailureDomain = uint(getReplicasPerFailureDomain(initData))
+	//lint:ignore ST1017 required to compare it directly
 	if "data" == poolType {
 		crs.TargetSizeRatio = .49
 	}

--- a/controllers/storagecluster/placement_test.go
+++ b/controllers/storagecluster/placement_test.go
@@ -3,7 +3,6 @@ package storagecluster
 import (
 	"testing"
 
-	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -161,7 +160,7 @@ func getOcsToleration() corev1.Toleration {
 func TestGetPlacement(t *testing.T) {
 	cases := []struct {
 		label              string
-		storageCluster     *api.StorageCluster
+		storageCluster     *ocsv1.StorageCluster
 		placements         rookCephv1.PlacementSpec
 		labelSelector      *metav1.LabelSelector
 		expectedPlacements rookCephv1.PlacementSpec

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -13,13 +13,11 @@ import (
 	"github.com/operator-framework/operator-lib/conditions"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
-	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	statusutil "github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/v4/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -167,7 +165,7 @@ func (r *StorageClusterReconciler) Reconcile(ctx context.Context, request reconc
 		ReconcileStrategy(sc.Spec.MultiCloudGateway.ReconcileStrategy) == ReconcileStrategyStandalone
 
 	var err error
-	r.clusters, err = util.GetClusters(ctx, r.Client)
+	r.clusters, err = statusutil.GetClusters(ctx, r.Client)
 	if err != nil {
 		r.Log.Error(err, "Failed to get clusters")
 		return reconcile.Result{}, err
@@ -656,7 +654,7 @@ func versionCheck(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 	return nil
 }
 
-func (r *StorageClusterReconciler) SetOperatorConditions(message string, reason string, isUpgradeable v1.ConditionStatus, prevError error) error {
+func (r *StorageClusterReconciler) SetOperatorConditions(message string, reason string, isUpgradeable metav1.ConditionStatus, prevError error) error {
 	prevError = client.IgnoreNotFound(prevError)
 	operatorConditionErr := r.OperatorCondition.Set(context.TODO(), isUpgradeable, conditions.Option(conditions.WithMessage(message)), conditions.Option(conditions.WithReason(reason)))
 	if operatorConditionErr != nil {

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -22,10 +22,8 @@ import (
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/platform"
-	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	statusutil "github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/v4/version"
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1103,33 +1101,33 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 	scheme := createFakeScheme(t)
 	name := mockStorageClusterRequest.NamespacedName.Name
 	namespace := mockStorageClusterRequest.NamespacedName.Namespace
-	cfs := &cephv1.CephFilesystem{
+	cfs := &rookCephv1.CephFilesystem{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-cephfilesystem", name),
 			Namespace: namespace,
 		},
-		Status: &cephv1.CephFilesystemStatus{
-			Phase: cephv1.ConditionType(util.PhaseReady),
+		Status: &rookCephv1.CephFilesystemStatus{
+			Phase: rookCephv1.ConditionType(statusutil.PhaseReady),
 		},
 	}
-	cbp := &cephv1.CephBlockPool{
+	cbp := &rookCephv1.CephBlockPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-cephblockpool", name),
 			Namespace: namespace,
 		},
-		Status: &cephv1.CephBlockPoolStatus{
-			Phase: cephv1.ConditionType(util.PhaseReady),
+		Status: &rookCephv1.CephBlockPoolStatus{
+			Phase: rookCephv1.ConditionType(statusutil.PhaseReady),
 		},
 	}
 	obj = append(obj, cbp, cfs)
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj...).WithStatusSubresource(sc).Build()
 
-	clusters, err := util.GetClusters(context.TODO(), client)
+	clusters, err := statusutil.GetClusters(context.TODO(), client)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get clusters %s", err.Error()))
 	}
 
-	operatorNamespace, err := util.GetOperatorNamespace()
+	operatorNamespace, err := statusutil.GetOperatorNamespace()
 	if err != nil {
 		operatorNamespace = "openshift-storage"
 	}

--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -369,6 +369,7 @@ func nodesHaveIdenticalValuesForKeys(nodes *corev1.NodeList, keys []string) bool
 // should be all within this function.
 func filterDuplicateLabels(sc *ocsv1.StorageCluster, nodes *corev1.NodeList, topologyMap *ocsv1.NodeTopologyMap) {
 
+	//lint:ignore ST1017 required to compare it directly
 	if "" == getFailureDomain(sc) {
 		//This is the first time we are determining the failure domain
 

--- a/controllers/storagecluster/topology_test.go
+++ b/controllers/storagecluster/topology_test.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 )
@@ -45,18 +44,18 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 	testcases := []struct {
 		label                   string
 		nodeList                *corev1.NodeList
-		storageCluster          *api.StorageCluster
+		storageCluster          *ocsv1.StorageCluster
 		failureDomain           string
-		expectedNodeTopologyMap *api.NodeTopologyMap
+		expectedNodeTopologyMap *ocsv1.NodeTopologyMap
 		expectedNodeCount       int
 	}{
 		{
 			label:          "Case 1", // failure domain is rack
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "rack",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -79,10 +78,10 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 		{
 			label:          "Case 2", // failure domain is not set and sufficient zones available
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -133,10 +132,10 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 					},
 				},
 			},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -192,10 +191,10 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 					},
 				},
 			},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -257,10 +256,10 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 					},
 				},
 			},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					corev1.LabelZoneFailureDomainStable: []string{
 						"zone1",
 						"zone2",
@@ -315,10 +314,10 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 					},
 				},
 			},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "zone",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					labelZoneFailureDomainWithoutBeta: []string{
 						"zone1",
 						"zone2",
@@ -376,10 +375,10 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 					},
 				},
 			},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			failureDomain:  "zone",
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					corev1.LabelZoneFailureDomainStable: []string{
 						"zone1",
 						"zone2",
@@ -410,7 +409,7 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 		err = reconciler.Client.Status().Update(context.TODO(), tc.storageCluster)
 		assert.NoError(t, err)
 
-		actual := &api.StorageCluster{}
+		actual := &ocsv1.StorageCluster{}
 		err = reconciler.Client.Get(context.TODO(), mockStorageClusterRequest.NamespacedName, actual)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.expectedNodeTopologyMap, actual.Status.NodeTopologies, "[%s]: failed to get correct nodeToplogies", tc.label)
@@ -426,17 +425,17 @@ func TestNodeTopologyMapOnDifferentAZ(t *testing.T) {
 	testcases := []struct {
 		label                   string
 		nodeList                *corev1.NodeList
-		storageCluster          *api.StorageCluster
+		storageCluster          *ocsv1.StorageCluster
 		zoneCount               int
-		expectedNodeTopologyMap *api.NodeTopologyMap
+		expectedNodeTopologyMap *ocsv1.NodeTopologyMap
 	}{
 		{
 			label:          "Case 1", // three nodes spread across a single zone
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			zoneCount:      1,
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 					},
@@ -456,10 +455,10 @@ func TestNodeTopologyMapOnDifferentAZ(t *testing.T) {
 		{
 			label:          "Case 2", // three nodes spread across two zones
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			zoneCount:      2,
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -480,10 +479,10 @@ func TestNodeTopologyMapOnDifferentAZ(t *testing.T) {
 		{
 			label:          "Case 3", // three nodes spread across three zones
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			zoneCount:      3,
-			expectedNodeTopologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			expectedNodeTopologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -516,7 +515,7 @@ func TestNodeTopologyMapOnDifferentAZ(t *testing.T) {
 		err = reconciler.Client.Status().Update(context.TODO(), tc.storageCluster)
 		assert.NoError(t, err)
 
-		actual := &api.StorageCluster{}
+		actual := &ocsv1.StorageCluster{}
 		err = reconciler.Client.Get(context.TODO(), mockStorageClusterRequest.NamespacedName, actual)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.expectedNodeTopologyMap, actual.Status.NodeTopologies, "[%s]: failed to get correct nodeToplogies", tc.label)
@@ -528,21 +527,21 @@ func TestReconcileNodeTopologyMapFailure(t *testing.T) {
 	testcases := []struct {
 		label          string
 		nodeList       *corev1.NodeList
-		storageCluster *api.StorageCluster
+		storageCluster *ocsv1.StorageCluster
 		nodesAvailable bool
 		repilcaCount   int
 	}{
 		{
 			label:          "Case 1", // deviceSet replica count (4) greater than eligible nodes (3)
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			nodesAvailable: true,
 			repilcaCount:   4,
 		},
 		{
 			label:          "Case 2", // No eligible nodes found
 			nodeList:       &corev1.NodeList{},
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			nodesAvailable: false,
 			repilcaCount:   3,
 		},
@@ -564,14 +563,14 @@ func TestReconcileNodeTopologyMapFailure(t *testing.T) {
 func TestFailureDomain(t *testing.T) {
 	testcases := []struct {
 		label                 string
-		storageCluster        *api.StorageCluster
-		NodeTopologyMap       *api.NodeTopologyMap
+		storageCluster        *ocsv1.StorageCluster
+		NodeTopologyMap       *ocsv1.NodeTopologyMap
 		expectedFailureDomain string
 	}{
 		{
 			label: "Case 1", // storagecluster has predefined failure domain of `zone`
-			storageCluster: &api.StorageCluster{
-				Status: api.StorageClusterStatus{
+			storageCluster: &ocsv1.StorageCluster{
+				Status: ocsv1.StorageClusterStatus{
 					FailureDomain:  "zone",
 					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
@@ -580,8 +579,8 @@ func TestFailureDomain(t *testing.T) {
 		},
 		{
 			label: "Case 2", // storagecluster has predefined failure domain of `rack`
-			storageCluster: &api.StorageCluster{
-				Status: api.StorageClusterStatus{
+			storageCluster: &ocsv1.StorageCluster{
+				Status: ocsv1.StorageClusterStatus{
 					FailureDomain:  "rack",
 					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
@@ -590,10 +589,10 @@ func TestFailureDomain(t *testing.T) {
 		},
 		{
 			label: "Case 3", // storagecluster with three or more zone topology labels
-			storageCluster: &api.StorageCluster{
-				Status: api.StorageClusterStatus{
-					NodeTopologies: &api.NodeTopologyMap{
-						Labels: map[string]api.TopologyLabelValues{
+			storageCluster: &ocsv1.StorageCluster{
+				Status: ocsv1.StorageClusterStatus{
+					NodeTopologies: &ocsv1.NodeTopologyMap{
+						Labels: map[string]ocsv1.TopologyLabelValues{
 							zoneTopologyLabel: []string{
 								"zone1",
 								"zone2",
@@ -607,10 +606,10 @@ func TestFailureDomain(t *testing.T) {
 		},
 		{
 			label: "Case 4", // storagecluster with less than three zone topology labels
-			storageCluster: &api.StorageCluster{
-				Status: api.StorageClusterStatus{
-					NodeTopologies: &api.NodeTopologyMap{
-						Labels: map[string]api.TopologyLabelValues{
+			storageCluster: &ocsv1.StorageCluster{
+				Status: ocsv1.StorageClusterStatus{
+					NodeTopologies: &ocsv1.NodeTopologyMap{
+						Labels: map[string]ocsv1.TopologyLabelValues{
 							zoneTopologyLabel: []string{
 								"zone1",
 								"zone2",
@@ -623,8 +622,8 @@ func TestFailureDomain(t *testing.T) {
 		},
 		{
 			label: "Case 5", // storagecluster has predefined failure domain of `host`
-			storageCluster: &api.StorageCluster{
-				Status: api.StorageClusterStatus{
+			storageCluster: &ocsv1.StorageCluster{
+				Status: ocsv1.StorageClusterStatus{
 					FailureDomain:  "host",
 					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
@@ -633,11 +632,11 @@ func TestFailureDomain(t *testing.T) {
 		},
 		{
 			label: "Case 6", // storagecluster with FlexibleScaling enabled
-			storageCluster: &api.StorageCluster{
-				Spec: api.StorageClusterSpec{
+			storageCluster: &ocsv1.StorageCluster{
+				Spec: ocsv1.StorageClusterSpec{
 					FlexibleScaling: true,
 				},
-				Status: api.StorageClusterStatus{
+				Status: ocsv1.StorageClusterStatus{
 					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
 			},
@@ -645,11 +644,11 @@ func TestFailureDomain(t *testing.T) {
 		},
 		{
 			label: "Case 7", // storagecluster has predefined failure domain of `zone` and newer labels have been added to the nodes
-			storageCluster: &api.StorageCluster{
-				Status: api.StorageClusterStatus{
+			storageCluster: &ocsv1.StorageCluster{
+				Status: ocsv1.StorageClusterStatus{
 					FailureDomain: "zone",
-					NodeTopologies: &api.NodeTopologyMap{
-						Labels: map[string]api.TopologyLabelValues{
+					NodeTopologies: &ocsv1.NodeTopologyMap{
+						Labels: map[string]ocsv1.TopologyLabelValues{
 							corev1.LabelZoneFailureDomainStable: []string{
 								"zone1",
 								"zone2",
@@ -673,14 +672,14 @@ func TestFailureDomain(t *testing.T) {
 func TestStorageClusterEligibleNodes(t *testing.T) {
 	testcases := []struct {
 		label             string
-		storageCluster    *api.StorageCluster
+		storageCluster    *ocsv1.StorageCluster
 		nodeList          *corev1.NodeList
 		labelSelectors    *metav1.LabelSelector
 		expectedNodeCount int
 	}{
 		{
 			label:          "Case 1", // One eligible node with `WorkerAffinityKey` matching storageCluster labelselector
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			nodeList: &corev1.NodeList{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "NodeList",
@@ -701,7 +700,7 @@ func TestStorageClusterEligibleNodes(t *testing.T) {
 		},
 		{
 			label:          "Case 2", // One out of two nodes match default NodeAffinityKey
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			nodeList: &corev1.NodeList{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "NodeList",
@@ -716,7 +715,7 @@ func TestStorageClusterEligibleNodes(t *testing.T) {
 		},
 		{
 			label:          "Case 3", // No eligible nodes matching default NodeAffinityKey
-			storageCluster: &api.StorageCluster{},
+			storageCluster: &ocsv1.StorageCluster{},
 			nodeList: &corev1.NodeList{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "NodeList",
@@ -776,11 +775,11 @@ func TestEnsureNodeRack(t *testing.T) {
 				},
 			},
 			minRacks: 3,
-			nodeRacks: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{},
+			nodeRacks: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{},
 			},
-			topologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			topologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -821,8 +820,8 @@ func TestEnsureNodeRack(t *testing.T) {
 				},
 			},
 			minRacks: 3,
-			nodeRacks: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			nodeRacks: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					rack0: []string{
 						"Node1",
 					},
@@ -831,8 +830,8 @@ func TestEnsureNodeRack(t *testing.T) {
 					},
 				},
 			},
-			topologyMap: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			topologyMap: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					zoneTopologyLabel: []string{
 						"zone1",
 						"zone2",
@@ -874,8 +873,8 @@ func TestDeterminePlacementRack(t *testing.T) {
 			nodeList: &corev1.NodeList{},
 			node:     corev1.Node{},
 			minRacks: 3,
-			nodeRacks: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{},
+			nodeRacks: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{},
 			},
 			expectedRack: "rack0",
 		},
@@ -884,8 +883,8 @@ func TestDeterminePlacementRack(t *testing.T) {
 			nodeList: &corev1.NodeList{},
 			node:     corev1.Node{},
 			minRacks: 3,
-			nodeRacks: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			nodeRacks: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					rack0: []string{
 						"node1",
 						"node2",
@@ -900,8 +899,8 @@ func TestDeterminePlacementRack(t *testing.T) {
 			nodeList: &corev1.NodeList{},
 			node:     corev1.Node{},
 			minRacks: 3,
-			nodeRacks: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			nodeRacks: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					rack0: []string{
 						"node1",
 						"node2",
@@ -969,8 +968,8 @@ func TestDeterminePlacementRack(t *testing.T) {
 				},
 			},
 			minRacks: 3,
-			nodeRacks: &api.NodeTopologyMap{
-				Labels: map[string]api.TopologyLabelValues{
+			nodeRacks: &ocsv1.NodeTopologyMap{
+				Labels: map[string]ocsv1.TopologyLabelValues{
 					rack0: []string{
 						"Node1",
 					},

--- a/controllers/storagecluster/uninstall_reconciler_test.go
+++ b/controllers/storagecluster/uninstall_reconciler_test.go
@@ -9,7 +9,6 @@ import (
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	v1 "github.com/openshift/api/config/v1"
-	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
@@ -53,7 +52,7 @@ func TestReconcileUninstallAnnotations(t *testing.T) {
 }
 
 func assertStorageClusterUninstallAnnotation(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster,
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster,
 	CleanupPolicy CleanupPolicyType, UninstallMode UninstallModeType, ShouldSCUpdate bool) {
 
 	wasSCUpdated, err := reconciler.reconcileUninstallAnnotations(sc)
@@ -105,7 +104,7 @@ func TestSetRookUninstallandCleanupPolicy(t *testing.T) {
 }
 
 func assertCephClusterCleanupPolicy(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster,
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster,
 	CleanupPolicyConfirmation cephv1.CleanupConfirmationProperty, AllowUninstallWithVolumes bool) {
 
 	var err error
@@ -144,7 +143,7 @@ func TestDeleteStorageClasses(t *testing.T) {
 }
 
 func assertTestDeleteStorageClasses(t *testing.T, reconciler StorageClusterReconciler,
-	sc *api.StorageCluster, storageClassExists bool) {
+	sc *ocsv1.StorageCluster, storageClassExists bool) {
 
 	var obj ocsStorageClass
 	if !storageClassExists {
@@ -193,10 +192,9 @@ func TestDeleteSnapshotClasses(t *testing.T) {
 	}
 }
 
-// This function is not used, yet. It will be used in the future.
-// nolint:unused
+//lint:ignore U1000 will be used in future
 func assertTestDeleteSnapshotClasses(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, SnapshotClassExists bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, SnapshotClassExists bool) {
 
 	var obj ocsSnapshotClass
 
@@ -248,7 +246,7 @@ func TestDeleteNodeAffinityKeyFromNodes(t *testing.T) {
 }
 
 func assertTestDeleteNodeAffinityKeyFromNodes(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, createUserDefinedKey bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, createUserDefinedKey bool) {
 
 	if createUserDefinedKey {
 		addFakeNodeAffinityKeyOnNodesAndSC(t, reconciler, sc)
@@ -281,7 +279,7 @@ func assertTestDeleteNodeAffinityKeyFromNodes(
 	}
 }
 
-func addFakeNodeAffinityKeyOnNodesAndSC(t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster) {
+func addFakeNodeAffinityKeyOnNodesAndSC(t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster) {
 	// create user defined key and val and apply it on SC
 	fakeKey, fakeVal := "fakeKey", "fakeVal"
 	sc.Spec.LabelSelector = metav1.AddLabelToSelector(&metav1.LabelSelector{}, fakeKey, fakeVal)
@@ -334,7 +332,7 @@ func TestDeleteNodeTaint(t *testing.T) {
 }
 
 func assertTestDeleteNodeTaint(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, createDefaultNodeTaint bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, createDefaultNodeTaint bool) {
 
 	if createDefaultNodeTaint {
 		addDefaultNodeTaintOnNodes(t, reconciler, sc)
@@ -356,7 +354,7 @@ func assertTestDeleteNodeTaint(
 	}
 }
 
-func addDefaultNodeTaintOnNodes(t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster) {
+func addDefaultNodeTaintOnNodes(t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster) {
 
 	nodes, err := reconciler.getStorageClusterEligibleNodes(sc)
 	assert.NoError(t, err)
@@ -404,7 +402,7 @@ func TestDeleteCephCluster(t *testing.T) {
 }
 
 func assertTestDeleteCephCluster(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, cephClusterExist bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, cephClusterExist bool) {
 
 	var obj ocsCephCluster
 
@@ -456,7 +454,7 @@ func TestDeleteCephFilesystems(t *testing.T) {
 }
 
 func assertTestDeleteCephFilesystems(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, cephFilesystemsExist bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, cephFilesystemsExist bool) {
 
 	var obj ocsCephFilesystems
 
@@ -514,10 +512,9 @@ func TestDeleteCephBlockPools(t *testing.T) {
 	}
 }
 
-// This function is not used, yet. It will be used in the future.
-// nolint:unused
+//lint:ignore U1000 will be used in future
 func assertTestDeleteCephBlockPools(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, cephBlockPoolsExist bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, cephBlockPoolsExist bool) {
 
 	var obj ocsCephBlockPools
 
@@ -610,7 +607,7 @@ func TestDeleteCephObjectStoreUsers(t *testing.T) {
 }
 
 func assertTestDeleteCephObjectStoreUsers(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, CephObjectStoreUsersExist bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, CephObjectStoreUsersExist bool) {
 
 	var obj ocsCephObjectStoreUsers
 
@@ -710,7 +707,7 @@ func TestDeleteCephObjectStores(t *testing.T) {
 }
 
 func assertTestDeleteCephObjectStores(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster, CephObjectStoreExist bool) {
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster, CephObjectStoreExist bool) {
 
 	var obj ocsCephObjectStores
 
@@ -791,7 +788,7 @@ func TestSetNoobaaUninstallMode(t *testing.T) {
 }
 
 func assertTestSetNoobaaUninstallMode(
-	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster,
+	t *testing.T, reconciler StorageClusterReconciler, sc *ocsv1.StorageCluster,
 	UninstallMode UninstallModeType, NoobaaUninstallMode nbv1.CleanupConfirmationProperty) {
 
 	_, err := reconciler.reconcileUninstallAnnotations(sc)


### PR DESCRIPTION
Remove dual imports of few packages and update the lint comment to ignore the go-staticchecks correctly