### PR TITLE
Adding empty label selector for prom service monitor selector

### DIFF
--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -10,12 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var serviceMonitorSelector = metav1.LabelSelector{
-	MatchLabels: map[string]string{
-		"app": "odf-prometheus",
-	},
-}
-
 var ruleSelector = metav1.LabelSelector{
 	MatchLabels: map[string]string{
 		"prometheus": "rook-prometheus",
@@ -31,7 +25,7 @@ var (
 var PrometheusSpecTemplate = promv1.PrometheusSpec{
 	CommonPrometheusFields: promv1.CommonPrometheusFields{
 		ServiceAccountName:     "prometheus-k8s",
-		ServiceMonitorSelector: &serviceMonitorSelector,
+		ServiceMonitorSelector: &metav1.LabelSelector{},
 		ListenLocal:            true,
 		Resources:              defaults.MonitoringResources["prometheus"],
 		Containers: []corev1.Container{{


### PR DESCRIPTION
Introduced in #2465 the service monitor selector in the Prometheus configuration was marked wrongly,hence it was scraping metrics from only k8s-service-monitor. Adding an empty service monitor selector scrapes metrics from all Service monitors  present in the namespace.
List of Service Monitors present in the namespace
```
k8s-metrics-service-monitor                      
noobaa-mgmt-service-monitor                    
ocs-metrics-exporter                            
odf-operator-controller-manager-metrics-monitor  
rook-ceph-exporter                              
rook-ceph-mgr                                    
s3-service-monitor                                
```