### PR TITLE
hack: define proper 'GOARCH' when building ARM64 images

### DIFF
--- a/hack/build-metrics-exporter.sh
+++ b/hack/build-metrics-exporter.sh
@@ -7,5 +7,5 @@ source hack/docker-common.sh
 
 pushd metrics
 ${IMAGE_BUILD_CMD} build --no-cache -f Dockerfile -t "${METRICS_EXPORTER_FULL_IMAGE_NAME}" . \
-    --build-arg="GOOS=${GOOS}" --build-arg="GOARCH=${GOARCH}" --build-arg="LDFLAGS=${LDFLAGS}"
+    --build-arg="GOOS=${GOOS}" --build-arg="GOARCH=${GOHOSTARCH}" --build-arg="LDFLAGS=${LDFLAGS}"
 popd

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -6,4 +6,4 @@ source hack/common.sh
 source hack/docker-common.sh
 
 ${IMAGE_BUILD_CMD} build --no-cache -t "${OPERATOR_FULL_IMAGE_NAME}" . \
-    --build-arg="GOOS=${GOOS}" --build-arg="GOARCH=${GOARCH}" --build-arg="LDFLAGS=${LDFLAGS}"
+    --build-arg="GOOS=${GOOS}" --build-arg="GOARCH=${GOHOSTARCH}" --build-arg="LDFLAGS=${LDFLAGS}"


### PR DESCRIPTION
Use local host CPU architecture and pass it as GOARCH to image-build command. Needed when building images on non x86_64 images (e.g., AWS/Graviton ARM64, [RHSTOR-2044]).