### PR TITLE
Revert "bundle: add rook as a dependency to allow upgrades from 4.15 to 4.16"

### DIFF
--- a/config/dependencies/dependencies.yaml
+++ b/config/dependencies/dependencies.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- type: olm.package
-  value:
-    packageName: rook-ceph-operator
-    version: ">=4.15.0 <=4.16.0"

--- a/deploy/ocs-operator/metadata/dependencies.yaml
+++ b/deploy/ocs-operator/metadata/dependencies.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- type: olm.package
-  value:
-    packageName: rook-ceph-operator
-    version: ">=4.15.0 <=4.16.0"

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -47,7 +47,6 @@ function gen_ocs_csv() {
 	$KUSTOMIZE build config/manifests/ocs-operator | $OPERATOR_SDK generate bundle -q --overwrite=false --output-dir deploy/ocs-operator --kustomize-dir config/manifests/ocs-operator --package ocs-operator --version "$CSV_VERSION" --extra-service-accounts=ux-backend-server
 	mv deploy/ocs-operator/manifests/*clusterserviceversion.yaml $OCS_CSV
 	cp config/crd/bases/* $ocs_crds_outdir
-	cp config/dependencies/dependencies.yaml deploy/ocs-operator/metadata/dependencies.yaml
 }
 
 gen_ocs_csv


### PR DESCRIPTION
This reverts commit 366b7d2036193912fa9bcf629e75bc6acce647f8.

4.17 onwards odf will take a ownership over rook and bring it as a OLM deps.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Related PR: #2565