### PR TITLE
do not check for storageconsumer when storagerequest is being deleted

### DIFF
--- a/controllers/storagerequest/storagerequest_controller.go
+++ b/controllers/storagerequest/storagerequest_controller.go
@@ -208,10 +208,6 @@ func (r *StorageRequestReconciler) initPhase() error {
 		return fmt.Errorf("no storage consumer owner ref on the storage class request")
 	}
 
-	if err := r.get(r.storageConsumer); err != nil {
-		return err
-	}
-
 	// check request status already contains the name of the resource. if not, add it.
 	if r.StorageRequest.Spec.Type == "block" {
 		// initialize in-memory structs
@@ -303,6 +299,12 @@ func (r *StorageRequestReconciler) reconcilePhases() (reconcile.Result, error) {
 				return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %v", err)
 			}
 		}
+
+		// we are loading the storageconsumer only to confirm it's presence
+		if err := r.get(r.storageConsumer); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		if r.StorageRequest.Spec.Type == "block" {
 
 			if err := r.reconcileCephClientRBDProvisioner(); err != nil {


### PR DESCRIPTION
there is a possibility that getting storageconsumer from cache would work even when the resource is deleted however if the event gets requeued then we will always hit failure while trying to get deleted resource after a cache sync.

with this commit we only check presence of storageconsumer if storagerequest is not being deleted as the deletion of storagerequest is generally triggered via owner references and storageconsumer is owner of storagerequest.

fix for https://bugzilla.redhat.com/show_bug.cgi?id=2280813