### PR TITLE
 Bug 2282086:[release-4.16] controllers: limit reconciliations to relevant events

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -253,7 +253,7 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	)
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&ocsv1.OCSInitialization{}).
+		For(&ocsv1.OCSInitialization{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
 		Owns(&promv1.Prometheus{}).
@@ -271,6 +271,7 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}}
 				},
 			),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		// Watcher for storageClass required to update values related to replica-1
 		// in ocs-operator-config configmap, if storageClass changes

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -6,7 +6,11 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	templatev1 "github.com/openshift/api/template/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/operator-framework/operator-lib/conditions"
 	ocsclientv1a1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
@@ -16,6 +20,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -165,14 +170,81 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	builder := ctrl.NewControllerManagedBy(mgr).
+	noobaaIgnoreTimeUpdatePredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldObj := e.ObjectOld.(*nbv1.NooBaa)
+			newObj := e.ObjectNew.(*nbv1.NooBaa)
+
+			ignorePaths := func(path cmp.Path) bool {
+				switch path.String() {
+				case "ObjectMeta.ManagedFields",
+					"ObjectMeta.ResourceVersion",
+					"Status.Conditions.LastHeartbeatTime",
+					"Status.Conditions.LastTransitionTime":
+					return true
+				}
+				return false
+			}
+			diff := cmp.Diff(
+				oldObj, newObj,
+				cmp.FilterPath(ignorePaths, cmp.Ignore()),
+			)
+
+			return diff != ""
+		},
+	}
+
+	cephClusterIgnoreTimeUpdatePredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldObj := e.ObjectOld.(*cephv1.CephCluster)
+			newObj := e.ObjectNew.(*cephv1.CephCluster)
+
+			ignorePaths := func(path cmp.Path) bool {
+				switch path.String() {
+				case "ObjectMeta.ManagedFields",
+					"ObjectMeta.ResourceVersion",
+					"Status.CephStatus.LastChecked",
+					"Status.CephStatus.Capacity.LastUpdated",
+					"Status.Conditions.LastHeartbeatTime",
+					"Status.Conditions.LastTransitionTime":
+					return true
+				}
+				return false
+			}
+			diff := cmp.Diff(
+				oldObj, newObj,
+				cmp.FilterPath(ignorePaths, cmp.Ignore()),
+			)
+
+			return diff != ""
+		},
+	}
+
+	build := ctrl.NewControllerManagedBy(mgr).
 		For(&ocsv1.StorageCluster{}, builder.WithPredicates(scPredicate)).
-		Owns(&cephv1.CephCluster{}).
+		Owns(&cephv1.CephCluster{}, builder.WithPredicates(cephClusterIgnoreTimeUpdatePredicate)).
+		Owns(&cephv1.CephBlockPool{}).
+		Owns(&cephv1.CephFilesystem{}).
+		Owns(&cephv1.CephFilesystemSubVolumeGroup{}).
+		Owns(&cephv1.CephNFS{}).
+		Owns(&cephv1.CephObjectStore{}).
+		Owns(&cephv1.CephObjectStoreUser{}).
+		Owns(&cephv1.CephRBDMirror{}).
 		Owns(&corev1.PersistentVolumeClaim{}, builder.WithPredicates(pvcPredicate)).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.ConfigMap{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&routev1.Route{}).
+		Owns(&templatev1.Template{}).
+		Watches(&storagev1.StorageClass{}, enqueueStorageClusterRequest).
+		Watches(&volumesnapshotv1.VolumeSnapshotClass{}, enqueueStorageClusterRequest).
 		Watches(&ocsclientv1a1.StorageClient{}, enqueueStorageClusterRequest).
 		Watches(&ocsv1.StorageProfile{}, enqueueStorageClusterRequest).
 		Watches(
@@ -184,9 +256,10 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			enqueueStorageClusterRequest,
 		).
 		Watches(&ocsv1alpha1.StorageConsumer{}, enqueueStorageClusterRequest, builder.WithPredicates(ocsClientOperatorVersionPredicate))
+
 	if os.Getenv("SKIP_NOOBAA_CRD_WATCH") != "true" {
-		builder.Owns(&nbv1.NooBaa{})
+		build.Owns(&nbv1.NooBaa{}, builder.WithPredicates(noobaaIgnoreTimeUpdatePredicate))
 	}
 
-	return builder.Complete(r)
+	return build.Complete(r)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ceph/ceph-csi/api v0.0.0-20240322131550-063319f6e516
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344
 	github.com/go-logr/logr v1.4.1
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.6.0
@@ -78,7 +79,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect


### PR DESCRIPTION
Noobaa and CephCluster CRs' status.conditions[].lastHeartbeatTime and status.conditions[].lastTransitionTime etc change frequently, causing unnecessary StorageCluster reconciliations. Implement logic to filter out these frequent, non-essential changes and trigger reconciliations only on relevant events.

Also add the owns for other objects as noobaa and cephcluster will trigger the recociles only for the relevant events. Previously, even though these objects were not owned by the controller, reconciliations were triggered due to status updates of the NooBaa and CephCluster CRs. Now the other objects should send thier own recocile requests because noobaa and ceph clkuster wont trigger the unnecessary reconciles and these objects can not rely on noobaa and ceph cluster.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
Co-authored-by: Malay Kumar Parida <mparida@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2280595

This is an manual cherry-pick of #2621