### PR TITLE
Bug 2276824: [release-4.15] Remove default value of waitTimeoutForHealthyOSDInMinutes

### DIFF
--- a/controllers/defaults/defaults.go
+++ b/controllers/defaults/defaults.go
@@ -2,8 +2,6 @@
 // options of a StorageCluster
 package defaults
 
-import "time"
-
 const (
 	// NodeAffinityKey is the node label to determine which nodes belong
 	// to a storage cluster
@@ -54,7 +52,4 @@ var (
 	// ArbiterReplicasPerFailureDomain is the default replica count in the failure domain when arbiter is enabled
 	// This maps to the ReplicasPerFailureDomain in the CephReplicatedSpec when creating the CephBlockPools
 	ArbiterReplicasPerFailureDomain = 2
-	// DefaultWaitTimeoutForHealthyOSD is the default time for which the operator would wait before an OSD can be stopped
-	// for an upgrade or restart
-	DefaultWaitTimeoutForHealthyOSD = 10 * time.Minute
 )

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -3,7 +3,6 @@ package storagecluster
 import (
 	// The embed package is required for the prometheus rule files
 	_ "embed"
-	"time"
 
 	"bytes"
 	"context"
@@ -483,8 +482,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *v
 					KernelMountOptions: getCephFSKernelMountOptions(sc),
 				},
 			},
-			WaitTimeoutForHealthyOSDInMinutes: getWaitTimeoutForHealthOSD(sc),
 		},
+	}
+
+	if sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes != 0 {
+		cephCluster.Spec.WaitTimeoutForHealthyOSDInMinutes = sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes
 	}
 
 	if sc.Spec.LogCollector != nil {
@@ -1324,12 +1326,4 @@ func getOsdCount(sc *ocsv1.StorageCluster, serverVersion *version.Info) int {
 		osdCount += ds.Count
 	}
 	return osdCount
-}
-
-func getWaitTimeoutForHealthOSD(sc *ocsv1.StorageCluster) time.Duration {
-	if sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes != 0 {
-		return sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes
-	}
-
-	return defaults.DefaultWaitTimeoutForHealthyOSD
 }


### PR DESCRIPTION
Remove default value of waitTimeoutForHealthyOSDInMinutes from ocs-operator, and only update the SC CR, if a value is provided by the user.
Reference PR that added this code: #2579 