### PR TITLE
Bug 2277926: [release-4.13] Remove default value of waitTimeoutForHealthyOSDInMinutes

### DIFF
--- a/controllers/defaults/defaults.go
+++ b/controllers/defaults/defaults.go
@@ -2,8 +2,6 @@
 // options of a StorageCluster
 package defaults
 
-import "time"
-
 const (
 	// NodeAffinityKey is the node label to determine which nodes belong
 	// to a storage cluster
@@ -50,7 +48,4 @@ var (
 	// ArbiterReplicasPerFailureDomain is the default replica count in the failure domain when arbiter is enabled
 	// This maps to the ReplicasPerFailureDomain in the CephReplicatedSpec when creating the CephBlockPools
 	ArbiterReplicasPerFailureDomain = 2
-	// DefaultWaitTimeoutForHealthyOSD is the default time for which the operator would wait before an OSD can be stopped
-	// for an upgrade or restart
-	DefaultWaitTimeoutForHealthyOSD = 10 * time.Minute
 )

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -3,7 +3,6 @@ package storagecluster
 import (
 	// The embed package is required for the prometheus rule files
 	_ "embed"
-	"time"
 
 	"bytes"
 	"context"
@@ -425,8 +424,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 			Labels: rookCephv1.LabelsSpec{
 				rookCephv1.KeyMonitoring: getCephClusterMonitoringLabels(*sc),
 			},
-			WaitTimeoutForHealthyOSDInMinutes: getWaitTimeoutForHealthOSD(sc),
 		},
+	}
+
+	if sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes != 0 {
+		cephCluster.Spec.WaitTimeoutForHealthyOSDInMinutes = sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes
 	}
 
 	if sc.Spec.LogCollector != nil {
@@ -1199,12 +1201,4 @@ func getMonitoringClient() (*monitoringclient.Clientset, error) {
 		return nil, fmt.Errorf("failed to get monitoring client bar. %v", err)
 	}
 	return client, nil
-}
-
-func getWaitTimeoutForHealthOSD(sc *ocsv1.StorageCluster) time.Duration {
-	if sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes != 0 {
-		return sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes
-	}
-
-	return defaults.DefaultWaitTimeoutForHealthyOSD
 }


### PR DESCRIPTION
Remove default value of waitTimeoutForHealthyOSDInMinutes from ocs-operator, and only update the SC CR, if a value is provided by the user.
Reference PR that added this code: #2579 