### PR TITLE
[release-4.13] Fix spell check CI

### DIFF
--- a/.github/workflows/ocs-operator-ci.yaml
+++ b/.github/workflows/ocs-operator-ci.yaml
@@ -110,4 +110,4 @@ jobs:
           check_filenames: true
           check_hidden: true
           skip: vendor
-          ignore_words_list: xdescribe,contails,shouldnot
+          ignore_words_list: xdescribe,contails,shouldnot,NotIn,notin

--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -156,7 +156,7 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 		MaxCount:               2,
 		AdditionalVirtualHosts: []string{},
 
-		// TODO: After spec.resources["noobaa-endpoint"] is decleared obesolete this
+		// TODO: After spec.resources["noobaa-endpoint"] is declared obesolete this
 		// definition should hold a constant value. and should not be read from
 		// GetDaemonResources()
 		Resources: &endpointResources,

--- a/docs/catalog-generation.md
+++ b/docs/catalog-generation.md
@@ -9,7 +9,7 @@ The converged CSV is created by sourcing CSV manifests from each component-level
 
 ### Building the converged catalog
 
-Building the unifed CSV is broken into two steps which are supported by the `make source-manifests` and `make gen-release-csv` make targets.
+Building the unified CSV is broken into two steps which are supported by the `make source-manifests` and `make gen-release-csv` make targets.
 
 #### Source component manifests
 

--- a/hack/gen-promethues-rules.sh
+++ b/hack/gen-promethues-rules.sh
@@ -5,7 +5,7 @@ BUILD_PATH="metrics/mixin/build"
 RULES_PATH="metrics/deploy"
 
 #Create intermediate yamls to test if alerts are compiling a
-echo "Creating Promethues Rules And Alerts"
+echo "Creating Prometheus Rules And Alerts"
 
 (cd $MIXIN_PATH && make prometheus_alert_rules.yaml prometheus_alert_rules_external.yaml)
 


### PR DESCRIPTION
Fix typo for `unifed`, `promethues` and `decleared` and added `NotIn`, `notin` to ignore_word_list for spell check CI