### PR TITLE
Sends `VolumeGroupSnapshotClass` to client

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -611,19 +611,24 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 				rbdStorageClassData["encryptionKMSID"] = storageRequest.Spec.EncryptionMethod
 			}
 
-			extR = append(extR, &pb.ExternalResource{
-				Name: "ceph-rbd",
-				Kind: "StorageClass",
-				Data: mustMarshal(rbdStorageClassData),
-			})
-
-			extR = append(extR, &pb.ExternalResource{
-				Name: "ceph-rbd",
-				Kind: "VolumeSnapshotClass",
-				Data: mustMarshal(map[string]string{
-					"clusterID": rbdStorageClassData["clusterID"],
-					"csi.storage.k8s.io/snapshotter-secret-name": provisionerSecretName,
-				})})
+			extR = append(extR,
+				&pb.ExternalResource{
+					Name: "ceph-rbd",
+					Kind: "StorageClass",
+					Data: mustMarshal(rbdStorageClassData),
+				},
+				&pb.ExternalResource{
+					Name: "ceph-rbd",
+					Kind: "VolumeSnapshotClass",
+					Data: mustMarshal(map[string]string{
+						"csi.storage.k8s.io/snapshotter-secret-name": provisionerSecretName,
+					})},
+				&pb.ExternalResource{
+					Name: "ceph-rbd",
+					Kind: "VolumeGroupSnapshotClass",
+					Data: mustMarshal(map[string]string{
+						"csi.storage.k8s.io/group-snapshotter-secret-name": provisionerSecretName,
+					})})
 
 		case "CephFilesystemSubVolumeGroup":
 			subVolumeGroup := &rookCephv1.CephFilesystemSubVolumeGroup{}
@@ -644,26 +649,30 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 				"csi.storage.k8s.io/controller-expand-secret-name": provisionerSecretName,
 			}
 
-			extR = append(extR, &pb.ExternalResource{
-				Name: "cephfs",
-				Kind: "StorageClass",
-				Data: mustMarshal(cephfsStorageClassData),
-			})
-
-			extR = append(extR, &pb.ExternalResource{
-				Name: cephRes.Name,
-				Kind: cephRes.Kind,
-				Data: mustMarshal(map[string]string{
-					"filesystemName": subVolumeGroup.Spec.FilesystemName,
-				})})
-
-			extR = append(extR, &pb.ExternalResource{
-				Name: "cephfs",
-				Kind: "VolumeSnapshotClass",
-				Data: mustMarshal(map[string]string{
-					"clusterID": getSubVolumeGroupClusterID(subVolumeGroup),
-					"csi.storage.k8s.io/snapshotter-secret-name": provisionerSecretName,
-				})})
+			extR = append(extR,
+				&pb.ExternalResource{
+					Name: "cephfs",
+					Kind: "StorageClass",
+					Data: mustMarshal(cephfsStorageClassData),
+				},
+				&pb.ExternalResource{
+					Name: cephRes.Name,
+					Kind: cephRes.Kind,
+					Data: mustMarshal(map[string]string{
+						"filesystemName": subVolumeGroup.Spec.FilesystemName,
+					})},
+				&pb.ExternalResource{
+					Name: "cephfs",
+					Kind: "VolumeSnapshotClass",
+					Data: mustMarshal(map[string]string{
+						"csi.storage.k8s.io/snapshotter-secret-name": provisionerSecretName,
+					})},
+				&pb.ExternalResource{
+					Name: "cephfs",
+					Kind: "VolumeGroupSnapshotClass",
+					Data: mustMarshal(map[string]string{
+						"csi.storage.k8s.io/group-snapshotter-secret-name": provisionerSecretName,
+					})})
 		}
 	}
 

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -507,8 +507,14 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Name: "ceph-rbd",
 				Kind: "VolumeSnapshotClass",
 				Data: map[string]string{
-					"clusterID": serverNamespace,
 					"csi.storage.k8s.io/snapshotter-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
+				},
+			},
+			"ceph-rbd-volumegroupsnapshotclass": {
+				Name: "ceph-rbd",
+				Kind: "VolumeGroupSnapshotClass",
+				Data: map[string]string{
+					"csi.storage.k8s.io/group-snapshotter-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
 				},
 			},
 			"ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c": {
@@ -547,8 +553,15 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Name: "cephfs",
 				Kind: "VolumeSnapshotClass",
 				Data: map[string]string{
-					"clusterID": "8d26c7378c1b0ec9c2455d1c3601c4cd",
 					"csi.storage.k8s.io/snapshotter-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
+				},
+			},
+
+			"cephfs-volumegroupsnapshotclass": {
+				Name: "cephfs",
+				Kind: "VolumeGroupSnapshotClass",
+				Data: map[string]string{
+					"csi.storage.k8s.io/group-snapshotter-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
 				},
 			},
 			"ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c": {
@@ -853,6 +866,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 			name = fmt.Sprintf("%s-volumesnapshotclass", name)
 		} else if extResource.Kind == "StorageClass" {
 			name = fmt.Sprintf("%s-storageclass", name)
+		} else if extResource.Kind == "VolumeGroupSnapshotClass" {
+			name = fmt.Sprintf("%s-volumegroupsnapshotclass", name)
 		}
 		mockResoruce, ok := mockBlockPoolClaimExtR[name]
 		assert.True(t, ok)
@@ -880,6 +895,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 			name = fmt.Sprintf("%s-volumesnapshotclass", name)
 		} else if extResource.Kind == "StorageClass" {
 			name = fmt.Sprintf("%s-storageclass", name)
+		} else if extResource.Kind == "VolumeGroupSnapshotClass" {
+			name = fmt.Sprintf("%s-volumegroupsnapshotclass", name)
 		}
 		mockResoruce, ok := mockShareFilesystemClaimExtR[name]
 		assert.True(t, ok)


### PR DESCRIPTION
Sends `VolumeGroupSnapshotClass` as an external resource to the client via the storage claim response.
Must be merged prior to [ocs-client-operator/pull/168](https://github.com/red-hat-storage/ocs-client-operator/pull/168).
[RHSTOR-5795](https://issues.redhat.com/browse/RHSTOR-5795)