### PR TITLE
Bug 2274175: [release-4.16] Set deviceClasses to avoid replicated pool spreading PGs across all OSDs

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -556,6 +556,9 @@ type StorageClusterStatus struct {
 	// Images holds the image reconcile status for all images reconciled by the operator
 	Images ImagesStatus `json:"images,omitempty"`
 
+	// DefaultCephDeviceClass holds the default ceph device class to be used for the pools
+	DefaultCephDeviceClass string `json:"defaultCephDeviceClass,omitempty"`
+
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -8002,6 +8002,10 @@ spec:
                 description: CurrentMonCount holds the value of ceph mons configured
                   in ceph cluster.
                 type: integer
+              defaultCephDeviceClass:
+                description: DefaultCephDeviceClass holds the default ceph device
+                  class to be used for the pools
+                type: string
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -61,7 +61,7 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 			},
 			Spec: cephv1.NamedBlockPoolSpec{
 				PoolSpec: cephv1.PoolSpec{
-					DeviceClass:    generateDeviceClass(initData),
+					DeviceClass:    initData.Status.DefaultCephDeviceClass,
 					FailureDomain:  getFailureDomain(initData),
 					Replicated:     generateCephReplicatedSpec(initData, "data"),
 					EnableRBDStats: true,
@@ -113,7 +113,7 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 				Spec: cephv1.NamedBlockPoolSpec{
 					Name: ".nfs",
 					PoolSpec: cephv1.PoolSpec{
-						DeviceClass:    generateDeviceClass(initData),
+						DeviceClass:    initData.Status.DefaultCephDeviceClass,
 						FailureDomain:  getFailureDomain(initData),
 						Replicated:     generateCephReplicatedSpec(initData, "data"),
 						EnableRBDStats: true,

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -279,7 +279,7 @@ func getActiveMetadataServers(sc *ocsv1.StorageCluster) int {
 // Define a function to generate default pool specifications
 func generateDefaultPoolSpec(sc *ocsv1.StorageCluster) cephv1.PoolSpec {
 	return cephv1.PoolSpec{
-		DeviceClass:   generateDeviceClass(sc),
+		DeviceClass:   sc.Status.DefaultCephDeviceClass,
 		Replicated:    generateCephReplicatedSpec(sc, "data"),
 		FailureDomain: sc.Status.FailureDomain,
 	}

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -169,7 +169,7 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 			Spec: cephv1.ObjectStoreSpec{
 				PreservePoolsOnDelete: false,
 				DataPool: cephv1.PoolSpec{
-					DeviceClass:   generateDeviceClass(initData),
+					DeviceClass:   initData.Status.DefaultCephDeviceClass,
 					FailureDomain: initData.Status.FailureDomain,
 					Replicated:    generateCephReplicatedSpec(initData, "data"),
 				},

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -44,14 +44,6 @@ func generateNameForCephBlockPool(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-cephblockpool", initData.Name)
 }
 
-func generateDeviceClass(initData *ocsv1.StorageCluster) string {
-	if initData.Spec.ManagedResources.CephNonResilientPools.Enable {
-		return "replicated"
-	}
-	// if Non-Resilient pools are not enabled then keep the device class blank
-	return ""
-}
-
 func generateNameForNonResilientCephBlockPool(initData *ocsv1.StorageCluster, failureDomainValue string) string {
 	return fmt.Sprintf("%s-cephblockpool-%s", initData.Name, failureDomainValue)
 }

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -8002,6 +8002,10 @@ spec:
                 description: CurrentMonCount holds the value of ceph mons configured
                   in ceph cluster.
                 type: integer
+              defaultCephDeviceClass:
+                description: DefaultCephDeviceClass holds the default ceph device
+                  class to be used for the pools
+                type: string
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -8001,6 +8001,10 @@ spec:
                 description: CurrentMonCount holds the value of ceph mons configured
                   in ceph cluster.
                 type: integer
+              defaultCephDeviceClass:
+                description: DefaultCephDeviceClass holds the default ceph device
+                  class to be used for the pools
+                type: string
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -556,6 +556,9 @@ type StorageClusterStatus struct {
 	// Images holds the image reconcile status for all images reconciled by the operator
 	Images ImagesStatus `json:"images,omitempty"`
 
+	// DefaultCephDeviceClass holds the default ceph device class to be used for the pools
+	DefaultCephDeviceClass string `json:"defaultCephDeviceClass,omitempty"`
+
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
 

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -556,6 +556,9 @@ type StorageClusterStatus struct {
 	// Images holds the image reconcile status for all images reconciled by the operator
 	Images ImagesStatus `json:"images,omitempty"`
 
+	// DefaultCephDeviceClass holds the default ceph device class to be used for the pools
+	DefaultCephDeviceClass string `json:"defaultCephDeviceClass,omitempty"`
+
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
 


### PR DESCRIPTION
This is a manual backport of https://github.com/red-hat-storage/ocs-operator/pull/2615

BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2274175

Set the deviceClasses of the pools to avoid wrong data placement

Earlier when replica-1 was getting enabled on an existing cluster the pool was setting it's deviceClass to replicated but there were no osds with this deviceClass as osd's during normal creation were given SSD deviceClass if blank, and now they can't change. To avoid & solve this problem we have to intelligently set the deviceClass for the pools, Depending on whether replica-1 is enabled & the number of deviceClasses found in the cephCluster CR status.

To do this we added a DefaultCephDeviceClass field in StorageCluster Status which will hold the default ceph device class to be used for the pools. Depending on whether replica-1 is enabled & the number of deviceClasses found in the status this value is determined and set in the status.