### PR TITLE
Bug 2291321: [release-4.15] Set deviceClasses to avoid replicated pool spreading PGs across all OSDs

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -534,6 +534,9 @@ type StorageClusterStatus struct {
 	// Images holds the image reconcile status for all images reconciled by the operator
 	Images ImagesStatus `json:"images,omitempty"`
 
+	// DefaultCephDeviceClass holds the default ceph device class to be used for the pools
+	DefaultCephDeviceClass string `json:"defaultCephDeviceClass,omitempty"`
+
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -6834,6 +6834,10 @@ spec:
                 description: CurrentMonCount holds the value of ceph mons configured
                   in ceph cluster.
                 type: integer
+              defaultCephDeviceClass:
+                description: DefaultCephDeviceClass holds the default ceph device
+                  class to be used for the pools
+                type: string
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -61,7 +61,7 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 			},
 			Spec: cephv1.NamedBlockPoolSpec{
 				PoolSpec: cephv1.PoolSpec{
-					DeviceClass:    generateDeviceClass(initData),
+					DeviceClass:    initData.Status.DefaultCephDeviceClass,
 					FailureDomain:  getFailureDomain(initData),
 					Replicated:     generateCephReplicatedSpec(initData, "data"),
 					EnableRBDStats: true,
@@ -109,7 +109,7 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 				Spec: cephv1.NamedBlockPoolSpec{
 					Name: ".nfs",
 					PoolSpec: cephv1.PoolSpec{
-						DeviceClass:    generateDeviceClass(initData),
+						DeviceClass:    initData.Status.DefaultCephDeviceClass,
 						FailureDomain:  getFailureDomain(initData),
 						Replicated:     generateCephReplicatedSpec(initData, "data"),
 						EnableRBDStats: true,

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -262,6 +262,11 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		return reconcile.Result{}, nil
 	}
 
+	// Set the default CephDeviceClass in the StorageCluster status(not needed for external clusters)
+	if !sc.Spec.ExternalStorage.Enable && found.Status.CephStorage != nil {
+		sc.Status.DefaultCephDeviceClass = determineDefaultCephDeviceClass(found.Status.CephStorage.DeviceClasses, sc.Spec.ManagedResources.CephNonResilientPools.Enable, sc.Status.FailureDomainValues)
+	}
+
 	// Record actual Ceph container image version before attempting update
 	sc.Status.Images.Ceph.ActualImage = found.Spec.CephVersion.Image
 
@@ -851,10 +856,6 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			annotations := map[string]string{
 				"crushDeviceClass": crushDeviceClass,
 			}
-			// if Non-Resilient Pools are enabled then change the existing osd crushDeviceClass to "replicated"
-			if sc.Spec.ManagedResources.CephNonResilientPools.Enable {
-				annotations["crushDeviceClass"] = "replicated"
-			}
 			// Annotation crushInitialWeight is an optional, explicit weight to set upon OSD's init (as float, in TiB units).
 			// ROOK & Ceph do not want any (optional) Ti[B] suffix, so trim it here.
 			// If not set, Ceph will define OSD's weight based on its capacity.
@@ -1326,4 +1327,28 @@ func getOsdCount(sc *ocsv1.StorageCluster, serverVersion *version.Info) int {
 		osdCount += ds.Count
 	}
 	return osdCount
+}
+
+func determineDefaultCephDeviceClass(foundDeviceClasses []rookCephv1.DeviceClasses, isReplica1 bool, replica1DeviceClasses []string) string {
+	// If device classes are found in status
+	if len(foundDeviceClasses) != 0 {
+		// If replica-1 is not enabled return the first device class
+		if !isReplica1 {
+			return foundDeviceClasses[0].Name
+		}
+		// If replica-1 is enabled return the first one that is not a replica1 device class
+		if len(foundDeviceClasses) != 0 {
+			replica1DeviceClassMap := make(map[string]bool)
+			for _, deviceClass := range replica1DeviceClasses {
+				replica1DeviceClassMap[deviceClass] = true
+			}
+			for _, deviceClass := range foundDeviceClasses {
+				if found := replica1DeviceClassMap[deviceClass.Name]; !found {
+					return deviceClass.Name
+				}
+			}
+		}
+	}
+	// By default return "ssd"
+	return "ssd"
 }

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -1629,3 +1629,140 @@ func TestEnsureRDRMigration(t *testing.T) {
 	assert.Equal(t, string(rookCephv1.StoreTypeBlueStoreRDR), actual.Spec.Storage.Store.Type)
 	assert.Equal(t, "yes-really-update-store", actual.Spec.Storage.Store.UpdateStore)
 }
+
+func TestDetermineDefaultCephDeviceClass(t *testing.T) {
+	cases := []struct {
+		label                 string
+		foundDeviceClasses    []rookCephv1.DeviceClasses
+		isReplica1            bool
+		replica1DeviceClasses []string
+		expectedDeviceClass   string
+	}{
+		{
+			label:                 "Case 1: Replica 1 not enabled & no DeviceClass in status",
+			foundDeviceClasses:    []rookCephv1.DeviceClasses{},
+			isReplica1:            false,
+			replica1DeviceClasses: []string{},
+			expectedDeviceClass:   "ssd",
+		},
+		{
+			label: "Case 2: Replica 1 not enabled & 1 DeviceClass is in status",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "gold",
+				},
+			},
+			isReplica1:            false,
+			replica1DeviceClasses: []string{},
+			expectedDeviceClass:   "gold",
+		},
+		{
+			label: "Case 3: Replica 1 not enabled & more than 1 DeviceClass is in status",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "gold",
+				},
+				{
+					Name: "silver",
+				},
+			},
+			isReplica1:            false,
+			replica1DeviceClasses: []string{},
+			expectedDeviceClass:   "gold",
+		},
+		{
+			label:                 "Case 4: Replica 1 enabled & no DeviceClass in status",
+			foundDeviceClasses:    []rookCephv1.DeviceClasses{},
+			isReplica1:            true,
+			replica1DeviceClasses: []string{"zone1", "zone2", "zone3"},
+			expectedDeviceClass:   "ssd",
+		},
+		{
+			label: "Case 5:  Replica 1 enabled. Total less than n DeviceClass are in status, with only one non replica-1 DeviceClass",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "gold",
+				},
+			},
+			isReplica1:            true,
+			replica1DeviceClasses: []string{"zone1", "zone2", "zone3"},
+			expectedDeviceClass:   "gold",
+		},
+		{
+			label: "Case 6:  Replica 1 enabled. Total less than n DeviceClass are in status, with more than one non replica-1 DeviceClass",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "gold",
+				},
+				{
+					Name: "silver",
+				},
+			},
+			isReplica1:          true,
+			expectedDeviceClass: "gold",
+		},
+		{
+			label: "Case 7: Replica 1 enabled & only n replica-1 DeviceClass are in status without any non-replica-1 DeviceClass",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "zone1",
+				},
+				{
+					Name: "zone2",
+				},
+				{
+					Name: "zone3",
+				},
+			},
+			isReplica1:            true,
+			replica1DeviceClasses: []string{"zone1", "zone2", "zone3"},
+			expectedDeviceClass:   "ssd",
+		},
+		{
+			label: "Case 8: Replica 1 enabled & n+1 total DeviceClass are in status(n replica-1 DeviceClass, 1 non-replica-1 DeviceClass)",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "gold",
+				},
+				{
+					Name: "zone1",
+				},
+				{
+					Name: "zone2",
+				},
+				{
+					Name: "zone3",
+				},
+			},
+			isReplica1:          true,
+			expectedDeviceClass: "gold",
+		},
+		{
+			label: "Case 9: Replica 1 enabled & more than n+1 DeviceClass are in status",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "gold",
+				},
+				{
+					Name: "silver",
+				},
+				{
+					Name: "zone1",
+				},
+				{
+					Name: "zone2",
+				},
+				{
+					Name: "zone3",
+				},
+			},
+			expectedDeviceClass: "gold",
+		},
+	}
+
+	for _, c := range cases {
+		t.Logf("Case: %s\n", c.label)
+		actual := determineDefaultCephDeviceClass(c.foundDeviceClasses, c.isReplica1, c.replica1DeviceClasses)
+		assert.Equal(t, c.expectedDeviceClass, actual)
+	}
+}

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -54,7 +54,7 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 		ret.Spec.DataPools = []cephv1.NamedPoolSpec{
 			{
 				PoolSpec: cephv1.PoolSpec{
-					DeviceClass:   generateDeviceClass(initStorageCluster),
+					DeviceClass:   initStorageCluster.Status.DefaultCephDeviceClass,
 					Replicated:    generateCephReplicatedSpec(initStorageCluster, "data"),
 					FailureDomain: initStorageCluster.Status.FailureDomain,
 				},

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -165,7 +165,7 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 			Spec: cephv1.ObjectStoreSpec{
 				PreservePoolsOnDelete: false,
 				DataPool: cephv1.PoolSpec{
-					DeviceClass:   generateDeviceClass(initData),
+					DeviceClass:   initData.Status.DefaultCephDeviceClass,
 					FailureDomain: initData.Status.FailureDomain,
 					Replicated:    generateCephReplicatedSpec(initData, "data"),
 				},

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -46,14 +46,6 @@ func generateNameForCephBlockPool(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-cephblockpool", initData.Name)
 }
 
-func generateDeviceClass(initData *ocsv1.StorageCluster) string {
-	if initData.Spec.ManagedResources.CephNonResilientPools.Enable {
-		return "replicated"
-	}
-	// if Non-Resilient pools are not enabled then keep the device class blank
-	return ""
-}
-
 func generateNameForNonResilientCephBlockPool(initData *ocsv1.StorageCluster, failureDomainValue string) string {
 	return fmt.Sprintf("%s-cephblockpool-%s", initData.Name, failureDomainValue)
 }

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -6834,6 +6834,10 @@ spec:
                 description: CurrentMonCount holds the value of ceph mons configured
                   in ceph cluster.
                 type: integer
+              defaultCephDeviceClass:
+                description: DefaultCephDeviceClass holds the default ceph device
+                  class to be used for the pools
+                type: string
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -6833,6 +6833,10 @@ spec:
                 description: CurrentMonCount holds the value of ceph mons configured
                   in ceph cluster.
                 type: integer
+              defaultCephDeviceClass:
+                description: DefaultCephDeviceClass holds the default ceph device
+                  class to be used for the pools
+                type: string
               externalSecretHash:
                 description: ExternalSecretHash holds the checksum value of external
                   secret data.

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -534,6 +534,9 @@ type StorageClusterStatus struct {
 	// Images holds the image reconcile status for all images reconciled by the operator
 	Images ImagesStatus `json:"images,omitempty"`
 
+	// DefaultCephDeviceClass holds the default ceph device class to be used for the pools
+	DefaultCephDeviceClass string `json:"defaultCephDeviceClass,omitempty"`
+
 	// KMSServerConnection holds the connection state to the KMS server.
 	KMSServerConnection KMSServerConnectionStatus `json:"kmsServerConnection,omitempty"`
 


### PR DESCRIPTION
This is a manual backport of https://github.com/red-hat-storage/ocs-operator/pull/2615

BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2274175

Set the deviceClasses of the pools to avoid wrong data placement

Earlier when replica-1 was getting enabled on an existing cluster the pool was setting it's deviceClass to replicated but there were no osds with this deviceClass as osd's during normal creation were given SSD deviceClass if blank, and now they can't change. To avoid & solve this problem we have to intelligently set the deviceClass for the pools, Depending on whether replica-1 is enabled & the number of deviceClasses found in the cephCluster CR status.

To do this we added a DefaultCephDeviceClass field in StorageCluster Status which will hold the default ceph device class to be used for the pools. Depending on whether replica-1 is enabled & the number of deviceClasses found in the status this value is determined and set in the status.