### PR TITLE
Adding storage quota field to spec of storage consumer

### DIFF
--- a/api/v1alpha1/storageconsumer_types.go
+++ b/api/v1alpha1/storageconsumer_types.go
@@ -40,6 +40,9 @@ const (
 type StorageConsumerSpec struct {
 	// Enable flag ignores a reconcile if set to false
 	Enable bool `json:"enable,omitempty"`
+	// StorageQuotaInGiB describes quota for the consumer
+	// +optional
+	StorageQuotaInGiB int `json:"storageQuotaInGiB,omitempty"`
 }
 
 // CephResourcesSpec hold details of created ceph resources required for external storage

--- a/config/crd/bases/ocs.openshift.io_storageconsumers.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageconsumers.yaml
@@ -38,6 +38,9 @@ spec:
               enable:
                 description: Enable flag ignores a reconcile if set to false
                 type: boolean
+              storageQuotaInGiB:
+                description: StorageQuotaInGiB describes quota for the consumer
+                type: integer
             type: object
           status:
             description: StorageConsumerStatus defines the observed state of StorageConsumer

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageconsumers.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageconsumers.yaml
@@ -38,6 +38,9 @@ spec:
               enable:
                 description: Enable flag ignores a reconcile if set to false
                 type: boolean
+              storageQuotaInGiB:
+                description: StorageQuotaInGiB describes quota for the consumer
+                type: integer
             type: object
           status:
             description: StorageConsumerStatus defines the observed state of StorageConsumer

--- a/deploy/ocs-operator/manifests/storageconsumer.crd.yaml
+++ b/deploy/ocs-operator/manifests/storageconsumer.crd.yaml
@@ -37,6 +37,9 @@ spec:
               enable:
                 description: Enable flag ignores a reconcile if set to false
                 type: boolean
+              storageQuotaInGiB:
+                description: StorageQuotaInGiB describes quota for the consumer
+                type: integer
             type: object
           status:
             description: StorageConsumerStatus defines the observed state of StorageConsumer

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
@@ -40,6 +40,9 @@ const (
 type StorageConsumerSpec struct {
 	// Enable flag ignores a reconcile if set to false
 	Enable bool `json:"enable,omitempty"`
+	// StorageQuotaInGiB describes quota for the consumer
+	// +optional
+	StorageQuotaInGiB int `json:"storageQuotaInGiB,omitempty"`
 }
 
 // CephResourcesSpec hold details of created ceph resources required for external storage

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
@@ -40,6 +40,9 @@ const (
 type StorageConsumerSpec struct {
 	// Enable flag ignores a reconcile if set to false
 	Enable bool `json:"enable,omitempty"`
+	// StorageQuotaInGiB describes quota for the consumer
+	// +optional
+	StorageQuotaInGiB int `json:"storageQuotaInGiB,omitempty"`
 }
 
 // CephResourcesSpec hold details of created ceph resources required for external storage


### PR DESCRIPTION
- Adding spec field to storage consumer CR
- Making it optional because for the consumer whos is having unlimited quota this field will not be set