### PR TITLE
changes to onboarding token api to include role in body

### DIFF
--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -6,6 +6,7 @@ import (
 	ocsclientv1a1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -31,7 +32,7 @@ func (s *storageClient) ensureCreated(r *StorageClusterReconciler, storagecluste
 	storageClient.Name = storagecluster.Name
 	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, storageClient, func() error {
 		if storageClient.Status.ConsumerID == "" {
-			token, err := util.GenerateOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, nil)
+			token, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, nil)
 			if err != nil {
 				return fmt.Errorf("unable to generate onboarding token: %v", err)
 			}

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -116,7 +116,13 @@ func (s *OCSProviderServer) OnboardConsumer(ctx context.Context, req *pb.Onboard
 		return nil, status.Errorf(codes.InvalidArgument, "onboarding ticket is not valid. %v", err)
 	}
 
-	storageConsumerUUID, err := s.consumerManager.Create(ctx, req, int(onboardingTicket.StorageQuotaInGiB))
+	if onboardingTicket.SubjectRole != services.ClientRole {
+		err := fmt.Errorf("unsupported ticket role for consumer %q, found %s, expected %s", req.ConsumerName, onboardingTicket.SubjectRole, services.ClientRole)
+		klog.Error(err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	storageConsumerUUID, err := s.consumerManager.Create(ctx, req, int(*onboardingTicket.StorageQuotaInGiB))
 	if err != nil {
 		if !kerrors.IsAlreadyExists(err) && err != errTicketAlreadyExists {
 			return nil, status.Errorf(codes.Internal, "failed to create storageConsumer %q. %v", req.ConsumerName, err)
@@ -487,8 +493,17 @@ func decodeAndValidateTicket(ticket string, pubKey *rsa.PublicKey) (*services.On
 		return nil, fmt.Errorf("failed to unmarshal onboarding ticket message. %v", err)
 	}
 
-	if ticketData.StorageQuotaInGiB > math.MaxInt {
-		return nil, fmt.Errorf("invalid value sent in onboarding ticket, storage quota should be greater than 0 and less than %v: %v", math.MaxInt, ticketData.StorageQuotaInGiB)
+	switch ticketData.SubjectRole {
+	case services.ClientRole:
+		if ticketData.StorageQuotaInGiB != nil {
+			quota := *ticketData.StorageQuotaInGiB
+			if quota > math.MaxInt {
+				return nil, fmt.Errorf("invalid value sent in onboarding ticket, storage quota should be greater than 0 and less than %v: %v", math.MaxInt, quota)
+			}
+		}
+	case services.PeerRole:
+	default:
+		return nil, fmt.Errorf("invalid onboarding ticket subject role")
 	}
 
 	signature, err := base64.StdEncoding.DecodeString(ticketArr[1])

--- a/services/types.go
+++ b/services/types.go
@@ -1,7 +1,15 @@
 package services
 
+type OnboardingSubjectRole string
+
+const (
+	ClientRole OnboardingSubjectRole = "ocs-client"
+	PeerRole   OnboardingSubjectRole = "ocs-peer"
+)
+
 type OnboardingTicket struct {
-	ID                string `json:"id"`
-	ExpirationDate    int64  `json:"expirationDate,string"`
-	StorageQuotaInGiB uint   `json:"storageQuotaInGiB,omitempty"`
+	ID                string                `json:"id"`
+	ExpirationDate    int64                 `json:"expirationDate,string"`
+	SubjectRole       OnboardingSubjectRole `json:"subjectRole"`
+	StorageQuotaInGiB *uint                 `json:"storageQuotaInGiB,omitempty"`
 }

--- a/services/ux-backend/handlers/onboarding/clienttokens/handler.go
+++ b/services/ux-backend/handlers/onboarding/clienttokens/handler.go
@@ -1,4 +1,4 @@
-package onboardingtokens
+package clienttokens
 
 import (
 	"encoding/json"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
@@ -57,8 +58,9 @@ func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int
 		}
 		storageQuotaInGiB = ptr.To(unitAsGiB * quota.Value)
 	}
-	if onboardingToken, err := util.GenerateOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, storageQuotaInGiB); err != nil {
-		klog.Errorf("failed to get onboardig token: %v", err)
+
+	if onboardingToken, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, storageQuotaInGiB); err != nil {
+		klog.Errorf("failed to get onboarding token: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
 
@@ -74,10 +76,11 @@ func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int
 			klog.Errorf("failed write data to response writer: %v", err)
 		}
 	}
+
 }
 
 func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
-	klog.Info("Only POST method should be used to send data to this endpoint /onboarding-tokens")
+	klog.Infof("Only POST method should be used to send data to this endpoint %s", r.URL.Path)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
 	w.Header().Set("Allow", "POST")

--- a/services/ux-backend/handlers/onboarding/peertokens/handler.go
+++ b/services/ux-backend/handlers/onboarding/peertokens/handler.go
@@ -1,0 +1,55 @@
+package peertokens
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	onboardingPrivateKeyFilePath = "/etc/private-key/key"
+)
+
+func HandleMessage(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int) {
+	switch r.Method {
+	case "POST":
+		handlePost(w, r, tokenLifetimeInHours)
+	default:
+		handleUnsupportedMethod(w, r)
+	}
+}
+
+func handlePost(w http.ResponseWriter, _ *http.Request, tokenLifetimeInHours int) {
+	if onboardingToken, err := util.GeneratePeerOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath); err != nil {
+		klog.Errorf("failed to get onboarding token: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+
+		if _, err := w.Write([]byte("Failed to generate token")); err != nil {
+			klog.Errorf("failed write data to response writer, %v", err)
+		}
+	} else {
+		klog.Info("onboarding token generated successfully")
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+
+		if _, err = w.Write([]byte(onboardingToken)); err != nil {
+			klog.Errorf("failed write data to response writer: %v", err)
+		}
+	}
+}
+
+func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
+	klog.Infof("Only POST method should be used to send data to this endpoint %s", r.URL.Path)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	w.Header().Set("Allow", "POST")
+
+	if _, err := w.Write([]byte(fmt.Sprintf("Unsupported method : %s", r.Method))); err != nil {
+		klog.Errorf("failed write data to response writer: %v", err)
+	}
+}


### PR DESCRIPTION
Update the onboarding Ticket to include an OnboardingSubjectRole - ocs-client, ocs-peer
1. ocs-client will be used to onboard a Client
2. ocs-peer role will be used to onboard a StorageCluster

Add a new endpoint to generate the peer onboarding token.

Part of [RHSTOR-4886](https://issues.redhat.com/browse/RHSTOR-4886)