### PR TITLE
storagecluster: rewrite cephblockpool reconcilation

### DIFF
--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -1,15 +1,16 @@
 package storagecluster
 
 import (
-	"context"
 	"fmt"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -17,17 +18,17 @@ import (
 type ocsCephBlockPools struct{}
 
 // ensures that peer cluster secret exists and adds it to CephBlockPool
-func (r *StorageClusterReconciler) addPeerSecretsToCephBlockPool(initData *ocsv1.StorageCluster, poolName string, poolNamespace string) cephv1.MirroringPeerSpec {
-	mirroringPeerSpec := cephv1.MirroringPeerSpec{}
+func (o *ocsCephBlockPools) addPeerSecretsToCephBlockPool(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster, poolName, poolNamespace string) *cephv1.MirroringPeerSpec {
+	mirroringPeerSpec := &cephv1.MirroringPeerSpec{}
 	secretNames := []string{}
 
-	if len(initData.Spec.Mirroring.PeerSecretNames) == 0 {
+	if len(storageCluster.Spec.Mirroring.PeerSecretNames) == 0 {
 		err := fmt.Errorf("mirroring is enabled but peerSecretNames is not provided")
 		r.Log.Error(err, "Unable to add cluster peer token to CephBlockPool.", "CephBlockPool", klog.KRef(poolNamespace, poolName))
 		return mirroringPeerSpec
 	}
-	for _, secretName := range initData.Spec.Mirroring.PeerSecretNames {
-		_, err := r.retrieveSecret(secretName, initData)
+	for _, secretName := range storageCluster.Spec.Mirroring.PeerSecretNames {
+		_, err := r.retrieveSecret(secretName, storageCluster)
 		if err != nil {
 			r.Log.Error(err, "Peer cluster token could not be retrieved using secretname.", "CephBlockPool", klog.KRef(poolNamespace, poolName))
 			return mirroringPeerSpec
@@ -39,199 +40,276 @@ func (r *StorageClusterReconciler) addPeerSecretsToCephBlockPool(initData *ocsv1
 	return mirroringPeerSpec
 }
 
-// newCephBlockPoolInstances returns the cephBlockPool instances that should be created
-// on first run.
-func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.StorageCluster) ([]*cephv1.CephBlockPool, error) {
-	var mirroringSpec cephv1.MirroringSpec
-	poolName := generateNameForCephBlockPool(initData)
-	// This name is used by UI to hide this pool from the list of CephBlockPools
-	builtinMgrPoolName := "builtin-mgr"
-	poolNamespace := initData.Namespace
-
-	if initData.Spec.Mirroring.Enabled {
-		mirroringSpec.Enabled = true
-		mirroringSpec.Mode = "image"
-		mirroringPeerSpec := r.addPeerSecretsToCephBlockPool(initData, poolName, poolNamespace)
-		mirroringSpec.Peers = &mirroringPeerSpec
+func (o *ocsCephBlockPools) deleteCephBlockPool(r *StorageClusterReconciler, cephBlockPool *cephv1.CephBlockPool) (reconcile.Result, error) {
+	// if deletion timestamp is set, wait till block pool is deleted
+	if cephBlockPool.DeletionTimestamp != nil {
+		r.Log.Info("Uninstall: Waiting for CephBlockPool to be deleted.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+		return reconcile.Result{}, fmt.Errorf("uninstall: Waiting for CephBlockPool %v to be deleted", cephBlockPool.Name)
 	}
 
-	ret := []*cephv1.CephBlockPool{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      poolName,
-				Namespace: poolNamespace,
-			},
-			Spec: cephv1.NamedBlockPoolSpec{
-				PoolSpec: cephv1.PoolSpec{
-					DeviceClass:    initData.Status.DefaultCephDeviceClass,
-					FailureDomain:  getFailureDomain(initData),
-					Replicated:     generateCephReplicatedSpec(initData, "data"),
-					EnableRBDStats: true,
-					Mirroring:      mirroringSpec,
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      builtinMgrPoolName,
-				Namespace: poolNamespace,
-			},
-			Spec: cephv1.NamedBlockPoolSpec{
-				Name: ".mgr",
-				PoolSpec: cephv1.PoolSpec{
-					DeviceClass:   initData.Status.DefaultCephDeviceClass,
-					FailureDomain: getFailureDomain(initData),
-					Replicated:    generateCephReplicatedSpec(initData, "metadata"),
-				},
-			},
-		},
+	// delete
+	r.Log.Info("Uninstall: Deleting CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+	if err := r.Client.Delete(r.ctx, cephBlockPool); err != nil {
+		r.Log.Error(err, "Uninstall: Failed to delete CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+		return reconcile.Result{}, fmt.Errorf("uninstall: Failed to delete CephBlockPool %v: %v", cephBlockPool.Name, err)
 	}
-
-	// Create Non-Resilient CephBlockPools if enabled
-	if initData.Spec.ManagedResources.CephNonResilientPools.Enable {
-		for _, failureDomainValue := range initData.Status.FailureDomainValues {
-			ret = append(ret,
-				&cephv1.CephBlockPool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      generateNameForNonResilientCephBlockPool(initData, failureDomainValue),
-						Namespace: initData.Namespace,
-					},
-					Spec: cephv1.NamedBlockPoolSpec{
-						PoolSpec: cephv1.PoolSpec{
-							DeviceClass:   failureDomainValue,
-							FailureDomain: getFailureDomain(initData),
-							Parameters: map[string]string{
-								"pg_num":  "16",
-								"pgp_num": "16",
-							},
-							Replicated: cephv1.ReplicatedSpec{
-								Size:                   1,
-								RequireSafeReplicaSize: false,
-							},
-							EnableRBDStats: true,
-							Mirroring:      mirroringSpec,
-						},
-					},
-				},
-			)
-		}
-
-	}
-
-	// create `.nfs` cephblockpool if NFS is enabled.
-	if initData.Spec.NFS != nil && initData.Spec.NFS.Enable {
-		ret = append(ret,
-			&cephv1.CephBlockPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      generateNameForCephNFSBlockPool(initData),
-					Namespace: initData.Namespace,
-				},
-				Spec: cephv1.NamedBlockPoolSpec{
-					Name: ".nfs",
-					PoolSpec: cephv1.PoolSpec{
-						DeviceClass:    initData.Status.DefaultCephDeviceClass,
-						FailureDomain:  getFailureDomain(initData),
-						Replicated:     generateCephReplicatedSpec(initData, "data"),
-						EnableRBDStats: true,
-					},
-				},
-			},
-		)
-	}
-
-	for _, obj := range ret {
-		err := controllerutil.SetControllerReference(initData, obj, r.Scheme)
-		if err != nil {
-			r.Log.Error(err, "Unable to set controller reference for CephBlockPool.", "CephBlockPool", klog.KRef(obj.Namespace, obj.Name))
-			return nil, err
-		}
-	}
-	return ret, nil
+	// Requeue as we need to wait till cephBlockPool is deleted
+	return reconcile.Result{Requeue: true}, nil
 }
 
-// ensureCreated ensures that cephBlockPool resources exist in the desired
-// state.
-func (obj *ocsCephBlockPools) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
-	reconcileStrategy := ReconcileStrategy(instance.Spec.ManagedResources.CephBlockPools.ReconcileStrategy)
+func (o *ocsCephBlockPools) reconcileCephBlockPool(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (reconcile.Result, error) {
+
+	cephBlockPool := &cephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephBlockPool(storageCluster),
+			Namespace: storageCluster.Namespace,
+		},
+	}
+
+	// Get to see if it already exists
+	err := r.Client.Get(r.ctx, client.ObjectKeyFromObject(cephBlockPool), cephBlockPool)
+	if client.IgnoreNotFound(err) != nil {
+		return reconcile.Result{}, err
+	}
+
+	// storageCluster is marked for deletion - delete the block pool
+	if storageCluster.GetDeletionTimestamp() != nil {
+		// if found, delete the block pool
+		if !errors.IsNotFound(err) {
+			return o.deleteCephBlockPool(r, cephBlockPool)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	// If found and reconcileStrategy is init we skip
+	if !errors.IsNotFound(err) && ReconcileStrategy(storageCluster.Spec.ManagedResources.CephBlockPools.ReconcileStrategy) == ReconcileStrategyInit {
+		return reconcile.Result{}, nil
+	}
+
+	_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
+		cephBlockPool.Spec.PoolSpec.DeviceClass = storageCluster.Status.DefaultCephDeviceClass
+		cephBlockPool.Spec.PoolSpec.FailureDomain = getFailureDomain(storageCluster)
+		cephBlockPool.Spec.PoolSpec.Replicated = generateCephReplicatedSpec(storageCluster, "data")
+		cephBlockPool.Spec.PoolSpec.EnableRBDStats = true
+
+		if storageCluster.Spec.Mirroring.Enabled {
+			cephBlockPool.Spec.PoolSpec.Mirroring.Enabled = true
+			cephBlockPool.Spec.PoolSpec.Mirroring.Mode = "image"
+			cephBlockPool.Spec.PoolSpec.Mirroring.Peers = o.addPeerSecretsToCephBlockPool(r, storageCluster, cephBlockPool.Name, cephBlockPool.Namespace)
+		}
+		return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)
+	})
+	if err != nil {
+		r.Log.Error(err, "Failed to create/update CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (o *ocsCephBlockPools) reconcileMgrCephBlockPool(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (reconcile.Result, error) {
+
+	// This name is used by UI to hide this pool from the list of CephBlockPools
+	builtinMgrPoolName := "builtin-mgr"
+
+	cephBlockPool := &cephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      builtinMgrPoolName,
+			Namespace: storageCluster.Namespace,
+		},
+	}
+
+	// Get to see if it already exists
+	err := r.Client.Get(r.ctx, client.ObjectKeyFromObject(cephBlockPool), cephBlockPool)
+	if client.IgnoreNotFound(err) != nil {
+		return reconcile.Result{}, err
+	}
+
+	// storageCluster is marked for deletion - delete the block pool
+	if storageCluster.GetDeletionTimestamp() != nil {
+		// if found, delete the block pool
+		if !errors.IsNotFound(err) {
+			return o.deleteCephBlockPool(r, cephBlockPool)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	// If found and reconcileStrategy is init we skip
+	if !errors.IsNotFound(err) && ReconcileStrategy(storageCluster.Spec.ManagedResources.CephBlockPools.ReconcileStrategy) == ReconcileStrategyInit {
+		return reconcile.Result{}, nil
+	}
+
+	_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
+		cephBlockPool.Spec.Name = ".mgr"
+		cephBlockPool.Spec.PoolSpec.DeviceClass = storageCluster.Status.DefaultCephDeviceClass
+		cephBlockPool.Spec.PoolSpec.FailureDomain = getFailureDomain(storageCluster)
+		cephBlockPool.Spec.PoolSpec.Replicated = generateCephReplicatedSpec(storageCluster, "metadata")
+
+		return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)
+	})
+	if err != nil {
+		r.Log.Error(err, "Failed to create/update CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (o *ocsCephBlockPools) reconcileNFSCephBlockPool(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (reconcile.Result, error) {
+
+	if storageCluster.Spec.NFS == nil || !storageCluster.Spec.NFS.Enable {
+		return reconcile.Result{}, nil
+	}
+
+	cephBlockPool := &cephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephNFSBlockPool(storageCluster),
+			Namespace: storageCluster.Namespace,
+		},
+	}
+
+	err := r.Client.Get(r.ctx, client.ObjectKeyFromObject(cephBlockPool), cephBlockPool)
+	if client.IgnoreNotFound(err) != nil {
+		return reconcile.Result{}, err
+	}
+
+	// storageCluster is marked for deletion - delete the block pool
+	if storageCluster.GetDeletionTimestamp() != nil {
+		// if found, delete the block pool
+		if !errors.IsNotFound(err) {
+			return o.deleteCephBlockPool(r, cephBlockPool)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !errors.IsNotFound(err) && ReconcileStrategy(storageCluster.Spec.ManagedResources.CephBlockPools.ReconcileStrategy) == ReconcileStrategyInit {
+		return reconcile.Result{}, nil
+	}
+
+	_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
+		cephBlockPool.Spec.Name = ".nfs"
+		cephBlockPool.Spec.PoolSpec.DeviceClass = storageCluster.Status.DefaultCephDeviceClass
+		cephBlockPool.Spec.PoolSpec.FailureDomain = getFailureDomain(storageCluster)
+		cephBlockPool.Spec.PoolSpec.Replicated = generateCephReplicatedSpec(storageCluster, "data")
+		cephBlockPool.Spec.PoolSpec.EnableRBDStats = true
+		return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)
+	})
+	if err != nil {
+		r.Log.Error(err, "Failed to create/update CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (o *ocsCephBlockPools) reconcileNonResilientCephBlockPool(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (reconcile.Result, error) {
+
+	if !storageCluster.Spec.ManagedResources.CephNonResilientPools.Enable {
+		return reconcile.Result{}, nil
+	}
+
+	for _, failureDomainValue := range storageCluster.Status.FailureDomainValues {
+
+		cephBlockPool := &cephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      generateNameForNonResilientCephBlockPool(storageCluster, failureDomainValue),
+				Namespace: storageCluster.Namespace,
+			},
+		}
+
+		err := r.Client.Get(r.ctx, client.ObjectKeyFromObject(cephBlockPool), cephBlockPool)
+		if client.IgnoreNotFound(err) != nil {
+			return reconcile.Result{}, err
+		}
+
+		// storageCluster is marked for deletion - delete the block pool
+		if storageCluster.GetDeletionTimestamp() != nil {
+			// if found, delete the block pool
+			if !errors.IsNotFound(err) {
+				return o.deleteCephBlockPool(r, cephBlockPool)
+			}
+			return reconcile.Result{}, nil
+		}
+
+		if !errors.IsNotFound(err) && ReconcileStrategy(storageCluster.Spec.ManagedResources.CephBlockPools.ReconcileStrategy) == ReconcileStrategyInit {
+			return reconcile.Result{}, nil
+		}
+
+		_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
+			cephBlockPool.Spec.PoolSpec.DeviceClass = failureDomainValue
+			cephBlockPool.Spec.PoolSpec.FailureDomain = getFailureDomain(storageCluster)
+			cephBlockPool.Spec.PoolSpec.Parameters = map[string]string{
+				"pg_num":  "16",
+				"pgp_num": "16",
+			}
+			cephBlockPool.Spec.PoolSpec.Replicated = cephv1.ReplicatedSpec{
+				Size:                   1,
+				RequireSafeReplicaSize: false,
+			}
+			cephBlockPool.Spec.PoolSpec.EnableRBDStats = true
+
+			if storageCluster.Spec.Mirroring.Enabled {
+				cephBlockPool.Spec.PoolSpec.Mirroring.Enabled = true
+				cephBlockPool.Spec.PoolSpec.Mirroring.Mode = "image"
+				cephBlockPool.Spec.PoolSpec.Mirroring.Peers = o.addPeerSecretsToCephBlockPool(r, storageCluster, cephBlockPool.Name, cephBlockPool.Namespace)
+			}
+			return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)
+		})
+		if err != nil {
+			r.Log.Error(err, "Failed to create/update CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+// ensureCreated ensures that cephBlockPool resources exist in the desired state.
+func (o *ocsCephBlockPools) ensureCreated(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (reconcile.Result, error) {
+	reconcileStrategy := ReconcileStrategy(storageCluster.Spec.ManagedResources.CephBlockPools.ReconcileStrategy)
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return reconcile.Result{}, nil
 	}
-	cephBlockPools, err := r.newCephBlockPoolInstances(instance)
-	if err != nil {
-		return reconcile.Result{}, err
+
+	//Create cephBlockPool one by one
+	if res, err := o.reconcileCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
 	}
-	for _, cephBlockPool := range cephBlockPools {
-		existing := cephv1.CephBlockPool{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: cephBlockPool.Name, Namespace: cephBlockPool.Namespace}, &existing)
 
-		switch {
-		case err == nil:
-			if reconcileStrategy == ReconcileStrategyInit {
-				return reconcile.Result{}, nil
-			}
-			if existing.DeletionTimestamp != nil {
-				r.Log.Info("Unable to restore CephBlockPool because it is marked for deletion.", "CephBlockPool", klog.KRef(existing.Namespace, existing.Name))
-				return reconcile.Result{}, fmt.Errorf("failed to restore initialization object %s because it is marked for deletion", existing.Name)
-			}
+	if res, err := o.reconcileMgrCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
+	}
 
-			r.Log.Info("Restoring original CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-			existing.ObjectMeta.OwnerReferences = cephBlockPool.ObjectMeta.OwnerReferences
-			existing.Spec = cephBlockPool.Spec
-			err = r.Client.Update(context.TODO(), &existing)
-			if err != nil {
-				r.Log.Error(err, "Failed to update CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-				return reconcile.Result{}, err
-			}
-		case errors.IsNotFound(err):
-			r.Log.Info("Creating CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-			err = r.Client.Create(context.TODO(), cephBlockPool)
-			if err != nil {
-				r.Log.Error(err, "Failed to create CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-				return reconcile.Result{}, err
-			}
-		}
+	if res, err := o.reconcileNonResilientCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	if res, err := o.reconcileNFSCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
 	}
 
 	return reconcile.Result{}, nil
 }
 
 // ensureDeleted deletes the CephBlockPools owned by the StorageCluster
-func (obj *ocsCephBlockPools) ensureDeleted(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
-	foundCephBlockPool := &cephv1.CephBlockPool{}
-	cephBlockPools, err := r.newCephBlockPoolInstances(sc)
-	if err != nil {
-		return reconcile.Result{}, err
+func (o *ocsCephBlockPools) ensureDeleted(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (reconcile.Result, error) {
+	reconcileStrategy := ReconcileStrategy(storageCluster.Spec.ManagedResources.CephBlockPools.ReconcileStrategy)
+	if reconcileStrategy == ReconcileStrategyIgnore {
+		return reconcile.Result{}, nil
 	}
 
-	for _, cephBlockPool := range cephBlockPools {
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: cephBlockPool.Name, Namespace: sc.Namespace}, foundCephBlockPool)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				r.Log.Info("Uninstall: CephBlockPool not found.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-				continue
-			}
-			return reconcile.Result{}, fmt.Errorf("uninstall: unable to retrieve CephBlockPool %v: %v", cephBlockPool.Name, err)
-		}
-
-		if cephBlockPool.GetDeletionTimestamp().IsZero() {
-			r.Log.Info("Uninstall: Deleting CephBlockPool.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-			err = r.Client.Delete(context.TODO(), foundCephBlockPool)
-			if err != nil {
-				r.Log.Error(err, "Uninstall: Failed to delete CephBlockPool.", "CephBlockPool", klog.KRef(foundCephBlockPool.Namespace, foundCephBlockPool.Name))
-				return reconcile.Result{}, fmt.Errorf("uninstall: Failed to delete CephBlockPool %v: %v", foundCephBlockPool.Name, err)
-			}
-		}
-
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: cephBlockPool.Name, Namespace: sc.Namespace}, foundCephBlockPool)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				r.Log.Info("Uninstall: CephBlockPool is deleted.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-				continue
-			}
-		}
-		r.Log.Error(err, "Uninstall: Waiting for CephBlockPool to be deleted.", "CephBlockPool", klog.KRef(cephBlockPool.Namespace, cephBlockPool.Name))
-		return reconcile.Result{}, fmt.Errorf("uninstall: Waiting for CephBlockPool %v to be deleted", cephBlockPool.Name)
-
+	//Create cephBlockPool one by one
+	if res, err := o.reconcileCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
 	}
+
+	if res, err := o.reconcileMgrCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	if res, err := o.reconcileNonResilientCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	if res, err := o.reconcileNFSCephBlockPool(r, storageCluster); err != nil || !res.IsZero() {
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
 }

--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -139,23 +139,41 @@ func assertCephBlockPools(t *testing.T, reconciler StorageClusterReconciler, cr 
 	request.Name = "ocsinit-cephblockpool"
 	err := reconciler.Client.Get(context.TODO(), request.NamespacedName, actualCbp)
 	assert.NoError(t, err)
+
+	expectedCbp := cephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephBlockPool(cr),
+			Namespace: cr.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID: cr.UID,
+				},
+			},
+		},
+		Spec: cephv1.NamedBlockPoolSpec{
+			PoolSpec: cephv1.PoolSpec{
+				DeviceClass:    cr.Status.DefaultCephDeviceClass,
+				FailureDomain:  getFailureDomain(cr),
+				Replicated:     generateCephReplicatedSpec(cr, "data"),
+				EnableRBDStats: true,
+			},
+		},
+	}
+
 	if mirroringEnabled {
-		assert.Equal(t, true, actualCbp.Spec.Mirroring.Enabled)
-		assert.Equal(t, "image", actualCbp.Spec.Mirroring.Mode)
+		expectedCbp.Spec.Mirroring.Enabled = true
+		expectedCbp.Spec.Mirroring.Mode = "image"
 		expectedSecretNames := []string(nil)
 		if validSecret {
 			expectedSecretNames = []string{testPeerSecretName}
 		}
-		assert.Equal(t, expectedSecretNames, actualCbp.Spec.Mirroring.Peers.SecretNames)
+		expectedCbp.Spec.Mirroring.Peers = &cephv1.MirroringPeerSpec{SecretNames: expectedSecretNames}
 	}
 
-	expectedCbp, err := reconciler.newCephBlockPoolInstances(cr)
-	assert.NoError(t, err)
+	assert.Equal(t, len(expectedCbp.OwnerReferences), 1)
 
-	assert.Equal(t, len(expectedCbp[0].OwnerReferences), 1)
-
-	assert.Equal(t, expectedCbp[0].ObjectMeta.Name, actualCbp.ObjectMeta.Name)
-	assert.Equal(t, expectedCbp[0].Spec, actualCbp.Spec)
+	assert.Equal(t, expectedCbp.ObjectMeta.Name, actualCbp.ObjectMeta.Name)
+	assert.Equal(t, expectedCbp.Spec, actualCbp.Spec)
 }
 
 func assertCephNFSBlockPool(t *testing.T, reconciler StorageClusterReconciler, cr *api.StorageCluster, request reconcile.Request) {
@@ -168,11 +186,28 @@ func assertCephNFSBlockPool(t *testing.T, reconciler StorageClusterReconciler, c
 	err := reconciler.Client.Get(context.TODO(), request.NamespacedName, actualNFSBlockPool)
 	assert.NoError(t, err)
 
-	expectedAf, err := reconciler.newCephBlockPoolInstances(cr)
-	assert.NoError(t, err)
+	expectedCbp := cephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephNFSBlockPool(cr),
+			Namespace: cr.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID: cr.UID,
+				},
+			},
+		},
+		Spec: cephv1.NamedBlockPoolSpec{
+			PoolSpec: cephv1.PoolSpec{
+				DeviceClass:    cr.Status.DefaultCephDeviceClass,
+				FailureDomain:  getFailureDomain(cr),
+				Replicated:     generateCephReplicatedSpec(cr, "data"),
+				EnableRBDStats: true,
+			},
+			Name: ".nfs",
+		},
+	}
 
-	assert.Equal(t, len(expectedAf[2].OwnerReferences), 1)
-
-	assert.Equal(t, expectedAf[2].ObjectMeta.Name, actualNFSBlockPool.ObjectMeta.Name)
-	assert.Equal(t, expectedAf[2].Spec, actualNFSBlockPool.Spec)
+	assert.Equal(t, len(expectedCbp.OwnerReferences), 1)
+	assert.Equal(t, expectedCbp.ObjectMeta.Name, actualNFSBlockPool.ObjectMeta.Name)
+	assert.Equal(t, expectedCbp.Spec, actualNFSBlockPool.Spec)
 }


### PR DESCRIPTION
The current implementation assumes only a single entity can touch the CR. Hence modifying the implementation such that the controller owns the specific fields and other entities are allowed to modify other fields of the cephblockpool CR.

Part of [RHSTOR-4886](https://issues.redhat.com/browse/RHSTOR-4886)