### PR TITLE
Added support for ocs provider server to fetch noobaa client resources

### DIFF
--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -61,3 +61,19 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - noobaa.io
+  resources:
+  - noobaaaccounts
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -61,3 +61,19 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - noobaa.io
+  resources:
+  - noobaaaccounts
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list

--- a/services/provider/server/consumer.go
+++ b/services/provider/server/consumer.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	ifaces "github.com/red-hat-storage/ocs-operator/v4/services/provider/interfaces"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -224,5 +227,49 @@ func (c *ocsConsumerManager) UpdateConsumerStatus(ctx context.Context, id string
 		return fmt.Errorf("Failed to patch Status for StorageConsumer %v: %v", consumerObj.Name, err)
 	}
 	klog.Infof("successfully updated Status for StorageConsumer %v", consumerObj.Name)
+	return nil
+}
+
+func (c *ocsConsumerManager) CreateNoobaaAccount(ctx context.Context, id string) error {
+
+	consumerObj, err := c.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	consumerClusterID := strings.TrimPrefix(consumerObj.Name, "storageconsumer-")
+	if consumerClusterID != "" && len(consumerClusterID) == 0 {
+		return fmt.Errorf("failed to get clusterID from consumerResource Name: %s %v", consumerObj.Name, err)
+	}
+
+	noobaaAccountName := fmt.Sprintf("noobaa-remote-%s", consumerClusterID)
+	nbAccountObj := &nbv1.NooBaaAccount{}
+	nbAccountObj.Name = noobaaAccountName
+	nbAccountObj.Namespace = consumerObj.Namespace
+	// the following annotation will enable noobaa-operator to create a auth_token secret based on this account
+	util.AddAnnotation(nbAccountObj, "remote-operator", "true")
+
+	err = c.client.Create(ctx, nbAccountObj)
+	if err != nil {
+		return fmt.Errorf("failed to create noobaa account for storageConsumer %v: %v", consumerObj.Name, err)
+	}
+	return nil
+}
+
+func (c *ocsConsumerManager) DeleteNoobaaAccount(ctx context.Context, id string) error {
+	consumerObj, err := c.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	clusterID := strings.TrimPrefix(consumerObj.Name, "storageconsumer-")
+	if clusterID != "" && len(clusterID) == 0 {
+		return fmt.Errorf("failed to get clusterID from consumerResource Name: %s %v", consumerObj.Name, err)
+	}
+	noobaaAccountName := fmt.Sprintf("noobaa-remote-%s", clusterID)
+	nbAccountObj := &nbv1.NooBaaAccount{}
+	nbAccountObj.Name = noobaaAccountName
+	nbAccountObj.Namespace = consumerObj.Namespace
+	if err := c.client.Delete(ctx, nbAccountObj); err != nil {
+		return fmt.Errorf("failed to delete Noobaa account %q. %v", nbAccountObj.Name, err)
+	}
 	return nil
 }

--- a/services/provider/server/consumer_test.go
+++ b/services/provider/server/consumer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	routev1 "github.com/openshift/api/route/v1"
 	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	providerClient "github.com/red-hat-storage/ocs-operator/v4/services/provider/client"
@@ -12,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -63,6 +63,8 @@ func newFakeClient(t *testing.T, obj ...client.Object) client.Client {
 	err = rookCephv1.AddToScheme(scheme)
 	assert.NoError(t, err, "failed to add rookCephv1 scheme")
 
+	err = routev1.AddToScheme(scheme)
+	assert.NoError(t, err, "failed to add routev1 scheme")
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(obj...).

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 	"testing"
 
+	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	quotav1 "github.com/openshift/api/quota/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	controllers "github.com/red-hat-storage/ocs-operator/v4/controllers/storageconsumer"
 	pb "github.com/red-hat-storage/ocs-operator/v4/services/provider/pb"
@@ -24,9 +26,9 @@ import (
 )
 
 type externalResource struct {
-	Kind string            `json:"kind"`
-	Data map[string]string `json:"data"`
-	Name string            `json:"name"`
+	Kind string `json:"kind"`
+	Data []byte `json:"data"`
+	Name string `json:"name"`
 }
 
 var serverNamespace = "openshift-storage"
@@ -48,48 +50,72 @@ var clusterResourceQuotaSpec = &quotav1.ClusterResourceQuotaSpec{
 		)},
 	},
 }
+
+var noobaaSpec = &nbv1.NooBaaSpec{
+	JoinSecret: &v1.SecretReference{
+		Name: "noobaa-remote-join-secret",
+	},
+}
+
+var joinSecret = &v1.Secret{
+	Data: map[string][]byte{
+		"auth_token": []byte("authToken"),
+		"mgmt_addr":  []byte("noobaaMgmtAddress"),
+	},
+}
+
 var mockExtR = map[string]*externalResource{
 	"rook-ceph-mon-endpoints": {
 		Name: "rook-ceph-mon-endpoints",
 		Kind: "ConfigMap",
-		Data: map[string]string{
+		Data: mustMarshal(map[string]string{
 			"data":     "a=10.99.45.27:6789",
 			"maxMonId": "0",
 			"mapping":  "{}",
-		},
+		}),
 	},
 	"rook-ceph-mon": {
 		Name: "rook-ceph-mon",
 		Kind: "Secret",
-		Data: map[string]string{
+		Data: mustMarshal(map[string]string{
 			"ceph-username": "client.995e66248ad3e8642de868f461cdd827",
 			"fsid":          "b88c2d78-9de9-4227-9313-a63f62f78743",
 			"mon-secret":    "mon-secret",
 			"ceph-secret":   "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-		},
+		}),
 	},
 	"monitoring-endpoint": {
 		Name: "monitoring-endpoint",
 		Kind: "CephCluster",
-		Data: map[string]string{
+		Data: mustMarshal(map[string]string{
 			"MonitoringEndpoint": "10.105.164.231",
 			"MonitoringPort":     "9283",
-		},
+		}),
 	},
 	"rook-ceph-client-995e66248ad3e8642de868f461cdd827": {
 		Name: "rook-ceph-client-995e66248ad3e8642de868f461cdd827",
 		Kind: "Secret",
-		Data: map[string]string{
+		Data: mustMarshal(map[string]string{
 			"userID":  "995e66248ad3e8642de868f461cdd827",
 			"userKey": "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-		},
+		}),
 	},
 	"QuotaForConsumer": {
 		Name: "QuotaForConsumer",
 		Kind: "ClusterResourceQuota",
-		Data: map[string]string{
+		Data: mustMarshal(map[string]string{
 			"QuotaForConsumer": fmt.Sprintf("%+v\n", clusterResourceQuotaSpec),
-		},
+		}),
+	},
+	"noobaa-remote-join-secret": {
+		Name: "noobaa-remote-join-secret",
+		Kind: "Secret",
+		Data: mustMarshal(joinSecret),
+	},
+	"noobaa-remote": {
+		Name: "noobaa-remote",
+		Kind: "Noobaa",
+		Data: mustMarshal(noobaaSpec),
 	},
 }
 
@@ -250,8 +276,33 @@ func TestGetExternalResources(t *testing.T) {
 		},
 	}
 
+	noobaaRemoteJoinSecretConsumer := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "noobaa-remote-join-secret-consumer", Namespace: server.namespace},
+		Data: map[string][]byte{
+			"auth_token": []byte("authToken"),
+		},
+	}
+
+	noobaaRemoteJoinSecretConsumer6 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "noobaa-remote-join-secret-consumer6", Namespace: server.namespace},
+		Data: map[string][]byte{
+			"auth_token": []byte("authToken"),
+		},
+	}
+
+	noobaaMgmtRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{Name: "noobaa-mgmt", Namespace: server.namespace},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{{Host: "noobaaMgmtAddress"}},
+		},
+	}
+
 	assert.NoError(t, client.Create(ctx, cephClient))
 	assert.NoError(t, client.Create(ctx, secret))
+
+	assert.NoError(t, client.Create(ctx, noobaaRemoteJoinSecretConsumer))
+	assert.NoError(t, client.Create(ctx, noobaaRemoteJoinSecretConsumer6))
+	assert.NoError(t, client.Create(ctx, noobaaMgmtRoute))
 
 	monCm, monSc := createMonConfigMapAndSecret(server)
 	assert.NoError(t, client.Create(ctx, monCm))
@@ -270,9 +321,18 @@ func TestGetExternalResources(t *testing.T) {
 		mockResoruce, ok := mockExtR[extResource.Name]
 		assert.True(t, ok)
 
-		data, err := json.Marshal(mockResoruce.Data)
 		assert.NoError(t, err)
-		assert.Equal(t, string(extResource.Data), string(data))
+		if extResource.Kind == "Noobaa" {
+			var extNoobaaSpec, mockNoobaaSpec nbv1.NooBaaSpec
+			err = json.Unmarshal(extResource.Data, &extNoobaaSpec)
+			assert.NoError(t, err)
+			err = json.Unmarshal(mockResoruce.Data, &mockNoobaaSpec)
+			assert.NoError(t, err)
+
+			assert.Equal(t, mockNoobaaSpec.JoinSecret, extNoobaaSpec.JoinSecret)
+		} else {
+			assert.Equal(t, extResource.Data, mockResoruce.Data)
+		}
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}
@@ -290,7 +350,6 @@ func TestGetExternalResources(t *testing.T) {
 		mockResoruce, ok := mockExtR[extResource.Name]
 		assert.True(t, ok)
 
-		data, err := json.Marshal(mockResoruce.Data)
 		assert.NoError(t, err)
 		if extResource.Kind == "ClusterResourceQuota" {
 			var clusterResourceQuotaSpec quotav1.ClusterResourceQuotaSpec
@@ -298,8 +357,16 @@ func TestGetExternalResources(t *testing.T) {
 			assert.NoError(t, err)
 			quantity, _ := resource.ParseQuantity("10240G")
 			assert.Equal(t, clusterResourceQuotaSpec.Quota.Hard["requests.storage"], quantity)
+		} else if extResource.Kind == "Noobaa" {
+			var extNoobaaSpec, mockNoobaaSpec nbv1.NooBaaSpec
+			err = json.Unmarshal(extResource.Data, &extNoobaaSpec)
+			assert.NoError(t, err)
+			err = json.Unmarshal(mockResoruce.Data, &mockNoobaaSpec)
+			assert.NoError(t, err)
+
+			assert.Equal(t, mockNoobaaSpec.JoinSecret, extNoobaaSpec.JoinSecret)
 		} else {
-			assert.Equal(t, string(extResource.Data), string(data))
+			assert.Equal(t, extResource.Data, mockResoruce.Data)
 		}
 
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
@@ -568,7 +635,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 			"ceph-rbd-storageclass": {
 				Name: "ceph-rbd",
 				Kind: "StorageClass",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"clusterID":                 serverNamespace,
 					"pool":                      "cephblockpool",
 					"radosnamespace":            "cephradosnamespace",
@@ -578,37 +645,37 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 					"csi.storage.k8s.io/provisioner-secret-name":       "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
 					"csi.storage.k8s.io/node-stage-secret-name":        "ceph-client-node-8d40b6be71600457b5dec219d2ce2d4c",
 					"csi.storage.k8s.io/controller-expand-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
-				},
+				}),
 			},
 			"ceph-rbd-volumesnapshotclass": {
 				Name: "ceph-rbd",
 				Kind: "VolumeSnapshotClass",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"csi.storage.k8s.io/snapshotter-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
-				},
+				}),
 			},
 			"ceph-rbd-volumegroupsnapshotclass": {
 				Name: "ceph-rbd",
 				Kind: "VolumeGroupSnapshotClass",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"csi.storage.k8s.io/group-snapshotter-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
-				},
+				}),
 			},
 			"ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c": {
 				Name: "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
 				Kind: "Secret",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"userID":  "3de200d5c23524a4612bde1fdbeb717e",
 					"userKey": "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-				},
+				}),
 			},
 			"ceph-client-node-8d40b6be71600457b5dec219d2ce2d4c": {
 				Name: "ceph-client-node-8d40b6be71600457b5dec219d2ce2d4c",
 				Kind: "Secret",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"userID":  "995e66248ad3e8642de868f461cdd827",
 					"userKey": "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-				},
+				}),
 			},
 		}
 
@@ -616,7 +683,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 			"cephfs-storageclass": {
 				Name: "cephfs",
 				Kind: "StorageClass",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"clusterID":          "8d26c7378c1b0ec9c2455d1c3601c4cd",
 					"fsName":             "myfs",
 					"subvolumegroupname": "cephFilesystemSubVolumeGroup",
@@ -624,46 +691,46 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 					"csi.storage.k8s.io/provisioner-secret-name":       "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
 					"csi.storage.k8s.io/node-stage-secret-name":        "ceph-client-node-0e8555e6556f70d23a61675af44e880c",
 					"csi.storage.k8s.io/controller-expand-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
-				},
+				}),
 			},
 			"cephfs-volumesnapshotclass": {
 				Name: "cephfs",
 				Kind: "VolumeSnapshotClass",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"csi.storage.k8s.io/snapshotter-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
-				},
+				}),
 			},
 
 			"cephfs-volumegroupsnapshotclass": {
 				Name: "cephfs",
 				Kind: "VolumeGroupSnapshotClass",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"csi.storage.k8s.io/group-snapshotter-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
-				},
+				}),
 			},
 			"ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c": {
 				Name: "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
 				Kind: "Secret",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"adminID":  "4ffcb503ff8044c8699dac415f82d604",
 					"adminKey": "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-				},
+				}),
 			},
 			"ceph-client-node-0e8555e6556f70d23a61675af44e880c": {
 				Name: "ceph-client-node-0e8555e6556f70d23a61675af44e880c",
 				Kind: "Secret",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"adminID":  "1b042fcc8812fe4203689eec38fdfbfa",
 					"adminKey": "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-				},
+				}),
 			},
 
 			"cephFilesystemSubVolumeGroup": {
 				Name: "cephFilesystemSubVolumeGroup",
 				Kind: "CephFilesystemSubVolumeGroup",
-				Data: map[string]string{
+				Data: mustMarshal(map[string]string{
 					"filesystemName": "myfs",
-				},
+				}),
 			},
 		}
 
@@ -949,9 +1016,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 		mockResoruce, ok := mockBlockPoolClaimExtR[name]
 		assert.True(t, ok)
 
-		data, err := json.Marshal(mockResoruce.Data)
 		assert.NoError(t, err)
-		assert.Equal(t, string(extResource.Data), string(data))
+		assert.Equal(t, extResource.Data, mockResoruce.Data)
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}
@@ -978,9 +1044,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 		mockResoruce, ok := mockShareFilesystemClaimExtR[name]
 		assert.True(t, ok)
 
-		data, err := json.Marshal(mockResoruce.Data)
 		assert.NoError(t, err)
-		assert.Equal(t, string(extResource.Data), string(data))
+		assert.Equal(t, extResource.Data, mockResoruce.Data)
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}


### PR DESCRIPTION
1. Added an annotation `is-local-client:true` for local storage client
2. Create a Noobaa Account CR for auth_token generation of remote noobaa client
    a.https://github.com/noobaa/noobaa-operator/pull/1389
4. Assemble noobaa remote auth token and management address to be sent via `GetStorageConfig`
5. Updated test cases

Part of : [RHSTOR-5187](https://issues.redhat.com//browse/RHSTOR-5187)