### PR TITLE
Reducing the noobaas resources privilege according to the required verbs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -205,7 +205,12 @@ rules:
   resources:
   - noobaas
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - objectbucket.io
   resources:

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -107,7 +107,7 @@ var validTopologyLabelKeys = []string{
 
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=*
-// +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=*
+// +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=*
 // +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -359,7 +359,12 @@ spec:
           resources:
           - noobaas
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - objectbucket.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -380,7 +380,12 @@ spec:
           resources:
           - noobaas
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - objectbucket.io
           resources:


### PR DESCRIPTION
```

Process:
1.Deploy OCP4.16

2.Install ODF4.16

3.Check clusterrole status:
$ oc get clusterrole ocs-operator.v4.16.0-rho-5RplQlPvR925g4JZ4kfHCVObO1Flr5sTYbYn2P -o yaml
- apiGroups:
  - noobaa.io
  resources:
  - noobaas
  verbs:
  - '*'
4.Add Get verb ocs-operator clusterrole status:
Add [get]
$ oc edit clusterrole ocs-operator.v4.16.0-rho-5RplQlPvR925g4JZ4kfHCVObO1Flr5sTYbYn2P
- apiGroups:
  - noobaa.io
  resources:
  - noobaas
  verbs:
  - get

5.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc get pods | grep ocs-oper
ocs-operator-595c6965f6-wd7dm                                     1/1     Running     11 (99m ago)    17h
$ oc delete pod ocs-operator-595c6965f6-wd7dm
$ oc logs ocs-operator-595c6965f6-wh6fk | grep noobaas
W0710 07:58:33.257978       1 reflector.go:539] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: failed to list *v1alpha1.NooBaa: noobaas.noobaa.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "noobaas" in API group "noobaa.io" in the namespace "openshift-storage-extended"

6.Add list verb ocs-operator clusterrole status:
Add [get,list]
- apiGroups:
  - noobaa.io
  resources:
  - noobaas
  verbs:
  - get
  - list


7.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc logs ocs-operator-595c6965f6-gmql8 | grep noobaa
E0710 08:03:04.226130       1 reflector.go:147] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: Failed to watch *v1alpha1.NooBaa: unknown (get noobaas.noobaa.io)

8.Add watch verb ocs-operator clusterrole status:
Add [get,list,watch]
- apiGroups:
  - noobaa.io
  resources:
  - noobaas
  verbs:
  - get
  - list
  - watch

9.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc logs ocs-operator-595c6965f6-tv2c4 | grep nooba
{"level":"info","ts":"2024-07-10T08:09:47Z","logger":"controllers.OCSInitialization","msg":"Updating SecurityContextConstraint.","Request.Namespace":"openshift-storage","Request.Name":"ocsinit","SecurityContextConstraint":{"name":"noobaa"}}

10.Run Noobaa test from OCS-CI:
https://github.com/red-hat-storage/ocs-ci/blob/master/tests/functional/object/mcg/test_bucket_creation_deletion.py

11.Check ocs operator logs
$ oc logs ocs-operator-595c6965f6-tv2c4 | grep noobaas | grep cannot
{"level":"error","ts":"2024-07-10T08:26:03Z","msg":"Reconciler error","controller":"storagecluster","controllerGroup":"ocs.openshift.io","controllerKind":"StorageCluster","StorageCluster":{"name":"ocs-storagecluster","namespace":"openshift-storage"},"namespace":"openshift-storage","name":"ocs-storagecluster","reconcileID":"e6534501-2485-42c6-a06e-8b064929def3","error":"noobaas.noobaa.io \"noobaa\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot update resource \"noobaas\" in API group \"noobaa.io\" in the namespace \"openshift-storage\"","stacktrace":"[sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler%5Cn%5Ct/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329%5Cnsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem%5Cn%5Ct/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266%5Cnsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2%5Cn%5Ct/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227)"}

12. Add update verb
Add [get,list,watch, update]
$ oc logs ocs-operator-595c6965f6-2nkt7 | grep noobaa
{"level":"info","ts":"2024-07-10T08:30:42Z","logger":"controllers.OCSInitialization","msg":"Updating SecurityContextConstraint.","Request.Namespace":"openshift-storage","Request.Name":"ocsinit","SecurityContextConstraint":{"name":"noobaa"}}

- apiGroups:
  - noobaa.io
  resources:
  - noobaas
  verbs:
  - get
  - list
  - watch
  - update

13.Added create verb because the storagecluster create the noobaa pods on openshift-storage namespace

- apiGroups:
  - noobaa.io
  resources:
  - noobaas
  verbs:
  - get
  - list
  - watch
  - update
  - create
```