### PR TITLE
Fix pg_autoscaler won't scale due to overlapping roots

### DIFF
--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -171,8 +171,8 @@ func assertCephNFSBlockPool(t *testing.T, reconciler StorageClusterReconciler, c
 	expectedAf, err := reconciler.newCephBlockPoolInstances(cr)
 	assert.NoError(t, err)
 
-	assert.Equal(t, len(expectedAf[1].OwnerReferences), 1)
+	assert.Equal(t, len(expectedAf[2].OwnerReferences), 1)
 
-	assert.Equal(t, expectedAf[1].ObjectMeta.Name, actualNFSBlockPool.ObjectMeta.Name)
-	assert.Equal(t, expectedAf[1].Spec, actualNFSBlockPool.Spec)
+	assert.Equal(t, expectedAf[2].ObjectMeta.Name, actualNFSBlockPool.ObjectMeta.Name)
+	assert.Equal(t, expectedAf[2].Spec, actualNFSBlockPool.Spec)
 }

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -79,6 +79,9 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 		}
 	}
 
+	// set device class for metadata pool from the default data pool
+	ret.Spec.MetadataPool.DeviceClass = ret.Spec.DataPools[0].PoolSpec.DeviceClass
+
 	err := controllerutil.SetControllerReference(initStorageCluster, ret, r.Scheme)
 	if err != nil {
 		r.Log.Error(err, "Unable to set Controller Reference for CephFileSystem.", "CephFileSystem", klog.KRef(ret.Namespace, ret.Name))

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -173,6 +173,7 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 					Replicated:    generateCephReplicatedSpec(initData, "data"),
 				},
 				MetadataPool: cephv1.PoolSpec{
+					DeviceClass:   initData.Status.DefaultCephDeviceClass,
 					FailureDomain: initData.Status.FailureDomain,
 					Replicated:    generateCephReplicatedSpec(initData, "metadata"),
 				},


### PR DESCRIPTION
There was no CephBlockPool defined for the .mgr pool, therefore it was using the default crush rule (with no deviceClass specified) The CephObjectStore & CephFilesystem metadataPool does not define the deviceClass (it is only set in the dataPools).

To fix this Create a CephBlockPool CR for the .mgr pool with the same poolSpec as the default CephBlockPool. Also set the deviceClass for the metadataPool in CephObjectStore and CephFilesystem.

BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2253013