### PR TITLE
Adding endpoint key for Thales enterprise KMS (KMIP)

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -180,14 +180,17 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 				// reset the KMS connection's error field,
 				// it will be anyway set if there is an error
 				sc.Status.KMSServerConnection.KMSServerConnectionError = ""
-				if kmsConfigMap.Data["KMS_PROVIDER"] == "vault" {
-					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["VAULT_ADDR"]
-				} else if kmsConfigMap.Data["KMS_PROVIDER"] == AzureKSMProvider {
-					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["AZURE_VAULT_URL"]
-				} else if kmsConfigMap.Data["KMS_PROVIDER"] == ThalesKMSProvider {
-					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["KMIP_ENDPOINT"]
-				}
-				if err = reachKMSProvider(kmsConfigMap); err != nil {
+				// get the current KMS provider name
+				currKMSProvider := kmsConfigMap.Data[KMSProviderKey]
+				// according to the KMS provider, get the corresponding address/endpoint key
+				// and use it to set 'KMSServerAddress' status
+				kmsAddrssKey := kmsProviderAddressKeyMap[currKMSProvider]
+				sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data[kmsAddrssKey]
+				// if the KMS connection address is empty, log it as an error and continue
+				if sc.Status.KMSServerConnection.KMSServerAddress == "" {
+					r.Log.Error(nil, "An empty KMS server connection address found",
+						"KMSProviderName", currKMSProvider, "KMSAddressKey", kmsAddrssKey)
+				} else if err = reachKMSProvider(kmsConfigMap); err != nil {
 					sc.Status.KMSServerConnection.KMSServerConnectionError = err.Error()
 					r.Log.Error(err, "Address provided in KMS ConfigMap is not reachable.", "KMSConfigMap", klog.KRef(kmsConfigMap.Namespace, kmsConfigMap.Name))
 					return reconcile.Result{}, err

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -184,6 +184,8 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["VAULT_ADDR"]
 				} else if kmsConfigMap.Data["KMS_PROVIDER"] == AzureKSMProvider {
 					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["AZURE_VAULT_URL"]
+				} else if kmsConfigMap.Data["KMS_PROVIDER"] == ThalesKMSProvider {
+					sc.Status.KMSServerConnection.KMSServerAddress = kmsConfigMap.Data["KMIP_ENDPOINT"]
 				}
 				if err = reachKMSProvider(kmsConfigMap); err != nil {
 					sc.Status.KMSServerConnection.KMSServerConnectionError = err.Error()

--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -42,7 +42,9 @@ const (
 var (
 	// currently supported KMS providers mapped to their address key
 	kmsProviderAddressKeyMap = map[string]string{
-		VaultKMSProvider: "VAULT_ADDR",
+		VaultKMSProvider:  "VAULT_ADDR",
+		AzureKSMProvider:  "AZURE_VAULT_URL",
+		ThalesKMSProvider: "KMIP_ENDPOINT",
 	}
 	// Mapping of KMS providers and key where corresponding Secret name is stored
 	kmsProviderSecretKeyMap = map[string]string{


### PR DESCRIPTION
Add the missing KMS endpoint keys for Thales and Azure KMS configs to the known list of `kmsProviderAddressKeyMap`.