### PR TITLE
Always enforce the TSCs even if the placement is specified by the user

### DIFF
--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -88,6 +88,12 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placeme
 		}
 	}
 
+	if component == "osd" || component == "osd-prepare" {
+		if len(placement.TopologySpreadConstraints) > 0 && placement.TopologySpreadConstraints[0].TopologyKey == "" {
+			placement.TopologySpreadConstraints[0].TopologyKey = topologyKey
+		}
+	}
+
 	return placement
 }
 


### PR DESCRIPTION
Currently TSCs are enforced only if there is no other placement spec defined for the osds & osd-prepares. Without the TSCs, the OSDs will rarely be balanced. So we should always enforce the TSCs even if the placement is specified by the user.
BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2254035#c16