### PR TITLE
provider-server: send info of kernelMountOptions for cephfs to client when encryption in transit is enabled

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -473,7 +473,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: getReadAffinityOptions(sc),
 				CephFS: rookCephv1.CSICephFSSpec{
-					KernelMountOptions: getCephFSKernelMountOptions(sc),
+					KernelMountOptions: statusutil.GetCephFSKernelMountOptions(sc),
 				},
 			},
 			SkipUpgradeChecks:            sc.Spec.ManagedResources.CephCluster.SkipUpgradeChecks,
@@ -666,7 +666,7 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, monitoringIP, monitoringPo
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: getReadAffinityOptions(sc),
 				CephFS: rookCephv1.CSICephFSSpec{
-					KernelMountOptions: getCephFSKernelMountOptions(sc),
+					KernelMountOptions: statusutil.GetCephFSKernelMountOptions(sc),
 				},
 			},
 		},

--- a/controllers/storagecluster/csi_options.go
+++ b/controllers/storagecluster/csi_options.go
@@ -5,33 +5,6 @@ import (
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 )
 
-// getCephFSKernelMountOptions returns the kernel mount options for CephFS based on the spec on the StorageCluster
-func getCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
-	// If Encryption is enabled, Always use secure mode
-	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
-		sc.Spec.Network.Connections.Encryption != nil && sc.Spec.Network.Connections.Encryption.Enabled {
-		return "ms_mode=secure"
-	}
-
-	// If Encryption is not enabled, but Compression or RequireMsgr2 is enabled, use prefer-crc mode
-	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
-		((sc.Spec.Network.Connections.Compression != nil && sc.Spec.Network.Connections.Compression.Enabled) ||
-			sc.Spec.Network.Connections.RequireMsgr2) {
-		return "ms_mode=prefer-crc"
-	}
-
-	// Network spec always has higher precedence even in the External or Provider cluster. so they are checked first above
-
-	// None of Encryption, Compression, RequireMsgr2 are enabled on the StorageCluster
-	// If it's an External or Provider cluster, We don't require msgr2 by default so no mount options are needed
-	if sc.Spec.ExternalStorage.Enable || sc.Spec.AllowRemoteStorageConsumers {
-		return "ms_mode=legacy"
-	}
-	// If none of the above cases apply, We set RequireMsgr2 true by default on the cephcluster
-	// so we need to set the mount options to prefer-crc
-	return "ms_mode=prefer-crc"
-}
-
 // getReadAffinityyOptions returns the read affinity options based on the spec on the StorageCluster.
 func getReadAffinityOptions(sc *ocsv1.StorageCluster) rookCephv1.ReadAffinitySpec {
 	if sc.Spec.CSI != nil && sc.Spec.CSI.ReadAffinity != nil {

--- a/controllers/util/clusters.go
+++ b/controllers/util/clusters.go
@@ -157,3 +157,16 @@ func (c *Clusters) HasMultipleStorageClustersWithSameName(name string) bool {
 
 	return count > 1
 }
+
+func GetStorageClustersInNamespace(ctx context.Context, cli client.Client, namespace string) (ocsv1.StorageClusterList, error) {
+	storageClusters := ocsv1.StorageClusterList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+	err := cli.List(ctx, &storageClusters, listOpts...)
+	if err != nil || len(storageClusters.Items) == 0 {
+		return storageClusters, err
+	}
+
+	return storageClusters, nil
+}

--- a/controllers/util/csi_options.go
+++ b/controllers/util/csi_options.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+)
+
+// GetCephFSKernelMountOptions returns the kernel mount options for CephFS based on the spec on the StorageCluster
+func GetCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
+	// If Encryption is enabled, Always use secure mode
+	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
+		sc.Spec.Network.Connections.Encryption != nil && sc.Spec.Network.Connections.Encryption.Enabled {
+		return "ms_mode=secure"
+	}
+
+	// If Encryption is not enabled, but Compression or RequireMsgr2 is enabled, use prefer-crc mode
+	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
+		((sc.Spec.Network.Connections.Compression != nil && sc.Spec.Network.Connections.Compression.Enabled) ||
+			sc.Spec.Network.Connections.RequireMsgr2) {
+		return "ms_mode=prefer-crc"
+	}
+
+	// Network spec always has higher precedence even in the External or Provider cluster. so they are checked first above
+
+	// None of Encryption, Compression, RequireMsgr2 are enabled on the StorageCluster
+	// If it's an External or Provider cluster, We don't require msgr2 by default so no mount options are needed
+	if sc.Spec.ExternalStorage.Enable || sc.Spec.AllowRemoteStorageConsumers {
+		return "ms_mode=legacy"
+	}
+	// If none of the above cases apply, We set RequireMsgr2 true by default on the cephcluster
+	// so we need to set the mount options to prefer-crc
+	return "ms_mode=prefer-crc"
+}

--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -61,3 +61,10 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclusters
+  verbs:
+  - get
+  - list

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -61,3 +61,10 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclusters
+  verbs:
+  - get
+  - list

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	quotav1 "github.com/openshift/api/quota/v1"
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	controllers "github.com/red-hat-storage/ocs-operator/v4/controllers/storageconsumer"
 	pb "github.com/red-hat-storage/ocs-operator/v4/services/provider/pb"
@@ -757,6 +758,13 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Phase: ocsv1alpha1.StorageRequestFailed,
 			},
 		}
+		storageClusterResourceName = "mock-storage-cluster"
+		storageClustersResource    = &ocsv1.StorageCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      storageClusterResourceName,
+				Namespace: serverNamespace,
+			},
+		}
 	)
 
 	ctx := context.TODO()
@@ -767,6 +775,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 		claimResourceInitializing,
 		claimResourceCreating,
 		claimResourceFailed,
+		storageClustersResource,
 	}
 
 	// Create a fake client to mock API calls.


### PR DESCRIPTION
add kernel mount option ms_mode=secure to cephfs storageclass data when encryption in transit is enabled