### PR TITLE
use "upmap-read" as default balancer mode

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -73,6 +73,7 @@ const (
 	clusterNetworkSelectorKey = "cluster"
 	// DisasterRecoveryTargetAnnotation signifies that the cluster is intended to be used for Disaster Recovery
 	DisasterRecoveryTargetAnnotation = "ocs.openshift.io/clusterIsDisasterRecoveryTarget"
+	upmapReadBalancerMode            = "upmap-read"
 )
 
 const (
@@ -1101,7 +1102,7 @@ func generateMgrSpec(sc *ocsv1.StorageCluster) rookCephv1.MgrSpec {
 		AllowMultiplePerNode: statusutil.IsSingleNodeDeployment(),
 		Modules: []rookCephv1.Module{
 			{Name: "pg_autoscaler", Enabled: true},
-			{Name: "balancer", Enabled: true},
+			{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
 		},
 	}
 

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -305,7 +305,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: false,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true},
+					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
 				},
 			},
 		},
@@ -325,7 +325,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: false,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true},
+					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
 				},
 			},
 		},
@@ -348,7 +348,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: false,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true},
+					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
 				},
 			},
 		},
@@ -361,7 +361,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: true,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true},
+					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
 				},
 			},
 		},


### PR DESCRIPTION
This new mode was added in Squid due to the balancer module not balancing the reads.
(BZ - https://bugzilla.redhat.com/show_bug.cgi?id=1870804)