### PR TITLE
Available CRDs check feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,10 @@ COPY --from=builder workspace/provider-api /usr/local/bin/provider-api
 COPY --from=builder workspace/onboarding-validation-keys-gen /usr/local/bin/onboarding-validation-keys-gen
 COPY --from=builder workspace/metrics/deploy/*rules*.yaml /ocs-prometheus-rules/
 COPY --from=builder workspace/ux-backend-server /usr/local/bin/ux-backend-server
+COPY --from=builder workspace/hack/crdavail.sh /usr/local/bin/crdavail
 
-RUN chmod +x /usr/local/bin/ocs-operator /usr/local/bin/provider-api
+RUN chmod +x /usr/local/bin/ocs-operator /usr/local/bin/provider-api /usr/local/bin/crdavail
 
 USER operator
 
-ENTRYPOINT ["/usr/local/bin/ocs-operator"]
+ENTRYPOINT ["/usr/local/bin/crdavail"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,10 +23,7 @@ spec:
       serviceAccountName: ocs-operator
       containers:
       - command:
-        - ocs-operator
-        args:
-        - --enable-leader-election
-        - "--health-probe-bind-address=:8081"
+        - crdavail
         image: ocs-dev/ocs-operator:latest
         imagePullPolicy: Always
         name: ocs-operator

--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -401,5 +401,6 @@ func createFakeInitializationStorageClusterReconciler(t *testing.T, obj ...runti
 		Scheme:            scheme,
 		OperatorCondition: newStubOperatorCondition(),
 		Log:               logf.Log.WithName("controller_storagecluster_test"),
+		AvailableCrds:     make(map[string]bool),
 	}
 }

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1168,6 +1168,7 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 		Log:               logf.Log.WithName("controller_storagecluster_test"),
 		clusters:          clusters,
 		OperatorNamespace: operatorNamespace,
+		AvailableCrds:     make(map[string]bool),
 	}
 }
 

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -11,6 +11,7 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +44,10 @@ const (
 	// This is the name for the OwnerUID FieldIndex
 	OwnerUIDIndexName = "ownerUID"
 )
+
+func GetCrds() []string {
+	return []string{}
+}
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes
 func GetWatchNamespace() (string, error) {
@@ -148,4 +153,17 @@ func GenerateNameForNonResilientCephBlockPoolSC(initData *ocsv1.StorageCluster) 
 		return initData.Spec.ManagedResources.CephNonResilientPools.StorageClassName
 	}
 	return fmt.Sprintf("%s-ceph-non-resilient-rbd", initData.Name)
+}
+
+func MapCRDAvailability(ctx context.Context, clnt client.Client, crdNames ...string) (map[string]bool, error) {
+	crdExist := map[string]bool{}
+	for _, crdName := range crdNames {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = crdName
+		if err := clnt.Get(ctx, client.ObjectKeyFromObject(crd), crd); client.IgnoreNotFound(err) != nil {
+			return nil, fmt.Errorf("error getting CRD, %v", err)
+		}
+		crdExist[crdName] = crd.UID != ""
+	}
+	return crdExist, nil
 }

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -611,11 +611,8 @@ spec:
                 name: ocs-operator
             spec:
               containers:
-              - args:
-                - --enable-leader-election
-                - --health-probe-bind-address=:8081
-                command:
-                - ocs-operator
+              - command:
+                - crdavail
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -620,11 +620,8 @@ spec:
                 name: ocs-operator
             spec:
               containers:
-              - args:
-                - --enable-leader-election
-                - --health-probe-bind-address=:8081
-                command:
-                - ocs-operator
+              - command:
+                - crdavail
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/hack/crdavail.sh
+++ b/hack/crdavail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+RESTART_EXIT_CODE=42
+
+while true; do
+    ./usr/local/bin/ocs-operator --enable-leader-election --health-probe-bind-address=:8081
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne $RESTART_EXIT_CODE ]; then
+      exit $EXIT_CODE
+    fi
+done


### PR DESCRIPTION
## Changes

- Adds a new controller that reacts whenever a create/delete event has been enqueued for a specific CRD that's become newly available. 
- Note: this PR introduces only the structure of the feature without any specific CRDs which will be added from their respective PRs (e.g., `ClusterClaim`, `VolumeGroupSnapshotClass` and `DRClusterConfig`).