### PR TITLE
Read secrets for onboarding-token validation

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -225,7 +225,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.ConfigMap{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&corev1.Secret{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&routev1.Route{}).
 		Owns(&templatev1.Template{}).
 		Watches(&storagev1.StorageClass{}, enqueueStorageClusterRequest).

--- a/controllers/util/onboardings_secrets.go
+++ b/controllers/util/onboardings_secrets.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ReadPrivateKey(cl client.Client) (*rsa.PrivateKey, error) {
+	klog.Info("Getting the Pem key")
+	ctx := context.Background()
+
+	operatorNamespace, err := GetOperatorNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get operator namespace: %v", err)
+	}
+
+	privateSecret := &corev1.Secret{}
+	privateSecret.Name = onboardingValidationPrivateKeySecretName
+	privateSecret.Namespace = operatorNamespace
+
+	err = cl.Get(ctx, client.ObjectKeyFromObject(privateSecret), privateSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get private secret: %v", err)
+	}
+
+	Block, _ := pem.Decode(privateSecret.Data["key"])
+	privateKey, err := x509.ParsePKCS1PrivateKey(Block.Bytes)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %v", err)
+	}
+
+	return privateKey, nil
+}

--- a/controllers/util/provider.go
+++ b/controllers/util/provider.go
@@ -5,12 +5,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,9 +15,9 @@ import (
 )
 
 // GenerateOnboardingToken generates a token valid for a duration of "tokenLifetimeInHours".
-// The token content is predefined and signed by the private key which'll be read from supplied "privateKeyPath".
+// The token content is predefined and signed by the private key which'll be read from supplied "privateKey"
 // The storageQuotaInGiB is optional, and it is used to limit the storage of PVC in the application cluster.
-func GenerateOnboardingToken(tokenLifetimeInHours int, privateKeyPath string, storageQuotaInGiB *uint) (string, error) {
+func GenerateOnboardingToken(tokenLifetimeInHours int, privateKey *rsa.PrivateKey, storageQuotaInGiB *uint) (string, error) {
 	tokenExpirationDate := time.Now().
 		Add(time.Duration(tokenLifetimeInHours) * time.Hour).
 		Unix()
@@ -46,11 +43,6 @@ func GenerateOnboardingToken(tokenLifetimeInHours int, privateKeyPath string, st
 		return "", fmt.Errorf("failed to hash onboarding token payload: %v", err)
 	}
 
-	privateKey, err := readAndDecodePrivateKey(privateKeyPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read and decode private key: %v", err)
-	}
-
 	msgHashSum := msgHash.Sum(nil)
 	// In order to generate the signature, we provide a random number generator,
 	// our private key, the hashing algorithm that we used, and the hash sum
@@ -62,18 +54,4 @@ func GenerateOnboardingToken(tokenLifetimeInHours int, privateKeyPath string, st
 
 	encodedSignature := base64.StdEncoding.EncodeToString(signature)
 	return fmt.Sprintf("%s.%s", encodedPayload, encodedSignature), nil
-}
-
-func readAndDecodePrivateKey(privateKeyPath string) (*rsa.PrivateKey, error) {
-	pemString, err := os.ReadFile(privateKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read private key: %v", err)
-	}
-
-	Block, _ := pem.Decode(pemString)
-	privateKey, err := x509.ParsePKCS1PrivateKey(Block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key: %v", err)
-	}
-	return privateKey, nil
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -5,6 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const onboardingValidationPrivateKeySecretName = "onboarding-private-key"
+
 func RemoveDuplicatesFromStringSlice(slice []string) []string {
 	keys := make(map[string]bool)
 	list := []string{}

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -707,6 +707,10 @@ spec:
                 - name: ONBOARDING_TOKEN_LIFETIME
                 - name: UX_BACKEND_PORT
                 - name: TLS_ENABLED
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 image: quay.io/ocs-dev/ocs-operator:latest
                 imagePullPolicy: IfNotPresent
                 name: ux-backend-server
@@ -717,8 +721,6 @@ spec:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
                 volumeMounts:
-                - mountPath: /etc/private-key
-                  name: onboarding-private-key
                 - mountPath: /etc/tls/private
                   name: ux-cert-secret
               - args:
@@ -754,10 +756,6 @@ spec:
                 operator: Equal
                 value: "true"
               volumes:
-              - name: onboarding-private-key
-                secret:
-                  optional: true
-                  secretName: onboarding-private-key
               - name: ux-proxy-secret
                 secret:
                   secretName: ux-backend-proxy

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -645,10 +645,6 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 						Name: "ux-backend-server",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name:      "onboarding-private-key",
-								MountPath: "/etc/private-key",
-							},
-							{
 								Name:      "ux-cert-secret",
 								MountPath: "/etc/tls/private",
 							},
@@ -673,6 +669,14 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 							{
 								Name:  "TLS_ENABLED",
 								Value: os.Getenv("TLS_ENABLED"),
+							},
+							{
+								Name: util.OperatorNamespaceEnvVar,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -716,15 +720,6 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 					},
 				},
 				Volumes: []corev1.Volume{
-					{
-						Name: "onboarding-private-key",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: "onboarding-private-key",
-								Optional:   ptr.To(true),
-							},
-						},
-					},
 					{
 						Name: "ux-proxy-secret",
 						VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
This PR reads the secrets instead of reading the secrets from the volume mounts. 
whenever the new onboarding secrets are created, it takes more time to read the secrets from the volume mounts,
The user clicks the rotate onboarding  keys, the kubernetes still uses the old  public, private keys , the new keys are mounted later,  So this PR will read the secrets directly from the kubernetes secrets.