### PR TITLE
Reducing the apps group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,7 +22,12 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -111,7 +111,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=*
 // +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
-// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=*
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -193,7 +193,12 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -202,7 +202,12 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:


### PR DESCRIPTION
```Process:
1.Deploy OCP4.17

2.Install ODF4.17  [4.17.0-29.stable]

3.Check clusterrole status:
// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*

$ oc get clusterrole ocs-operator.v4.17.0-29.-a2YWGo4YLCr5DJ6FdgHYR9jOIUTJOWs7bLd3qO -o yaml | grep deployment -C10
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  - replicasets
  - statefulsets
  verbs:
  - '*'

4. Add create verb ocs-operator clusterrole status:
Add [create]
$ oc edit clusterrole ocs-operator.v4.17.0-29.-a2YWGo4YLCr5DJ6FdgHYR9jOIUTJOWs7bLd3qO 
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  - replicasets
  - statefulsets
  verbs:
  - create

5.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator-7d49979444-l58wr
list:
W0729 11:34:15.923096       1 reflector.go:539] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "deployments" in API group "apps" in the namespace "openshift-storage"

watch:
E0729 11:34:15.923128       1 reflector.go:147] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: Failed to watch *v1.Deployment: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "deployments" in API group "apps" in the namespace "openshift-storage"

6.Add "list" and "watch":
oc edit clusterrole ocs-operator.v4.17.0-29.-a2YWGo4YLCr5DJ6FdgHYR9jOIUTJOWs7bLd3qO 
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  - replicasets
  - statefulsets
  verbs:
  - create
  - list
  - watch

7.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator
$oc logs ocs-operator
{"level":"error","ts":"2024-07-29T11:41:39Z","msg":"Reconciler error","controller":"storagecluster","controllerGroup":"ocs.openshift.io","controllerKind":"StorageCluster","StorageCluster":{"name":"ocs-storagecluster","namespace":"openshift-storage"},"namespace":"openshift-storage","name":"ocs-storagecluster","reconcileID":"6258532a-f28a-421f-a9bd-72e0055f1f99","error":"deployments.apps \"rook-ceph-tools\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot update resource \"deployments\" in API group \"apps\" in the namespace \"openshift-storage\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227"}

8.Add "update":
oc edit clusterrole ocs-operator.v4.17.0-29.-a2YWGo4YLCr5DJ6FdgHYR9jOIUTJOWs7bLd3qO 
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  - replicasets
  - statefulsets
  verbs:
  - create
  - list
  - watch
  - update

9.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator
$ oc logs ocs-operator

{"level":"error","ts":"2024-07-29T11:44:24Z","msg":"Reconciler error","controller":"storagecluster","controllerGroup":"ocs.openshift.io","controllerKind":"StorageCluster","StorageCluster":{"name":"ocs-storagecluster","namespace":"openshift-storage"},"namespace":"openshift-storage","name":"ocs-storagecluster","reconcileID":"d80690cf-c6eb-45dc-a54a-10db9586aedf","error":"deployments.apps \"ocs-provider-server\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot delete resource \"deployments\" in API group \"apps\" in the namespace \"openshift-storage\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227"}

10.Add "get" and "delete":
oc edit clusterrole ocs-operator.v4.17.0-29.-a2YWGo4YLCr5DJ6FdgHYR9jOIUTJOWs7bLd3qO 
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  - replicasets
  - statefulsets
  verbs:
  - create
  - list
  - watch
  - update
  - get
  - delete

11.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator
$ oc logs ocs-operator
[No Error]

12.Check OCS CRs stautus 
$ oc get storageclusters.ocs.openshift.io 
NAME                 AGE   PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   21h   Ready              2024-07-28T14:36:03Z   4.17.0

$ oc get cephclusters.ceph.rook.io 
NAME                             DATADIRHOSTPATH   MONCOUNT   AGE   PHASE   MESSAGE                        HEALTH      EXTERNAL   FSID
ocs-storagecluster-cephcluster   /var/lib/rook     3          21h   Ready   Cluster created successfully   HEALTH_OK              bfe74cbf-3fa9-4cbe-928a-2377853ffb5d

$ oc get ocsinitializations.ocs.openshift.io 
NAME      AGE   PHASE   CREATED AT
ocsinit   21h   Ready   2024-07-28T14:33:28Z
```