### PR TITLE
provider: add annotation to StorageCluster about deployment mode

### DIFF
--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -222,6 +222,7 @@ func initStorageClusterResourceCreateUpdateTestProviderMode(t *testing.T, runtim
 		addedRuntimeObjects := []runtime.Object{node, service, deployment, secret, clientConfigMap}
 		rtObjsToCreateReconciler = append(rtObjsToCreateReconciler, addedRuntimeObjects...)
 
+		util.AddAnnotation(cr, "ocs.openshift.io/deployment-mode", "provider")
 	}
 
 	// Unpacks StorageProfile list to runtime objects array


### PR DESCRIPTION
setting an annotation on the storagecluster allows to only look at metadata for finding the configured mode rather than parsing the spec.

this helps for client-operator to decide reconciliation.