### PR TITLE
Update provider-api-server to be deployed in internal and provider mode

### DIFF
--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -83,6 +83,8 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 		},
 	}
 
+	obj := &ocsCephBlockPools{}
+
 	for _, c := range cases {
 		cr := getInitData(c.spec)
 		request := reconcile.Request{
@@ -92,7 +94,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			},
 		}
 		reconciler := createReconcilerFromCustomResources(t, cr)
-		_, err := reconciler.Reconcile(context.TODO(), request)
+		_, err := obj.ensureCreated(&reconciler, cr)
 		assert.NoError(t, err)
 		if c.label == "test-injecting-peer-token-to-cephblockpool" {
 			assertCephBlockPools(t, reconciler, cr, request, true, true)

--- a/controllers/storagecluster/cephrbdmirrors_test.go
+++ b/controllers/storagecluster/cephrbdmirrors_test.go
@@ -41,6 +41,8 @@ func TestCephRbdMirror(t *testing.T) {
 		},
 	}
 
+	obj := &ocsCephRbdMirrors{}
+
 	for _, c := range cases {
 		cr := getInitData(c.spec)
 		request := reconcile.Request{
@@ -50,7 +52,7 @@ func TestCephRbdMirror(t *testing.T) {
 			},
 		}
 		reconciler := createReconcilerFromCustomResources(t, cr)
-		_, err := reconciler.Reconcile(context.TODO(), request)
+		_, err := obj.ensureCreated(&reconciler, cr)
 		assert.NoError(t, err)
 		switch c.label {
 		case "create-ceph-rbd-mirror":

--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -2,12 +2,16 @@ package storagecluster
 
 import (
 	"fmt"
+	"maps"
+	"strconv"
 
 	ocsclientv1a1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -15,6 +19,10 @@ import (
 const (
 	tokenLifetimeInHours         = 48
 	onboardingPrivateKeyFilePath = "/etc/private-key/key"
+
+	ocsClientConfigMapName = "ocs-client-operator-config"
+	deployCSIKey           = "DEPLOY_CSI"
+	manageNoobaaSubKey     = "manageNoobaaSubscription"
 )
 
 type storageClient struct{}
@@ -26,6 +34,10 @@ func (s *storageClient) ensureCreated(r *StorageClusterReconciler, storagecluste
 	if !storagecluster.Spec.AllowRemoteStorageConsumers {
 		r.Log.Info("Spec.AllowRemoteStorageConsumers is disabled")
 		return s.ensureDeleted(r, storagecluster)
+	}
+
+	if err := s.updateClientConfigMap(r, storagecluster.Namespace); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	storageClient := &ocsclientv1a1.StorageClient{}
@@ -59,4 +71,31 @@ func (s *storageClient) ensureDeleted(r *StorageClusterReconciler, storagecluste
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+func (s *storageClient) updateClientConfigMap(r *StorageClusterReconciler, namespace string) error {
+	clientConfig := &corev1.ConfigMap{}
+	clientConfig.Name = ocsClientConfigMapName
+	clientConfig.Namespace = namespace
+
+	if err := r.Client.Get(r.ctx, client.ObjectKeyFromObject(clientConfig), clientConfig); err != nil {
+		r.Log.Error(err, "failed to get ocs client configmap")
+		return err
+	}
+
+	existingData := maps.Clone(clientConfig.Data)
+	if clientConfig.Data == nil {
+		clientConfig.Data = map[string]string{}
+	}
+	clientConfig.Data[deployCSIKey] = "true"
+	clientConfig.Data[manageNoobaaSubKey] = strconv.FormatBool(false)
+
+	if !maps.Equal(clientConfig.Data, existingData) {
+		if err := r.Client.Update(r.ctx, clientConfig); err != nil {
+			r.Log.Error(err, "failed to update client operator's configmap data")
+			return err
+		}
+	}
+
+	return nil
 }

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -23,6 +23,9 @@ const (
 	// this value is empty if the operator is running with clusterScope.
 	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
 
+	// PodNamespaceEnvVar is the env variable for the pod namespace
+	PodNamespaceEnvVar = "POD_NAMESPACE"
+
 	// SingleNodeEnvVar is set if StorageCluster needs to be deployed on a single node
 	SingleNodeEnvVar = "SINGLE_NODE"
 
@@ -46,6 +49,16 @@ const (
 
 	OdfInfoNamespacedNameClaimName = "odfinfo.odf.openshift.io"
 )
+
+var podNamespace = os.Getenv(PodNamespaceEnvVar)
+
+// GetPodNamespace returns the namespace where the pod is deployed
+func GetPodNamespace() string {
+	if podNamespace == "" {
+		panic(fmt.Errorf("%s must be set", PodNamespaceEnvVar))
+	}
+	return podNamespace
+}
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes
 func GetWatchNamespace() (string, error) {

--- a/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-binding.yaml
+++ b/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-binding.yaml
@@ -7,6 +7,5 @@ roleRef:
   kind: Role
   name: onboarding-validation-keys-generator
 subjects:
-- kind: ServiceAccount
-  name: onboarding-validation-keys-generator
-  namespace: openshift-storage
+  - kind: ServiceAccount
+    name: onboarding-validation-keys-generator

--- a/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-role.yaml
+++ b/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-role.yaml
@@ -3,19 +3,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onboarding-validation-keys-generator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-    - get
-    - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list

--- a/deploy/ocs-operator/manifests/provider-role-binding.yaml
+++ b/deploy/ocs-operator/manifests/provider-role-binding.yaml
@@ -7,5 +7,5 @@ roleRef:
   kind: Role
   name: ocs-provider-server
 subjects:
-- kind: ServiceAccount
-  name: ocs-provider-server
+  - kind: ServiceAccount
+    name: ocs-provider-server

--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -3,75 +3,75 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-provider-server
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  - services
-  verbs:
-  - get
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephfilesystemsubvolumegroups
-  - cephblockpoolradosnamespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageconsumers
-  - storageconsumers/finalizers
-  - storageconsumers/status
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-  - update
-  - patch
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephclients
-  verbs:
-  - get
-- apiGroups:
-    - ""
-  resources:
-    - pods
-  verbs:
-    - get
-    - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storagerequests
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephfilesystemsubvolumegroups
+      - cephblockpoolradosnamespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageconsumers
+      - storageconsumers/finalizers
+      - storageconsumers/status
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephclients
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storagerequests
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list

--- a/rbac/onboarding-validation-keys-generator-binding.yaml
+++ b/rbac/onboarding-validation-keys-generator-binding.yaml
@@ -7,6 +7,5 @@ roleRef:
   kind: Role
   name: onboarding-validation-keys-generator
 subjects:
-- kind: ServiceAccount
-  name: onboarding-validation-keys-generator
-  namespace: openshift-storage
+  - kind: ServiceAccount
+    name: onboarding-validation-keys-generator

--- a/rbac/onboarding-validation-keys-generator-role.yaml
+++ b/rbac/onboarding-validation-keys-generator-role.yaml
@@ -3,19 +3,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onboarding-validation-keys-generator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-    - get
-    - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list

--- a/rbac/provider-role-binding.yaml
+++ b/rbac/provider-role-binding.yaml
@@ -7,5 +7,5 @@ roleRef:
   kind: Role
   name: ocs-provider-server
 subjects:
-- kind: ServiceAccount
-  name: ocs-provider-server
+  - kind: ServiceAccount
+    name: ocs-provider-server

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -3,75 +3,75 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-provider-server
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  - services
-  verbs:
-  - get
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephfilesystemsubvolumegroups
-  - cephblockpoolradosnamespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageconsumers
-  - storageconsumers/finalizers
-  - storageconsumers/status
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-  - update
-  - patch
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephclients
-  verbs:
-  - get
-- apiGroups:
-    - ""
-  resources:
-    - pods
-  verbs:
-    - get
-    - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storagerequests
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephfilesystemsubvolumegroups
+      - cephblockpoolradosnamespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageconsumers
+      - storageconsumers/finalizers
+      - storageconsumers/status
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephclients
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storagerequests
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list

--- a/services/provider/main.go
+++ b/services/provider/main.go
@@ -21,11 +21,7 @@ func main() {
 
 	klog.Info("Starting Provider API server")
 
-	namespace, err := util.GetWatchNamespace()
-	if err != nil {
-		klog.Errorf("failed to get provider cluster namespace. %v", err)
-		return
-	}
+	namespace := util.GetPodNamespace()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()


### PR DESCRIPTION
Allow provider-server to be deployed in intenal and provider mode

Why?
This is a part of RDR for Provider Mode RHSTOR-4886.
With this epic, we are introducing rpc calls for odf to odf communication, the RPC's we have for this epic are limited to Onboarding a Storage Cluster on different Openshift clusters and Getting the Mirroring Info required for setting up RDR (refer #2671).

This can also be used to replace the mechanism we have in the internal mode for setting up Mirroring for blockpool using MCO's Agents.

Hence moving the ocs-provider-server deployment to be deployed in both modes to enable both client to provider communication and cross odf communication.

The PR does the following:
1. Create service, deployment, onboarding job for both modes
2. Update the variable from watchnamespace to podnamespace
3. Remove hardcoded name for storagecluster
4. Move client configmap in storageclient
5. Update the unit tests
