### PR TITLE
Sends and labels `V*ReplicationClass`, `V*SnapClass`, `StorageClass` to client

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -58,6 +58,10 @@ const (
 	onboardingTicketKeySecret = "onboarding-ticket-key"
 	storageRequestNameLabel   = "ocs.openshift.io/storagerequest-name"
 	notAvailable              = "N/A"
+
+	ramenDRStorageIDKey     = "ramendr.openshift.io/storageID"
+	ramenDRReplicationIDKey = "ramendr.openshift.io/replicationid"
+	ramenDRFlattenModeKey   = "replication.storage.openshift.io/flatten-mode"
 )
 
 const (
@@ -656,9 +660,24 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 			return nil, status.Error(codes.Internal, msg)
 		}
 	}
+
+	// fetch storage cluster peer to indicate whether replication is enabled
+	scp := &ocsv1.StorageClusterPeerList{}
+	if err = s.client.List(ctx, scp, client.InNamespace(s.namespace)); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get StorageClusterPeerList. %v", err)
+	}
+	replicationEnabled := len(scp.Items) > 1
+	var replicationID string
+	if replicationEnabled {
+		replicationID = util.CalculateMD5Hash(req.StorageClaimName)
+	}
+
 	var extR []*pb.ExternalResource
 
 	storageRequestHash := getStorageRequestHash(req.StorageConsumerUUID, req.StorageClaimName)
+	// SID for RamenDR
+	storageID := storageRequestHash
+
 	for _, cephRes := range storageRequest.Status.CephResources {
 		switch cephRes.Kind {
 		case "CephClient":
@@ -690,13 +709,12 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 			})
 
 		case "CephBlockPoolRadosNamespace":
-
 			rns := &rookCephv1.CephBlockPoolRadosNamespace{}
 			err = s.client.Get(ctx, types.NamespacedName{Name: cephRes.Name, Namespace: s.namespace}, rns)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to get %s CephBlockPoolRadosNamespace. %v", cephRes.Name, err)
 			}
-
+			mirroringEnabled := rns.Spec.Mirroring != nil
 			provisionerSecretName := storageClaimCephCsiSecretName("provisioner", storageRequestHash)
 			nodeSecretName := storageClaimCephCsiSecretName("node", storageRequestHash)
 			rbdStorageClassData := map[string]string{
@@ -717,22 +735,48 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 
 			extR = append(extR,
 				&pb.ExternalResource{
-					Name: "ceph-rbd",
-					Kind: "StorageClass",
-					Data: mustMarshal(rbdStorageClassData),
+					Name:   "ceph-rbd",
+					Kind:   "StorageClass",
+					Data:   mustMarshal(rbdStorageClassData),
+					Labels: getExternalResourceLabels("StorageClass", mirroringEnabled, false, replicationID, storageID),
 				},
 				&pb.ExternalResource{
 					Name: "ceph-rbd",
 					Kind: "VolumeSnapshotClass",
 					Data: mustMarshal(map[string]string{
 						"csi.storage.k8s.io/snapshotter-secret-name": provisionerSecretName,
-					})},
+					}),
+					Labels: getExternalResourceLabels("VolumeSnapshotClass", mirroringEnabled, false, replicationID, storageID)},
 				&pb.ExternalResource{
 					Name: "ceph-rbd",
 					Kind: "VolumeGroupSnapshotClass",
 					Data: mustMarshal(map[string]string{
 						"csi.storage.k8s.io/group-snapshotter-secret-name": provisionerSecretName,
-					})},
+					}),
+					Labels: getExternalResourceLabels("VolumeGroupSnapshotClass", mirroringEnabled, false, replicationID, storageID)},
+				&pb.ExternalResource{
+					Name: "ceph-rbd",
+					Kind: "VolumeReplicationClass",
+					Data: mustMarshal(map[string]string{
+						"replication.storage.openshift.io/replication-secret-name": provisionerSecretName,
+						"mirroringMode": "snapshot",
+					}),
+					Labels: getExternalResourceLabels("VolumeReplicationClass", mirroringEnabled, false, replicationID, storageID),
+					Annotations: map[string]string{
+						"replication.storage.openshift.io/is-default-class": "true",
+					},
+				},
+				&pb.ExternalResource{
+					Name: "ceph-rbd-flatten",
+					Kind: "VolumeReplicationClass",
+					Data: mustMarshal(map[string]string{
+						"replication.storage.openshift.io/replication-secret-name": provisionerSecretName,
+						"mirroringMode": "snapshot",
+						"flattenMode":   "force",
+					}),
+					Labels:      getExternalResourceLabels("VolumeReplicationClass", mirroringEnabled, true, replicationID, storageID),
+					Annotations: map[string]string{},
+				},
 				&pb.ExternalResource{
 					Kind: "ClientProfile",
 					Name: "ceph-rbd",
@@ -777,9 +821,10 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 
 			extR = append(extR,
 				&pb.ExternalResource{
-					Name: "cephfs",
-					Kind: "StorageClass",
-					Data: mustMarshal(cephfsStorageClassData),
+					Name:   "cephfs",
+					Kind:   "StorageClass",
+					Data:   mustMarshal(cephfsStorageClassData),
+					Labels: getExternalResourceLabels("StorageClass", replicationEnabled, false, replicationID, storageID),
 				},
 				&pb.ExternalResource{
 					Name: cephRes.Name,
@@ -792,13 +837,17 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 					Kind: "VolumeSnapshotClass",
 					Data: mustMarshal(map[string]string{
 						"csi.storage.k8s.io/snapshotter-secret-name": provisionerSecretName,
-					})},
+					}),
+					Labels: getExternalResourceLabels("VolumeSnapshotClass", replicationEnabled, false, replicationID, storageID),
+				},
 				&pb.ExternalResource{
 					Name: "cephfs",
 					Kind: "VolumeGroupSnapshotClass",
 					Data: mustMarshal(map[string]string{
 						"csi.storage.k8s.io/group-snapshotter-secret-name": provisionerSecretName,
-					})},
+					}),
+					Labels: getExternalResourceLabels("VolumeGroupSnapshotClass", replicationEnabled, false, replicationID, storageID),
+				},
 				&pb.ExternalResource{
 					Kind: "ClientProfile",
 					Name: "cephfs",
@@ -815,6 +864,33 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 	klog.Infof("successfully returned the storage class claim %q for %q", req.StorageClaimName, req.StorageConsumerUUID)
 	return &pb.StorageClaimConfigResponse{ExternalResource: extR}, nil
 
+}
+
+func getExternalResourceLabels(kind string, isMirroringReplicationEnabled bool, isFlattenMode bool,
+	replicationID string, storageID string) map[string]string {
+	labels := make(map[string]string)
+	switch kind {
+	case "VolumeReplicationClass", "VolumeGroupReplicationClass":
+		if isMirroringReplicationEnabled {
+			labels[ramenDRReplicationIDKey] = replicationID
+			if isFlattenMode {
+				labels[ramenDRFlattenModeKey] = "force"
+			}
+			labels[ramenDRStorageIDKey] = storageID
+		}
+	case "VolumeSnapshotClass", "VolumeGroupSnapshotClass":
+		if isMirroringReplicationEnabled {
+			labels[ramenDRStorageIDKey] = storageID
+		}
+	case "StorageClass":
+		if isMirroringReplicationEnabled {
+			labels[ramenDRStorageIDKey] = storageID
+		}
+
+	default:
+		panic(fmt.Sprintf("unknown storage class kind %q", kind))
+	}
+	return labels
 }
 
 // ReportStatus rpc call to check if a consumer can reach to the provider.

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -29,9 +29,11 @@ import (
 )
 
 type externalResource struct {
-	Kind string `json:"kind"`
-	Data any    `json:"data"`
-	Name string `json:"name"`
+	Kind        string            `json:"kind"`
+	Data        any               `json:"data"`
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
 }
 
 var serverNamespace = "openshift-storage"
@@ -310,7 +312,10 @@ func TestGetExternalResources(t *testing.T) {
 			data, err := json.Marshal(mockResoruce.Data)
 			assert.NoError(t, err)
 			assert.Equal(t, string(extResource.Data), string(data))
+
 		}
+		assert.Equal(t, extResource.GetLabels(), mockResoruce.Labels)
+		assert.Equal(t, extResource.GetAnnotations(), mockResoruce.Annotations)
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}
@@ -348,7 +353,8 @@ func TestGetExternalResources(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, string(extResource.Data), string(data))
 		}
-
+		assert.Equal(t, extResource.GetLabels(), mockResoruce.Labels)
+		assert.Equal(t, extResource.GetAnnotations(), mockResoruce.Annotations)
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}
@@ -626,12 +632,19 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 					"csi.storage.k8s.io/node-stage-secret-name":        "ceph-client-node-8d40b6be71600457b5dec219d2ce2d4c",
 					"csi.storage.k8s.io/controller-expand-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
 				},
+				Labels: map[string]string{
+					"ramendr.openshift.io/storageID": "8d40b6be71600457b5dec219d2ce2d4c",
+				},
 			},
 			"ceph-rbd-volumesnapshotclass": {
 				Name: "ceph-rbd",
 				Kind: "VolumeSnapshotClass",
 				Data: map[string]string{
 					"csi.storage.k8s.io/snapshotter-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
+				},
+				Labels: map[string]string{
+
+					"ramendr.openshift.io/storageID": "8d40b6be71600457b5dec219d2ce2d4c",
 				},
 			},
 			"ceph-rbd-volumegroupsnapshotclass": {
@@ -640,6 +653,39 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Data: map[string]string{
 					"csi.storage.k8s.io/group-snapshotter-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
 				},
+				Labels: map[string]string{
+					"ramendr.openshift.io/storageID": "8d40b6be71600457b5dec219d2ce2d4c",
+				},
+			},
+			"ceph-rbd-volumereplicationclass": {
+				Name: "ceph-rbd",
+				Kind: "VolumeReplicationClass",
+				Data: map[string]string{
+					"replication.storage.openshift.io/replication-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
+					"mirroringMode": "snapshot",
+				},
+				Labels: map[string]string{
+					"ramendr.openshift.io/replicationid": "",
+					"ramendr.openshift.io/storageID":     "8d40b6be71600457b5dec219d2ce2d4c",
+				},
+				Annotations: map[string]string{
+					"replication.storage.openshift.io/is-default-class": "true",
+				},
+			},
+			"ceph-rbd-flatten-volumereplicationclass": {
+				Name: "ceph-rbd-flatten",
+				Kind: "VolumeReplicationClass",
+				Data: map[string]string{
+					"replication.storage.openshift.io/replication-secret-name": "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
+					"mirroringMode": "snapshot",
+					"flattenMode":   "force",
+				},
+				Labels: map[string]string{
+					"replication.storage.openshift.io/flatten-mode": "force",
+					"ramendr.openshift.io/replicationid":            "",
+					"ramendr.openshift.io/storageID":                "8d40b6be71600457b5dec219d2ce2d4c",
+				},
+				Annotations: map[string]string{},
 			},
 			"ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c": {
 				Name: "ceph-client-provisioner-8d40b6be71600457b5dec219d2ce2d4c",
@@ -681,6 +727,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 					"csi.storage.k8s.io/node-stage-secret-name":        "ceph-client-node-0e8555e6556f70d23a61675af44e880c",
 					"csi.storage.k8s.io/controller-expand-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
 				},
+				Labels: map[string]string{},
 			},
 			"cephfs-volumesnapshotclass": {
 				Name: "cephfs",
@@ -688,6 +735,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Data: map[string]string{
 					"csi.storage.k8s.io/snapshotter-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
 				},
+				Labels: map[string]string{},
 			},
 
 			"cephfs-volumegroupsnapshotclass": {
@@ -696,6 +744,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 				Data: map[string]string{
 					"csi.storage.k8s.io/group-snapshotter-secret-name": "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
 				},
+				Labels: map[string]string{},
 			},
 			"ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c": {
 				Name: "ceph-client-provisioner-0e8555e6556f70d23a61675af44e880c",
@@ -1003,9 +1052,24 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 		},
 		Spec: rookCephv1.CephBlockPoolRadosNamespaceSpec{
 			BlockPoolName: "cephblockpool",
+			Mirroring: &rookCephv1.RadosNamespaceMirroring{
+				Mode: "pool",
+			},
 		},
 	}
 	assert.NoError(t, client.Create(ctx, radosNamespace))
+
+	cephBlockPool := &rookCephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cephblockpool",
+			Namespace: server.namespace,
+		},
+		Spec: rookCephv1.NamedBlockPoolSpec{
+			PoolSpec: rookCephv1.PoolSpec{
+				Mirroring: rookCephv1.MirroringSpec{Enabled: false},
+			}},
+	}
+	assert.NoError(t, client.Create(ctx, cephBlockPool))
 
 	// get the storage class request config for block pool
 	req := pb.StorageClaimConfigRequest{
@@ -1025,6 +1089,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 			name = fmt.Sprintf("%s-storageclass", name)
 		} else if extResource.Kind == "VolumeGroupSnapshotClass" {
 			name = fmt.Sprintf("%s-volumegroupsnapshotclass", name)
+		} else if extResource.Kind == "VolumeReplicationClass" {
+			name = fmt.Sprintf("%s-volumereplicationclass", name)
 		} else if extResource.Kind == "ClientProfile" {
 			name = fmt.Sprintf("%s-clientprofile", name)
 		}
@@ -1034,6 +1100,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 		data, err := json.Marshal(mockResoruce.Data)
 		assert.NoError(t, err)
 		assert.Equal(t, string(extResource.Data), string(data))
+		assert.Equal(t, extResource.GetLabels(), mockResoruce.Labels)
+		assert.Equal(t, extResource.GetAnnotations(), mockResoruce.Annotations)
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}
@@ -1056,6 +1124,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 			name = fmt.Sprintf("%s-storageclass", name)
 		} else if extResource.Kind == "VolumeGroupSnapshotClass" {
 			name = fmt.Sprintf("%s-volumegroupsnapshotclass", name)
+		} else if extResource.Kind == "VolumeReplicationClass" {
+			name = fmt.Sprintf("%s-volumereplicationclass", name)
 		} else if extResource.Kind == "ClientProfile" {
 			name = fmt.Sprintf("%s-clientprofile", name)
 		}
@@ -1064,6 +1134,8 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 		data, err := json.Marshal(mockResoruce.Data)
 		assert.NoError(t, err)
 		assert.Equal(t, string(extResource.Data), string(data))
+		assert.Equal(t, extResource.GetLabels(), mockResoruce.Labels)
+		assert.Equal(t, extResource.GetAnnotations(), mockResoruce.Annotations)
 		assert.Equal(t, extResource.Kind, mockResoruce.Kind)
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}


### PR DESCRIPTION
## Changes

- Sends two VRCs (one for image flattening) and one VGRC. Depends on #2620 
- Labels V*RepClass, V*SnapClass and StorageClass

[RHSTOR-5753](https://issues.redhat.com/browse/RHSTOR-5753), [RHSTOR-5794](https://issues.redhat.com/browse/RHSTOR-5794), [RHSTOR-5754](https://issues.redhat.com/browse/RHSTOR-5754)