### PR TITLE
Bug 2302448: Refactor imports in odfinfoconfig.go

### DIFF
--- a/controllers/storagecluster/odfinfoconfig.go
+++ b/controllers/storagecluster/odfinfoconfig.go
@@ -2,7 +2,6 @@ package storagecluster
 
 import (
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 	"sync"
 
@@ -10,13 +9,14 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1a1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/controllers/storagecluster/odfinfoconfig_test.go
+++ b/controllers/storagecluster/odfinfoconfig_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	ocsversion "github.com/red-hat-storage/ocs-operator/v4/version"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"gotest.tools/v3/assert"


### PR DESCRIPTION
- Add 'gopkg.in/yaml.v2' import.
- go fmt import changes

This change is required because 'sigs.k8s.io/yaml' produced a PascalCase output, which the UI cannot use. By using the new dependency 'gopkg.in/yaml.v2', we ensure the output is in camelCase, which the UI can use for its unmarshalling.

example output by `sigs.k8s.io/yaml`

```
Clients:
- ClusterID: cluster1
  Name: client1
- ClusterID: cluster2
  Name: client2
DeploymentType: internal
StorageCluster:
  CephClusterFSID: fsid12345
  NamespacedName:
    Name: storage-cluster
    Namespace: openshift-storage
  StorageProviderEndpoint: http://storage-provider-endpoint/
StorageSystemName: storage-system-1
Version: 4.17.0
```

example output required by UI  and done by 'gopkg.in/yaml.v2',
```
version: 4.17.0
deploymentType: internal
clients:
- name: client1
  clusterId: cluster1
- name: client2
  clusterId: cluster2
storageCluster:
  namespacedName:
    namespace: openshift-storage
    name: storage-cluster
  storageProviderEndpoint: http://storage-provider-endpoint/
  cephClusterFSID: fsid12345
storageSystemName: storage-system-1
```