### PR TITLE
Add travisn to approvers and reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - BlaineEXE
   - nb-ohad
   - iamniting
+  - travisn
 # review == this code is good /lgtm
 reviewers:
   - jarrpa
@@ -18,3 +19,4 @@ reviewers:
   - BlaineEXE
   - nb-ohad
   - iamniting
+  - travisn


### PR DESCRIPTION
Joining the list of approvers and reviewers for the OCS operator, particularly in case of urgent reviews and merges.