### PR TITLE
Available CRDs check feature (with script)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,10 @@ COPY --from=builder workspace/provider-api /usr/local/bin/provider-api
 COPY --from=builder workspace/onboarding-validation-keys-gen /usr/local/bin/onboarding-validation-keys-gen
 COPY --from=builder workspace/metrics/deploy/*rules*.yaml /ocs-prometheus-rules/
 COPY --from=builder workspace/ux-backend-server /usr/local/bin/ux-backend-server
+COPY --from=builder workspace/hack/crdavail.sh /usr/local/bin/crdavail
 
-RUN chmod +x /usr/local/bin/ocs-operator /usr/local/bin/provider-api
+RUN chmod +x /usr/local/bin/ocs-operator /usr/local/bin/provider-api /usr/local/bin/crdavail
 
 USER operator
 
-ENTRYPOINT ["/usr/local/bin/ocs-operator"]
+ENTRYPOINT ["/usr/local/bin/crdavail"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,10 +23,7 @@ spec:
       serviceAccountName: ocs-operator
       containers:
       - command:
-        - ocs-operator
-        args:
-        - --enable-leader-election
-        - "--health-probe-bind-address=:8081"
+          - crdavail
         image: ocs-dev/ocs-operator:latest
         imagePullPolicy: Always
         name: ocs-operator

--- a/controllers/crd/crd_controller.go
+++ b/controllers/crd/crd_controller.go
@@ -1,0 +1,79 @@
+package crd
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/klog/v2"
+	"os"
+	"reflect"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// CustomResourceDefinitionReconciler reconciles a CustomResourceDefinition object
+// nolint:revive
+type CustomResourceDefinitionReconciler struct {
+	Client        client.Client
+	ctx           context.Context
+	Log           logr.Logger
+	AvailableCrds map[string]bool
+}
+
+// Reconcile compares available CRDs maps following either a Create or Delete event
+func (r *CustomResourceDefinitionReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	prevLogger := r.Log
+	defer func() { r.Log = prevLogger }()
+	r.Log = r.Log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	r.ctx = ctx
+
+	r.Log.Info("Reconciling CustomResourceDefinition.", "CRD", klog.KRef(request.Namespace, request.Name))
+
+	var err error
+	var crds []string
+	availableCrds, err := util.MapCRDAvailability(ctx, r.Client, crds...)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !reflect.DeepEqual(availableCrds, r.AvailableCrds) {
+		r.Log.Info("New CustomResourceDefinitions detected. Restarting process.")
+		os.Exit(42)
+	}
+	return reconcile.Result{}, nil
+}
+
+// SetupWithManager sets up a controller with a manager
+func (r *CustomResourceDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	crdPredicate := predicate.Funcs{
+		CreateFunc: func(e event.TypedCreateEvent[client.Object]) bool {
+			_, ok := r.AvailableCrds[e.Object.GetName()]
+			if ok {
+				r.Log.Info("CustomResourceDefinition %s was Created.", e.Object.GetName())
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[client.Object]) bool {
+			_, ok := r.AvailableCrds[e.Object.GetName()]
+			if ok {
+				r.Log.Info("CustomResourceDefinition %s was Deleted.", e.Object.GetName())
+				return true
+			}
+			return false
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+			return false
+		},
+		GenericFunc: func(e event.TypedGenericEvent[client.Object]) bool {
+			return false
+		},
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&apiextensionsv1.CustomResourceDefinition{}, builder.WithPredicates(crdPredicate)).
+		Complete(r)
+}

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -611,11 +611,8 @@ spec:
                 name: ocs-operator
             spec:
               containers:
-              - args:
-                - --enable-leader-election
-                - --health-probe-bind-address=:8081
-                command:
-                - ocs-operator
+              - command:
+                - crdavail
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -620,11 +620,8 @@ spec:
                 name: ocs-operator
             spec:
               containers:
-              - args:
-                - --enable-leader-election
-                - --health-probe-bind-address=:8081
-                command:
-                - ocs-operator
+              - command:
+                - crdavail
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/hack/crdavail.sh
+++ b/hack/crdavail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+RESTART_EXIT_CODE=42
+
+while true; do
+    ./usr/local/bin/ocs-operator --enable-leader-election --health-probe-bind-address=:8081
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne $RESTART_EXIT_CODE ]; then
+      exit $EXIT_CODE
+    fi
+done

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/crd"
 	"os"
 	"runtime"
 
@@ -250,6 +251,22 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "Unable to get Client")
 		os.Exit(1)
+	}
+
+	var crds []string
+	availCrds, err := util.MapCRDAvailability(context.Background(), apiClient, crds...)
+	if err != nil {
+		setupLog.Error(err, "Unable to get CRD")
+		os.Exit(1)
+	}
+	if len(crds) > 0 {
+		if err = (&crd.CustomResourceDefinitionReconciler{
+			Client:        mgr.GetClient(),
+			AvailableCrds: availCrds,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "CustomResourceDefinitionReconciler")
+			os.Exit(1)
+		}
 	}
 
 	// Set OperatorCondition Upgradeable to True


### PR DESCRIPTION
## Changes
### Reasons for this enhancement:
- A controller cannot set up a watch for a CRD that is not installed on the cluster, trying to set up a watch will panic the operator
- There is no known way, that we are aware of, to add a watch later without client cache issue

### How does the enhancement work around the issue:
- On start up, detect which CRD are avail (out of a fixed list) and skip watches for ones that are not avail
- At the start each reconcile iteration, revalidate which CRD are now available. If a CRD of interest is now avail, exit the op with a known exit code (42)
- Have the pod command detect the exit code and if it is the known exist code (42), restart the process

This process will guarantee that the pod does restart when a new CRD of
 interest becomes available. This in turn helps to avoid the following
  issue:
- Pod will not get into CrushLoopBackoff state
- There will be no change that the pod becomes unschedulable after restart as of missing resources

#### Note
#2712 is considered as a potential enhancement by @iamniting 