### PR TITLE
Available CRDs check feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,10 @@ COPY --from=builder workspace/provider-api /usr/local/bin/provider-api
 COPY --from=builder workspace/onboarding-validation-keys-gen /usr/local/bin/onboarding-validation-keys-gen
 COPY --from=builder workspace/metrics/deploy/*rules*.yaml /ocs-prometheus-rules/
 COPY --from=builder workspace/ux-backend-server /usr/local/bin/ux-backend-server
+COPY --from=builder workspace/hack/entrypoint.sh /usr/local/bin/entrypoint
 
-RUN chmod +x /usr/local/bin/ocs-operator /usr/local/bin/provider-api
+RUN chmod +x /usr/local/bin/ocs-operator /usr/local/bin/provider-api /usr/local/bin/entrypoint
 
 USER operator
 
-ENTRYPOINT ["/usr/local/bin/ocs-operator"]
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: ocs-operator
       containers:
       - command:
-        - ocs-operator
+        - entrypoint
         args:
         - --enable-leader-election
         - "--health-probe-bind-address=:8081"

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -13,7 +13,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -452,9 +451,7 @@ func (r *StorageClusterReconciler) newStorageClassConfigurations(initData *ocsv1
 	// when allowing consumers, creation of storage classes should only be done via storagerequests
 	if !initData.Spec.AllowRemoteStorageConsumers {
 		// If kubevirt crd is present, we create a specialized rbd storageclass for virtualization environment
-		kvcrd := &extv1.CustomResourceDefinition{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "virtualmachines.kubevirt.io", Namespace: ""}, kvcrd)
-		if err == nil {
+		if r.AvailableCrds[VirtualMachineCrdName] {
 			ret = append(ret, newCephBlockPoolVirtualizationStorageClassConfiguration(initData))
 		}
 	}

--- a/controllers/storagecluster/storageclasses_test.go
+++ b/controllers/storagecluster/storageclasses_test.go
@@ -62,6 +62,7 @@ var (
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pluralName + "." + "kubevirt.io",
+				UID:  "uid",
 			},
 			Spec: extv1.CustomResourceDefinitionSpec{
 				Group: "kubevirt.io",
@@ -99,7 +100,6 @@ func TestCustomEncryptedStorageClasses(t *testing.T) {
 
 func testStorageClasses(t *testing.T, pvEncryption bool, customSpec *api.StorageClusterSpec) {
 	runtimeObjs := []client.Object{}
-	runtimeObjs = append(runtimeObjs, createVirtualMachineCRD())
 	if pvEncryption {
 		runtimeObjs = append(runtimeObjs, createDummyKMSConfigMap(dummyKmsProvider, dummyKmsAddress, ""))
 	}

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1208,6 +1208,8 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 	frecorder := record.NewFakeRecorder(1024)
 	reporter := statusutil.NewEventReporter(frecorder)
 
+	availCrds := map[string]bool{}
+
 	return StorageClusterReconciler{
 		recorder:          reporter,
 		Client:            client,
@@ -1216,6 +1218,7 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 		Log:               logf.Log.WithName("controller_storagecluster_test"),
 		clusters:          clusters,
 		OperatorNamespace: operatorNamespace,
+		AvailableCrds:     availCrds,
 	}
 }
 

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"strings"
 
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
-	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +47,8 @@ const (
 	// This is the name for the OwnerUID FieldIndex
 	OwnerUIDIndexName = "ownerUID"
 
-	OdfInfoNamespacedNameClaimName = "odfinfo.odf.openshift.io"
+	OdfInfoNamespacedNameClaimName      = "odfinfo.odf.openshift.io"
+	ExitCodeThatShouldRestartTheProcess = 42
 )
 
 var podNamespace = os.Getenv(PodNamespaceEnvVar)
@@ -164,18 +165,4 @@ func GenerateNameForNonResilientCephBlockPoolSC(initData *ocsv1.StorageCluster) 
 		return initData.Spec.ManagedResources.CephNonResilientPools.StorageClassName
 	}
 	return fmt.Sprintf("%s-ceph-non-resilient-rbd", initData.Name)
-}
-
-func MapCRDAvailability(ctx context.Context, clnt client.Client, log logr.Logger, crdNames ...string) (map[string]bool, error) {
-	crdExist := map[string]bool{}
-	for _, crdName := range crdNames {
-		crd := &apiextensionsv1.CustomResourceDefinition{}
-		crd.Name = crdName
-		if err := clnt.Get(ctx, client.ObjectKeyFromObject(crd), crd); client.IgnoreNotFound(err) != nil {
-			log.Error(err, fmt.Sprintf("Error getting CRD  for %s", crdName))
-			return nil, fmt.Errorf("error getting CRD, %v", err)
-		}
-		crdExist[crdName] = crd.UID != ""
-	}
-	return crdExist, nil
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -5,8 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"os"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,4 +96,10 @@ func CalculateMD5Hash(value any) string {
 	}
 	hash := md5.Sum(data)
 	return hex.EncodeToString(hash[:])
+}
+
+func AssertEqual[T comparable](actual T, expected T, exitCode int) {
+	if actual != expected {
+		os.Exit(exitCode)
+	}
 }

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -537,7 +537,7 @@ spec:
                 - --enable-leader-election
                 - --health-probe-bind-address=:8081
                 command:
-                - ocs-operator
+                - entrypoint
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -546,7 +546,7 @@ spec:
                 - --enable-leader-election
                 - --health-probe-bind-address=:8081
                 command:
-                - ocs-operator
+                - entrypoint
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+RESTART_EXIT_CODE=42
+
+while true; do
+    ./usr/local/bin/ocs-operator $@
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne $RESTART_EXIT_CODE ]; then
+      exit $EXIT_CODE
+    fi
+done


### PR DESCRIPTION
## Changes

- Update the storageCluster controller to react whenever a create/delete event has been enqueued for a specific CRD that's become newly available.
- Exit the ocs-operator process with a specific exit code whenever a new card of interest is being created or deleted
- Catch the exit code with a bash script and restart the ocs-operator process
- Conditionally watch the ClusterClaim CRD from the ocsinit controller
