### PR TITLE
remove upmap-read balancer mode

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -72,7 +72,6 @@ const (
 	networkProvider           = "multus"
 	publicNetworkSelectorKey  = "public"
 	clusterNetworkSelectorKey = "cluster"
-	upmapReadBalancerMode     = "upmap-read"
 )
 
 const (
@@ -1100,7 +1099,7 @@ func generateMgrSpec(sc *ocsv1.StorageCluster) rookCephv1.MgrSpec {
 		AllowMultiplePerNode: statusutil.IsSingleNodeDeployment(),
 		Modules: []rookCephv1.Module{
 			{Name: "pg_autoscaler", Enabled: true},
-			{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
+			{Name: "balancer", Enabled: true},
 		},
 	}
 

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -305,7 +305,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: false,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
+					{Name: "balancer", Enabled: true},
 				},
 			},
 		},
@@ -325,7 +325,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: false,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
+					{Name: "balancer", Enabled: true},
 				},
 			},
 		},
@@ -348,7 +348,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: false,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
+					{Name: "balancer", Enabled: true},
 				},
 			},
 		},
@@ -361,7 +361,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				AllowMultiplePerNode: true,
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true, Settings: rookCephv1.ModuleSettings{BalancerMode: upmapReadBalancerMode}},
+					{Name: "balancer", Enabled: true},
 				},
 			},
 		},


### PR DESCRIPTION
upmap-read mode of the balancer isn't supported by the kernel client. There was a recent change on the RADOS side which actually enforced this, see ceph/ceph#57776. Prior to 18.2.4 and 19.1.1 all sorts of incompatibility checks were missing in this area. So we need to revert upmap-read mode for now.