### PR TITLE
kms: skip checking azure kms endpoint reachability

### DIFF
--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -43,7 +43,6 @@ var (
 	// currently supported KMS providers mapped to their address key
 	kmsProviderAddressKeyMap = map[string]string{
 		VaultKMSProvider:  "VAULT_ADDR",
-		AzureKSMProvider:  "AZURE_VAULT_URL",
 		ThalesKMSProvider: "KMIP_ENDPOINT",
 	}
 	// Mapping of KMS providers and key where corresponding Secret name is stored


### PR DESCRIPTION
Vault URL provided in the KMS settings does not have a port number. As a result, endpoint reachable check in `checkEndpointReachable` function fails.  . This only works when we provide the default port of 443 and along with the URL. For now, we can simply avoid checking azure vault URL for endpoint reachability.

This fixes BZ - https://bugzilla.redhat.com/show_bug.cgi?id=2303619 which is a blocker for Azure customers using KMS