### PR TITLE
Reducing the storage.k8s.io group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -411,13 +411,10 @@ rules:
   resources:
   - storageclasses
   verbs:
-  - '*'
   - create
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - template.openshift.io

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -109,7 +109,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=*
 // +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=*
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=watch;create;delete;get;list
 // +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;delete

--- a/controllers/storagerequest/storagerequest_controller.go
+++ b/controllers/storagerequest/storagerequest_controller.go
@@ -76,7 +76,7 @@ type StorageRequestReconciler struct {
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephfilesystemsubvolumegroups,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephblockpoolradosnamespaces,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclusters,verbs=get;watch;list
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=watch;create;delete;get;list
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch
 

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -582,13 +582,10 @@ spec:
           resources:
           - storageclasses
           verbs:
-          - '*'
           - create
           - delete
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - template.openshift.io

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -591,13 +591,10 @@ spec:
           resources:
           - storageclasses
           verbs:
-          - '*'
           - create
           - delete
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - template.openshift.io


### PR DESCRIPTION
```
Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-08-19-165854]

2. Deploy ODF4.17 [odf-operator.v4.17.0-80.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster 
NAME                 AGE     PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   5m22s   Ready              2024-08-22T15:07:34Z   4.17.0

4.Check clusterrole status:
+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=*
$ oc get clusterrole ocs-operator.v4.17.0-80.-5ZFqOum5B7idpvPbl6Z3TfkwxJZUIirvkN8UEe -o yaml | grep storageclasses -C 10

- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  verbs:
  - '*'
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch

5. Add create and  delete verbs to ocs-operator clusterrole:
$ oc edit clusterrole ocs-operator.v4.17.0-80.-5ZFqOum5B7idpvPbl6Z3TfkwxJZUIirvkN8UEe
- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  verbs:
  - create
  - delete

6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator-6fbf456698-kn4r7 
pod "ocs-operator-6fbf456698-kn4r7" deleted

$ oc logs ocs-operator-6fbf456698-ldfhh
{"level":"error","ts":"2024-08-22T15:25:30Z","logger":"controllers.StorageCluster","msg":"unable to update clusterroles for metrics exporter","Request.Namespace":"openshift-storage","Request.Name":"ocs-storagecluster","error":"clusterroles.rbac.authorization.k8s.io \"ocs-metrics-exporter\" is forbidden: user \"system:serviceaccount:openshift-storage:ocs-operator\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:openshift-storage\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"storage.k8s.io\"], Resources:[\"storageclasses\"], Verbs:[\"watch\"]}","stacktrace":"github.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).enableMetricsExporter\n\t/remote-source/app/controllers/storagecluster/exporter.go:56\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).reconcilePhases\n\t/remote-source/app/controllers/storagecluster/reconcile.go:598\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).Reconcile\n\t/remote-source/app/controllers/storagecluster/reconcile.go:178\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}

7.Add "watch" verb to ocs-operator clusterrole:
$ oc edit clusterrole ocs-operator.v4.17.0-80.-5ZFqOum5B7idpvPbl6Z3TfkwxJZUIirvkN8UEe
- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  verbs:
  - create
  - delete
  - watch

8.Delete ocs-operator pod and check ocs-operator pod logs:
oviner~$ oc delete pod ocs-operator-6fbf456698-ldfhh 
pod "ocs-operator-6fbf456698-ldfhh" deleted

No Error in logs ["oc logs ocs-operator"]

9.Running Stoageclass test [ storage class creation,pvc and pod with rbd/cephfs]
https://github.com/red-hat-storage/ocs-ci/blob/master/tests/functional/storageclass/test_create_storage_class_pvc.py


```

