### PR TITLE
Reducing the route.openshift.io group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -370,7 +370,11 @@ rules:
   resources:
   - routes
   verbs:
-  - '*'
+  - create
+  - delete
+  - list
+  - update
+  - watch
 - apiGroups:
   - security.openshift.io
   resources:

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -120,7 +120,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=*
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=*
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=create;delete;list;watch;update
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=operatorconditions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=*

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -541,7 +541,11 @@ spec:
           resources:
           - routes
           verbs:
-          - '*'
+          - create
+          - delete
+          - list
+          - update
+          - watch
         - apiGroups:
           - security.openshift.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -550,7 +550,11 @@ spec:
           resources:
           - routes
           verbs:
-          - '*'
+          - create
+          - delete
+          - list
+          - update
+          - watch
         - apiGroups:
           - security.openshift.io
           resources:


### PR DESCRIPTION
```
Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-08-19-165854]

2. Deploy ODF4.17 [4.17.0-84.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster
NAME                 AGE    PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   2d3h   Ready              2024-08-26T08:39:13Z   4.17.0


4.Check clusterrole status:
// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=*
$ oc get clusterrole ocs-operator.v4.17.0-84.-8Luvew6SyBvGMmyBWPm4T89mZWV6JigkKo20ha -o yaml | grep route -C 10 
- apiGroups:
  - route.openshift.io
  resources:
  - routes
  verbs:
  - '*'

5. Add create and  delete verbs to ocs-operator clusterrole:
$ oc edit clusterrole ocs-operator.v4.17.0-84.-8Luvew6SyBvGMmyBWPm4T89mZWV6JigkKo20ha 

- apiGroups:
  - route.openshift.io
  resources:
  - routes
  verbs:
  - create
  - delete

6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
W0828 12:01:43.608164       1 reflector.go:547] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "openshift-storage"
E0828 12:01:43.608205       1 reflector.go:150] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.Route: failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "openshift-storage"
W0828 12:01:45.027206       1 reflector.go:547] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "openshift-storage"
E0828 12:01:45.027236       1 reflector.go:150] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.Route: failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "openshift-storage"


7.Add "watch" and "list verbs to ocs-operator clusterrole:
$ oc edit clusterrole ocs-operator.v4.17.0-8
- apiGroups:
  - route.openshift.io
  resources:
  - routes
  verbs:
  - create
  - delete
  - list
  - watch


8.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator-

$ oc logs ocs-operator
{"level":"error","ts":"2024-08-28T12:05:33Z","logger":"controllers.StorageCluster","msg":"Failed to update Ceph RGW Route Object.","Request.Namespace":"openshift-storage","Request.Name":"ocs-storagecluster","CephRGWRoute":{"name":"ocs-storagecluster-cephobjectstore","namespace":"openshift-storage"},"error":"routes.route.openshift.io \"ocs-storagecluster-cephobjectstore\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot update resource \"routes\" in API group \"route.openshift.io\" in the namespace \"openshift-storage\"","stacktrace":"github.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).createCephRGWRoutes\n\t/remote-source/app/controllers/storagecluster/routes.go:123\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*ocsCephRGWRoutes).ensureCreated\n\t/remote-source/app/controllers/storagecluster/routes.go:49\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).reconcilePhases\n\t/remote-source/app/controllers/storagecluster/reconcile.go:443\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).Reconcile\n\t/remote-source/app/controllers/storagecluster/reconcile.go:178\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}

10.Add "update" verb:
- apiGroups:
  - route.openshift.io
  resources:
  - routes
  verbs:
  - create
  - delete
  - list
  - watch
  - update

11.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator-
$ oc logs ocs-operator
[No errors]

```