### PR TITLE
Reducing the template.openshift.io group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -328,4 +328,9 @@ rules:
   resources:
   - templates
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -115,7 +115,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=get;create;delete
-// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*
+// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -499,7 +499,12 @@ spec:
           resources:
           - templates
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         serviceAccountName: ocs-operator
       - rules:
         - apiGroups:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -508,7 +508,12 @@ spec:
           resources:
           - templates
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         serviceAccountName: ocs-operator
       - rules:
         - apiGroups:


### PR DESCRIPTION
```
Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-08-19-165854]

2. Deploy ODF4.17 [4.17.0-84.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster
NAME                 AGE    PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   3d3h   Ready              2024-08-26T08:39:13Z   4.17.0

4.Check clusterrole status:
// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*
- apiGroups:
  - template.openshift.io
  resources:
  - templates
  verbs:
  - '*'

5. Add create and  delete verbs to ocs-operator clusterrole:
- apiGroups:
  - template.openshift.io
  resources:
  - templates
  verbs:
  - create
  - delete

6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
W0829 12:16:57.004941       1 reflector.go:547] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: failed to list *v1.Template: templates.template.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "templates" in API group "template.openshift.io" in the namespace "openshift-storage-extended"
E0829 12:16:57.004973       1 reflector.go:150] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.Template: failed to list *v1.Template: templates.template.openshift.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "templates" in API group "template.openshift.io" in the namespace "openshift-storage-extended"

7.Add "watch" and "list verbs to ocs-operator clusterrole:
$ oc edit clusterrole ocs-operator.v4.17.0-84.-8Luvew6SyBvGMmyBWPm4T89mZWV6JigkKo20ha
- apiGroups:
  - template.openshift.io
  resources:
  - templates
  verbs:
  - create
  - delete
  - watch
  - list

8.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
{"level":"error","ts":"2024-08-29T12:21:19Z","msg":"Reconciler error","controller":"storagecluster","controllerGroup":"ocs.openshift.io","controllerKind":"StorageCluster","StorageCluster":{"name":"ocs-storagecluster","namespace":"openshift-storage"},"namespace":"openshift-storage","name":"ocs-storagecluster","reconcileID":"f1b3e3f3-e40e-4ec9-8e3c-4aeaac4683bf","error":"failed to create Template : templates.template.openshift.io \"ocs-osd-removal\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot update resource \"templates\" in API group \"template.openshift.io\" in the namespace \"openshift-storage\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}

9.Add "update" verb to ocs-operator clusterrole:
$ oc edit clusterrole ocs-operator.v4.17.0-84.-8Luvew6SyBvGMmyBWPm4T89mZWV6JigkKo20ha
- apiGroups:
  - template.openshift.io
  resources:
  - templates
  verbs:
  - create
  - delete
  - watch
  - list
  - update

10.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
[no errors]

11. Change code:
// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=list;watch;create;update;delete

12.make gen-latest-csv:
export REGISTRY_NAMESPACE=ocs-dev
export IMAGE_TAG=latest
make gen-latest-csv
```