### PR TITLE
Delete console.openshift.io group from clusterrole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -109,12 +109,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - console.openshift.io
-  resources:
-  - consolequickstarts
-  verbs:
-  - '*'
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -118,7 +118,6 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch
-// +kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=*
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=*
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -280,12 +280,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - console.openshift.io
-          resources:
-          - consolequickstarts
-          verbs:
-          - '*'
-        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -289,12 +289,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - console.openshift.io
-          resources:
-          - consolequickstarts
-          verbs:
-          - '*'
-        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases


### PR DESCRIPTION
```
Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-08-19-165854]

2. Deploy ODF4.17 [4.17.0-84.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster
NAME                 AGE    PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   3d3h   Ready              2024-08-26T08:39:13Z   4.17.0

4.Check clusterrole status:
// +kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=*


5. Delete console.openshift.io from clusterrole:
-        - apiGroups:
-          - console.openshift.io
-          resources:
-          - consolequickstarts
-          verbs:
-          - '*'

6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
[no errors]

7.Check the code
I did not find any relevant code.

```