### PR TITLE
Reducing the snapshot.storage.k8s.io group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -315,7 +315,6 @@ rules:
   resources:
   - volumesnapshotclasses
   verbs:
-  - '*'
   - create
   - delete
   - get
@@ -326,7 +325,9 @@ rules:
   resources:
   - volumesnapshots
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -114,7 +114,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=*
+// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=get;create;delete
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=*
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -486,7 +486,6 @@ spec:
           resources:
           - volumesnapshotclasses
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -497,7 +496,9 @@ spec:
           resources:
           - volumesnapshots
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
         - apiGroups:
           - storage.k8s.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -495,7 +495,6 @@ spec:
           resources:
           - volumesnapshotclasses
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -506,7 +505,9 @@ spec:
           resources:
           - volumesnapshots
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
         - apiGroups:
           - storage.k8s.io
           resources:


### PR DESCRIPTION
```

Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-08-31-032707]

2. Deploy ODF4.17 [odf-operator.v4.17.0-53.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster
NAME                 AGE   PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   20h   Ready              2024-09-01T11:48:56Z   4.17.0

4.Check clusterrole status:
// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=*

5. Add "create" and "delete" verbs
delete: https://github.com/red-hat-storage/ocs-operator/blob/main/controllers/storagecluster/volumesnapshotterclasses.go#L174
create: https://github.com/red-hat-storage/ocs-operator/blob/main/controllers/storagecluster/volumesnapshotterclasses.go#L108
$ oc edit clusterrole ocs-operator.v4.17.0-53.-1QHgeXms7btcF6mudj63wa1ngH5P094kD8jAtR
- apiGroups:
  - snapshot.storage.k8s.io
  resources:
  - volumesnapshotclasses
  verbs:
  - create
  - delete
  - get
  - list
  - watch
- apiGroups:
  - snapshot.storage.k8s.io
  resources:
  - volumesnapshotclasses
  - volumesnapshots
  verbs:
  - '*'

- apiGroups:
  - snapshot.storage.k8s.io
  resources:
  - volumesnapshotclasses
  verbs:
  - create
  - delete
  - get
  - list
  - watch
- apiGroups:
  - snapshot.storage.k8s.io
  resources:
  - volumesnapshotclasses
  - volumesnapshots
  verbs:
  - create
  - delete


6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
[No errors]

7.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

8. Ruuning OCS-CI test:
tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py [pass]

9.Add get [based code]
https://github.com/red-hat-storage/ocs-operator/blob/main/controllers/storagecluster/volumesnapshotterclasses.go#L103

10. Change code:
// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots;volumesnapshotclasses,verbs=get;create;delete

11.make gen-latest-csv:
export REGISTRY_NAMESPACE=ocs-dev
export IMAGE_TAG=latest
make gen-latest-csv
```