### PR TITLE
Reducing the ceph.rook.io group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,31 +56,15 @@ rules:
   - ceph.rook.io
   resources:
   - cephblockpoolradosnamespaces
-  verbs:
-  - '*'
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ceph.rook.io
-  resources:
   - cephblockpools
+  - cephclients
   - cephclusters
   - cephfilesystems
+  - cephfilesystemsubvolumegroups
   - cephnfses
   - cephobjectstores
   - cephobjectstoreusers
   - cephrbdmirrors
-  verbs:
-  - '*'
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephclients
-  - cephfilesystemsubvolumegroups
   verbs:
   - create
   - delete

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -107,7 +107,7 @@ var validTopologyLabelKeys = []string{
 }
 
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=*
+// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=watch;create;delete;get;list
 // +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -227,31 +227,15 @@ spec:
           - ceph.rook.io
           resources:
           - cephblockpoolradosnamespaces
-          verbs:
-          - '*'
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ceph.rook.io
-          resources:
           - cephblockpools
+          - cephclients
           - cephclusters
           - cephfilesystems
+          - cephfilesystemsubvolumegroups
           - cephnfses
           - cephobjectstores
           - cephobjectstoreusers
           - cephrbdmirrors
-          verbs:
-          - '*'
-        - apiGroups:
-          - ceph.rook.io
-          resources:
-          - cephclients
-          - cephfilesystemsubvolumegroups
           verbs:
           - create
           - delete

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -236,31 +236,15 @@ spec:
           - ceph.rook.io
           resources:
           - cephblockpoolradosnamespaces
-          verbs:
-          - '*'
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ceph.rook.io
-          resources:
           - cephblockpools
+          - cephclients
           - cephclusters
           - cephfilesystems
+          - cephfilesystemsubvolumegroups
           - cephnfses
           - cephobjectstores
           - cephobjectstoreusers
           - cephrbdmirrors
-          verbs:
-          - '*'
-        - apiGroups:
-          - ceph.rook.io
-          resources:
-          - cephclients
-          - cephfilesystemsubvolumegroups
           verbs:
           - create
           - delete


### PR DESCRIPTION
```
Reducing the snapshot.storage.k8s.io group privileges 

Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-08-31-032707]

2. Deploy ODF4.17 [odf-operator.v4.17.0-53.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster
NAME                 AGE   PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   20h   Ready              2024-09-01T11:48:56Z   4.17.0

4.Check clusterrole status:
// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=*
- apiGroups:
  - ceph.rook.io
  resources:
  - cephblockpoolradosnamespaces
  - cephblockpools
  - cephclusters
  - cephfilesystems
  - cephnfses
  - cephobjectstores
  - cephobjectstoreusers
  - cephrbdmirrors
  verbs:
  - '*'

5. Add "create" and "delete" verbs
$ oc edit clusterrole ocs-operator.v4.17.0-53.-1QHgeXms7btcF6mudj63wa1ngH5P094kD8jAtR
- apiGroups:
  - ceph.rook.io
  resources:
  - cephblockpoolradosnamespaces
  - cephblockpools
  - cephclusters
  - cephfilesystems
  - cephnfses
  - cephobjectstores
  - cephobjectstoreusers
  - cephrbdmirrors
  verbs:
  - create
  - delete

6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
E0902 09:56:03.661896       1 reflector.go:150] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.CephObjectStoreUser: failed to list *v1.CephObjectStoreUser: cephobjectstoreusers.ceph.rook.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "cephobjectstoreusers" in API group "ceph.rook.io" in the namespace "openshift-storage-extended"
E0902 09:57:18.311843       1 reflector.go:150] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.CephCluster: failed to list *v1.CephCluster: cephclusters.ceph.rook.io is forbidden: User "system:serviceaccount:openshift-storage:ocs-operator" cannot list resource "cephclusters" in API group "ceph.rook.io" in the namespace "openshift-storage-extended"

7. Add "list" and "watch" verbs
$ oc edit clusterrole ocs-operator.v4.17.0-53.-1QHgeXms7btcF6mudj63wa1ngH5P094kD8jAtR
- apiGroups:
  - ceph.rook.io
  resources:
  - cephblockpoolradosnamespaces
  - cephblockpools
  - cephclusters
  - cephfilesystems
  - cephnfses
  - cephobjectstores
  - cephobjectstoreusers
  - cephrbdmirrors
  verbs:
  - create
  - delete
  - list
  - watch

8.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
{"level":"error","ts":"2024-09-02T10:01:14Z","logger":"controllers.StorageCluster","msg":"Unable to update CephCluster.","Request.Namespace":"openshift-storage","Request.Name":"ocs-storagecluster","CephCluster":{"name":"ocs-storagecluster-cephcluster","namespace":"openshift-storage"},"error":"cephclusters.ceph.rook.io \"ocs-storagecluster-cephcluster\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot update resource \"cephclusters\" in API group \"ceph.rook.io\" in the namespace \"openshift-storage\"","stacktrace":"github.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*ocsCephCluster).ensureCreated\n\t/remote-source/app/controllers/storagecluster/cephcluster.go:342\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).reconcilePhases\n\t/remote-source/app/controllers/storagecluster/reconcile.go:434\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).Reconcile\n\t/remote-source/app/controllers/storagecluster/reconcile.go:177\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}

9. Add "update" verb:
- apiGroups:
  - ceph.rook.io
  resources:
  - cephblockpoolradosnamespaces
  - cephblockpools
  - cephclusters
  - cephfilesystems
  - cephnfses
  - cephobjectstores
  - cephobjectstoreusers
  - cephrbdmirrors
  verbs:
  - create
  - delete
  - list
  - watch
  - update

10.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
{"level":"error","ts":"2024-09-02T10:12:39Z","logger":"controllers.StorageCluster","msg":"Failed to reconcile metrics exporter.","Request.Namespace":"openshift-storage","Request.Name":"ocs-storagecluster","error":"roles.rbac.authorization.k8s.io \"ocs-metrics-exporter\" is forbidden: user \"system:serviceaccount:openshift-storage:ocs-operator\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:openshift-storage\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"ceph.rook.io\"], Resources:[\"cephblockpools\"], Verbs:[\"get\"]}\n{APIGroups:[\"ceph.rook.io\"], Resources:[\"cephclusters\"], Verbs:[\"get\"]}\n{APIGroups:[\"ceph.rook.io\"], Resources:[\"cephobjectstores\"], Verbs:[\"get\"]}\n{APIGroups:[\"ceph.rook.io\"], Resources:[\"cephrbdmirrors\"], Verbs:[\"get\"]}","stacktrace":"github.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).reconcilePhases\n\t/remote-source/app/controllers/storagecluster/reconcile.go:590\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster.(*StorageClusterReconciler).Reconcile\n\t/remote-source/app/controllers/storagecluster/reconcile.go:177\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}

11. Add "get" verb:
- apiGroups:
  - ceph.rook.io
  resources:
  - cephblockpoolradosnamespaces
  - cephblockpools
  - cephclusters
  - cephfilesystems
  - cephnfses
  - cephobjectstores
  - cephobjectstoreusers
  - cephrbdmirrors
  verbs:
  - create
  - delete
  - list
  - watch
  - update
  - get

12. Change code:
// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=get;list;watch;create;update;delete

13.make gen-latest-csv:
export REGISTRY_NAMESPACE=ocs-dev
export IMAGE_TAG=latest
make gen-latest-csv
```