### PR TITLE
disabling rook mgr module in CephCluster

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -1101,6 +1101,7 @@ func generateMgrSpec(sc *ocsv1.StorageCluster) rookCephv1.MgrSpec {
 		Modules: []rookCephv1.Module{
 			{Name: "pg_autoscaler", Enabled: true},
 			{Name: "balancer", Enabled: true},
+			{Name: "rook", Enabled: false},
 		},
 	}
 

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -306,6 +306,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
 					{Name: "balancer", Enabled: true},
+					{Name: "rook", Enabled: false},
 				},
 			},
 		},
@@ -326,6 +327,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
 					{Name: "balancer", Enabled: true},
+					{Name: "rook", Enabled: false},
 				},
 			},
 		},
@@ -349,6 +351,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
 					{Name: "balancer", Enabled: true},
+					{Name: "rook", Enabled: false},
 				},
 			},
 		},
@@ -362,6 +365,7 @@ func TestGenerateMgrSpec(t *testing.T) {
 				Modules: []rookCephv1.Module{
 					{Name: "pg_autoscaler", Enabled: true},
 					{Name: "balancer", Enabled: true},
+					{Name: "rook", Enabled: false},
 				},
 			},
 		},


### PR DESCRIPTION
Sometimes, during installation with ODF, the rook mgr module in ceph cluster is being enabled. This pr ensures that it is disabled during installation. 

For example:
`sh-4.4$ ceph mgr module ls | grep rook`
`rook                  on`     

With this change:
`sh-4.4$ ceph mgr module ls | grep rook`
`rook                  -`     