### PR TITLE
Fix noobaa-account name to be storageconsumer name

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -134,7 +134,7 @@ func (r *StorageConsumerReconciler) initReconciler(request reconcile.Request) {
 	r.cephClientHealthChecker.Namespace = r.namespace
 
 	r.noobaaAccount = &nbv1.NooBaaAccount{}
-	r.noobaaAccount.Name = "noobaa-remote-" + r.storageConsumer.Name
+	r.noobaaAccount.Name = r.storageConsumer.Name
 	r.noobaaAccount.Namespace = r.storageConsumer.Namespace
 }
 


### PR DESCRIPTION
Currently noobaa would create a secret with the name of the noobaa account prefixed with `noobaa-account`
https://github.com/noobaa/noobaa-operator/blob/002966de315ac4003fb6581fc35affd6f49fdcc8/pkg/noobaaaccount/reconciler.go#L79

This change makes sure the noobaa account secret is created as `noobaa-account-{storageconsumeName}` to be fetched by provider-server