### PR TITLE
provider-api-server: updated client connection error message

### DIFF
--- a/services/provider/client/client.go
+++ b/services/provider/client/client.go
@@ -39,7 +39,7 @@ func NewProviderClient(ctx context.Context, serverAddr string, timeout time.Dura
 	//nolint:golint,all
 	conn, err := grpc.DialContext(apiCtx, serverAddr, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial: %v", err)
+		return nil, fmt.Errorf("failed to dial %v, %v : %v", serverAddr, conn.GetState().String(), err)
 	}
 
 	return &OCSProviderClient{


### PR DESCRIPTION
updated error message for storage client failed to connect. Now error message will show the IP of the provider server.

earlier it showed the following error message which was not clear
```2024-07-10T07:37:41Z    ERROR   Reconciler error        {"controller": "storageclient", "controllerGroup": "ocs.openshift.io", "controllerKind": "StorageClient", "StorageClient": {"name":"storage-client"}, "namespace": "", "name": "storage-client", "reconcileID": "22f6a770-892d-4776-b04b-48af84b8ad4f", "error": "failed to create a new provider client: failed to dial: context deadline exceeded"}```