### PR TITLE
Bug 2270889: [release-4.14] Revert "add topology mode annotation rgw service"

### DIFF
--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -183,7 +183,6 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 					Service: &cephv1.RGWServiceSpec{
 						Annotations: map[string]string{
 							"service.beta.openshift.io/serving-cert-secret-name": fmt.Sprintf("%s-%s-%s", initData.Name, "cos", cephRgwTLSSecretKey),
-							"service.kubernetes.io/topology-mode":                "Auto",
 						},
 					},
 					Instances: gatewayInstances,


### PR DESCRIPTION
This reverts commit f5ba884b012bf0a7acfe612578f1f0091b2d1fd2.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>
(cherry picked from commit ef469011231b9ba925acab1457d9ea02b73039fa)