### PR TITLE
Read secrets for onboarding-token validation

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -198,21 +198,22 @@ type ManageCephCluster struct {
 	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
 	// The default value is `30` minutes.
 	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
-	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.95.
-	// +kubebuilder:validation:Minimum=0.0
-	// +kubebuilder:validation:Maximum=1.0
-	// +nullable
-	FullRatio *float64 `json:"fullRatio,omitempty"`
-	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
+	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.75.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	NearFullRatio *float64 `json:"nearFullRatio,omitempty"`
-	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
+	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.80.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	BackfillFullRatio *float64 `json:"backfillFullRatio,omitempty"`
+	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.85.
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=1.0
+	// +nullable
+	FullRatio *float64 `json:"fullRatio,omitempty"`
+
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FullRatio != nil {
-		in, out := &in.FullRatio, &out.FullRatio
-		*out = new(float64)
-		**out = **in
-	}
 	if in.NearFullRatio != nil {
 		in, out := &in.NearFullRatio, &out.NearFullRatio
 		*out = new(float64)
@@ -323,6 +318,11 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 	}
 	if in.BackfillFullRatio != nil {
 		in, out := &in.BackfillFullRatio, &out.BackfillFullRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.FullRatio != nil {
+		in, out := &in.FullRatio, &out.FullRatio
 		*out = new(float64)
 		**out = **in
 	}

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -752,7 +752,7 @@ spec:
                       backfillFullRatio:
                         description: BackfillFullRatio is the ratio at which the cluster
                           is too full for backfill. Backfill will be disabled if above
-                          this threshold. Default is 0.90.
+                          this threshold. Default is 0.80.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -764,7 +764,7 @@ spec:
                       fullRatio:
                         description: FullRatio is the ratio at which the cluster is
                           considered full and ceph will stop accepting writes. Default
-                          is 0.95.
+                          is 0.85.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -782,7 +782,7 @@ spec:
                       nearFullRatio:
                         description: NearFullRatio is the ratio at which the cluster
                           is considered nearly full and will raise a ceph health warning.
-                          Default is 0.85.
+                          Default is 0.75.
                         maximum: 1
                         minimum: 0
                         nullable: true

--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -83,6 +83,8 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 		},
 	}
 
+	obj := &ocsCephBlockPools{}
+
 	for _, c := range cases {
 		cr := getInitData(c.spec)
 		request := reconcile.Request{
@@ -92,7 +94,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			},
 		}
 		reconciler := createReconcilerFromCustomResources(t, cr)
-		_, err := reconciler.Reconcile(context.TODO(), request)
+		_, err := obj.ensureCreated(&reconciler, cr)
 		assert.NoError(t, err)
 		if c.label == "test-injecting-peer-token-to-cephblockpool" {
 			assertCephBlockPools(t, reconciler, cr, request, true, true)

--- a/controllers/storagecluster/cephrbdmirrors_test.go
+++ b/controllers/storagecluster/cephrbdmirrors_test.go
@@ -41,6 +41,8 @@ func TestCephRbdMirror(t *testing.T) {
 		},
 	}
 
+	obj := &ocsCephRbdMirrors{}
+
 	for _, c := range cases {
 		cr := getInitData(c.spec)
 		request := reconcile.Request{
@@ -50,7 +52,7 @@ func TestCephRbdMirror(t *testing.T) {
 			},
 		}
 		reconciler := createReconcilerFromCustomResources(t, cr)
-		_, err := reconciler.Reconcile(context.TODO(), request)
+		_, err := obj.ensureCreated(&reconciler, cr)
 		assert.NoError(t, err)
 		switch c.label {
 		case "create-ceph-rbd-mirror":

--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -6,6 +6,7 @@ import (
 	ocsclientv1a1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -31,7 +32,7 @@ func (s *storageClient) ensureCreated(r *StorageClusterReconciler, storagecluste
 	storageClient.Name = storagecluster.Name
 	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, storageClient, func() error {
 		if storageClient.Status.ConsumerID == "" {
-			token, err := util.GenerateOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, nil)
+			token, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, nil)
 			if err != nil {
 				return fmt.Errorf("unable to generate onboarding token: %v", err)
 			}

--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -2,12 +2,16 @@ package storagecluster
 
 import (
 	"fmt"
+	"maps"
+	"strconv"
 
 	ocsclientv1a1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -15,6 +19,10 @@ import (
 const (
 	tokenLifetimeInHours         = 48
 	onboardingPrivateKeyFilePath = "/etc/private-key/key"
+
+	ocsClientConfigMapName = "ocs-client-operator-config"
+	deployCSIKey           = "DEPLOY_CSI"
+	manageNoobaaSubKey     = "manageNoobaaSubscription"
 )
 
 type storageClient struct{}
@@ -26,6 +34,10 @@ func (s *storageClient) ensureCreated(r *StorageClusterReconciler, storagecluste
 	if !storagecluster.Spec.AllowRemoteStorageConsumers {
 		r.Log.Info("Spec.AllowRemoteStorageConsumers is disabled")
 		return s.ensureDeleted(r, storagecluster)
+	}
+
+	if err := s.updateClientConfigMap(r, storagecluster.Namespace); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	storageClient := &ocsclientv1a1.StorageClient{}
@@ -59,4 +71,31 @@ func (s *storageClient) ensureDeleted(r *StorageClusterReconciler, storagecluste
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+func (s *storageClient) updateClientConfigMap(r *StorageClusterReconciler, namespace string) error {
+	clientConfig := &corev1.ConfigMap{}
+	clientConfig.Name = ocsClientConfigMapName
+	clientConfig.Namespace = namespace
+
+	if err := r.Client.Get(r.ctx, client.ObjectKeyFromObject(clientConfig), clientConfig); err != nil {
+		r.Log.Error(err, "failed to get ocs client configmap")
+		return err
+	}
+
+	existingData := maps.Clone(clientConfig.Data)
+	if clientConfig.Data == nil {
+		clientConfig.Data = map[string]string{}
+	}
+	clientConfig.Data[deployCSIKey] = "true"
+	clientConfig.Data[manageNoobaaSubKey] = strconv.FormatBool(false)
+
+	if !maps.Equal(clientConfig.Data, existingData) {
+		if err := r.Client.Update(r.ctx, clientConfig); err != nil {
+			r.Log.Error(err, "failed to update client operator's configmap data")
+			return err
+		}
+	}
+
+	return nil
 }

--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -44,7 +44,12 @@ func (s *storageClient) ensureCreated(r *StorageClusterReconciler, storagecluste
 	storageClient.Name = storagecluster.Name
 	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, storageClient, func() error {
 		if storageClient.Status.ConsumerID == "" {
-			token, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, nil)
+
+			privateKey, err := util.GetParsedPrivateKey(r.Client, r.OperatorNamespace)
+			if err != nil {
+				return fmt.Errorf("unable to get Parsed Private Key: %v", err)
+			}
+			token, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, privateKey, nil)
 			if err != nil {
 				return fmt.Errorf("unable to generate onboarding token: %v", err)
 			}

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -225,7 +225,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.ConfigMap{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&corev1.Secret{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&routev1.Route{}).
 		Owns(&templatev1.Template{}).
 		Watches(&storagev1.StorageClass{}, enqueueStorageClusterRequest).

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -23,6 +23,9 @@ const (
 	// this value is empty if the operator is running with clusterScope.
 	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
 
+	// PodNamespaceEnvVar is the env variable for the pod namespace
+	PodNamespaceEnvVar = "POD_NAMESPACE"
+
 	// SingleNodeEnvVar is set if StorageCluster needs to be deployed on a single node
 	SingleNodeEnvVar = "SINGLE_NODE"
 
@@ -46,6 +49,16 @@ const (
 
 	OdfInfoNamespacedNameClaimName = "odfinfo.odf.openshift.io"
 )
+
+var podNamespace = os.Getenv(PodNamespaceEnvVar)
+
+// GetPodNamespace returns the namespace where the pod is deployed
+func GetPodNamespace() string {
+	if podNamespace == "" {
+		panic(fmt.Errorf("%s must be set", PodNamespaceEnvVar))
+	}
+	return podNamespace
+}
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes
 func GetWatchNamespace() (string, error) {

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -752,7 +752,7 @@ spec:
                       backfillFullRatio:
                         description: BackfillFullRatio is the ratio at which the cluster
                           is too full for backfill. Backfill will be disabled if above
-                          this threshold. Default is 0.90.
+                          this threshold. Default is 0.80.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -764,7 +764,7 @@ spec:
                       fullRatio:
                         description: FullRatio is the ratio at which the cluster is
                           considered full and ceph will stop accepting writes. Default
-                          is 0.95.
+                          is 0.85.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -782,7 +782,7 @@ spec:
                       nearFullRatio:
                         description: NearFullRatio is the ratio at which the cluster
                           is considered nearly full and will raise a ceph health warning.
-                          Default is 0.85.
+                          Default is 0.75.
                         maximum: 1
                         minimum: 0
                         nullable: true

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -629,6 +629,10 @@ spec:
                 - name: ONBOARDING_TOKEN_LIFETIME
                 - name: UX_BACKEND_PORT
                 - name: TLS_ENABLED
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 image: quay.io/ocs-dev/ocs-operator:latest
                 imagePullPolicy: IfNotPresent
                 name: ux-backend-server
@@ -639,8 +643,6 @@ spec:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
                 volumeMounts:
-                - mountPath: /etc/private-key
-                  name: onboarding-private-key
                 - mountPath: /etc/tls/private
                   name: ux-cert-secret
               - args:
@@ -676,10 +678,6 @@ spec:
                 operator: Equal
                 value: "true"
               volumes:
-              - name: onboarding-private-key
-                secret:
-                  optional: true
-                  secretName: onboarding-private-key
               - name: ux-proxy-secret
                 secret:
                   secretName: ux-backend-proxy

--- a/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-binding.yaml
+++ b/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-binding.yaml
@@ -7,6 +7,5 @@ roleRef:
   kind: Role
   name: onboarding-validation-keys-generator
 subjects:
-- kind: ServiceAccount
-  name: onboarding-validation-keys-generator
-  namespace: openshift-storage
+  - kind: ServiceAccount
+    name: onboarding-validation-keys-generator

--- a/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-role.yaml
+++ b/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-role.yaml
@@ -3,19 +3,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onboarding-validation-keys-generator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-    - get
-    - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list

--- a/deploy/ocs-operator/manifests/provider-role-binding.yaml
+++ b/deploy/ocs-operator/manifests/provider-role-binding.yaml
@@ -7,5 +7,5 @@ roleRef:
   kind: Role
   name: ocs-provider-server
 subjects:
-- kind: ServiceAccount
-  name: ocs-provider-server
+  - kind: ServiceAccount
+    name: ocs-provider-server

--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -3,75 +3,75 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-provider-server
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  - services
-  verbs:
-  - get
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephfilesystemsubvolumegroups
-  - cephblockpoolradosnamespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageconsumers
-  - storageconsumers/finalizers
-  - storageconsumers/status
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-  - update
-  - patch
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephclients
-  verbs:
-  - get
-- apiGroups:
-    - ""
-  resources:
-    - pods
-  verbs:
-    - get
-    - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storagerequests
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephfilesystemsubvolumegroups
+      - cephblockpoolradosnamespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageconsumers
+      - storageconsumers/finalizers
+      - storageconsumers/status
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephclients
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storagerequests
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -752,7 +752,7 @@ spec:
                       backfillFullRatio:
                         description: BackfillFullRatio is the ratio at which the cluster
                           is too full for backfill. Backfill will be disabled if above
-                          this threshold. Default is 0.90.
+                          this threshold. Default is 0.80.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -764,7 +764,7 @@ spec:
                       fullRatio:
                         description: FullRatio is the ratio at which the cluster is
                           considered full and ceph will stop accepting writes. Default
-                          is 0.95.
+                          is 0.85.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -782,7 +782,7 @@ spec:
                       nearFullRatio:
                         description: NearFullRatio is the ratio at which the cluster
                           is considered nearly full and will raise a ceph health warning.
-                          Default is 0.85.
+                          Default is 0.75.
                         maximum: 1
                         minimum: 0
                         nullable: true

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -198,21 +198,22 @@ type ManageCephCluster struct {
 	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
 	// The default value is `30` minutes.
 	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
-	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.95.
-	// +kubebuilder:validation:Minimum=0.0
-	// +kubebuilder:validation:Maximum=1.0
-	// +nullable
-	FullRatio *float64 `json:"fullRatio,omitempty"`
-	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
+	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.75.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	NearFullRatio *float64 `json:"nearFullRatio,omitempty"`
-	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
+	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.80.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	BackfillFullRatio *float64 `json:"backfillFullRatio,omitempty"`
+	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.85.
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=1.0
+	// +nullable
+	FullRatio *float64 `json:"fullRatio,omitempty"`
+
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FullRatio != nil {
-		in, out := &in.FullRatio, &out.FullRatio
-		*out = new(float64)
-		**out = **in
-	}
 	if in.NearFullRatio != nil {
 		in, out := &in.NearFullRatio, &out.NearFullRatio
 		*out = new(float64)
@@ -323,6 +318,11 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 	}
 	if in.BackfillFullRatio != nil {
 		in, out := &in.BackfillFullRatio, &out.BackfillFullRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.FullRatio != nil {
+		in, out := &in.FullRatio, &out.FullRatio
 		*out = new(float64)
 		**out = **in
 	}

--- a/rbac/onboarding-validation-keys-generator-binding.yaml
+++ b/rbac/onboarding-validation-keys-generator-binding.yaml
@@ -7,6 +7,5 @@ roleRef:
   kind: Role
   name: onboarding-validation-keys-generator
 subjects:
-- kind: ServiceAccount
-  name: onboarding-validation-keys-generator
-  namespace: openshift-storage
+  - kind: ServiceAccount
+    name: onboarding-validation-keys-generator

--- a/rbac/onboarding-validation-keys-generator-role.yaml
+++ b/rbac/onboarding-validation-keys-generator-role.yaml
@@ -3,19 +3,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onboarding-validation-keys-generator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-    - get
-    - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list

--- a/rbac/provider-role-binding.yaml
+++ b/rbac/provider-role-binding.yaml
@@ -7,5 +7,5 @@ roleRef:
   kind: Role
   name: ocs-provider-server
 subjects:
-- kind: ServiceAccount
-  name: ocs-provider-server
+  - kind: ServiceAccount
+    name: ocs-provider-server

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -3,75 +3,75 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-provider-server
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  - services
-  verbs:
-  - get
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephfilesystemsubvolumegroups
-  - cephblockpoolradosnamespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageconsumers
-  - storageconsumers/finalizers
-  - storageconsumers/status
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-  - update
-  - patch
-- apiGroups:
-  - ceph.rook.io
-  resources:
-  - cephclients
-  verbs:
-  - get
-- apiGroups:
-    - ""
-  resources:
-    - pods
-  verbs:
-    - get
-    - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storagerequests
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ocs.openshift.io
-  resources:
-  - storageclusters
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephfilesystemsubvolumegroups
+      - cephblockpoolradosnamespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageconsumers
+      - storageconsumers/finalizers
+      - storageconsumers/status
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephclients
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storagerequests
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list

--- a/services/provider/main.go
+++ b/services/provider/main.go
@@ -21,11 +21,7 @@ func main() {
 
 	klog.Info("Starting Provider API server")
 
-	namespace, err := util.GetWatchNamespace()
-	if err != nil {
-		klog.Errorf("failed to get provider cluster namespace. %v", err)
-		return
-	}
+	namespace := util.GetPodNamespace()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -443,6 +443,11 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 	noobaaOperatorSecret.Namespace = s.namespace
 
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(noobaaOperatorSecret), noobaaOperatorSecret); err != nil {
+		if kerrors.IsNotFound(err) {
+			// ignoring because it is a provider cluster and the noobaa secret does not exist
+			return extR, nil
+
+		}
 		return nil, fmt.Errorf("failed to get %s secret. %v", noobaaOperatorSecret.Name, err)
 	}
 
@@ -469,9 +474,9 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 	extR = append(extR, &pb.ExternalResource{
 		Name: "noobaa-remote-join-secret",
 		Kind: "Secret",
-		Data: mustMarshal(map[string][]byte{
-			"auth_token": authToken,
-			"mgmt_addr":  []byte(noobaaMgmtAddress),
+		Data: mustMarshal(map[string]string{
+			"auth_token": string(authToken),
+			"mgmt_addr":  noobaaMgmtAddress,
 		}),
 	})
 

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -120,7 +120,13 @@ func (s *OCSProviderServer) OnboardConsumer(ctx context.Context, req *pb.Onboard
 		return nil, status.Errorf(codes.InvalidArgument, "onboarding ticket is not valid. %v", err)
 	}
 
-	storageConsumerUUID, err := s.consumerManager.Create(ctx, req, int(onboardingTicket.StorageQuotaInGiB))
+	if onboardingTicket.SubjectRole != services.ClientRole {
+		err := fmt.Errorf("unsupported ticket role for consumer %q, found %s, expected %s", req.ConsumerName, onboardingTicket.SubjectRole, services.ClientRole)
+		klog.Error(err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	storageConsumerUUID, err := s.consumerManager.Create(ctx, req, int(*onboardingTicket.StorageQuotaInGiB))
 	if err != nil {
 		if !kerrors.IsAlreadyExists(err) && err != errTicketAlreadyExists {
 			return nil, status.Errorf(codes.Internal, "failed to create storageConsumer %q. %v", req.ConsumerName, err)
@@ -565,8 +571,17 @@ func decodeAndValidateTicket(ticket string, pubKey *rsa.PublicKey) (*services.On
 		return nil, fmt.Errorf("failed to unmarshal onboarding ticket message. %v", err)
 	}
 
-	if ticketData.StorageQuotaInGiB > math.MaxInt {
-		return nil, fmt.Errorf("invalid value sent in onboarding ticket, storage quota should be greater than 0 and less than %v: %v", math.MaxInt, ticketData.StorageQuotaInGiB)
+	switch ticketData.SubjectRole {
+	case services.ClientRole:
+		if ticketData.StorageQuotaInGiB != nil {
+			quota := *ticketData.StorageQuotaInGiB
+			if quota > math.MaxInt {
+				return nil, fmt.Errorf("invalid value sent in onboarding ticket, storage quota should be greater than 0 and less than %v: %v", math.MaxInt, quota)
+			}
+		}
+	case services.PeerRole:
+	default:
+		return nil, fmt.Errorf("invalid onboarding ticket subject role")
 	}
 
 	signature, err := base64.StdEncoding.DecodeString(ticketArr[1])

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -64,9 +64,9 @@ var noobaaSpec = &nbv1.NooBaaSpec{
 	},
 }
 
-var joinSecret = map[string][]byte{
-	"auth_token": []byte("authToken"),
-	"mgmt_addr":  []byte("noobaaMgmtAddress"),
+var joinSecret = map[string]string{
+	"auth_token": "authToken",
+	"mgmt_addr":  "noobaaMgmtAddress",
 }
 
 var mockExtR = map[string]*externalResource{

--- a/services/types.go
+++ b/services/types.go
@@ -1,7 +1,15 @@
 package services
 
+type OnboardingSubjectRole string
+
+const (
+	ClientRole OnboardingSubjectRole = "ocs-client"
+	PeerRole   OnboardingSubjectRole = "ocs-peer"
+)
+
 type OnboardingTicket struct {
-	ID                string `json:"id"`
-	ExpirationDate    int64  `json:"expirationDate,string"`
-	StorageQuotaInGiB uint   `json:"storageQuotaInGiB,omitempty"`
+	ID                string                `json:"id"`
+	ExpirationDate    int64                 `json:"expirationDate,string"`
+	SubjectRole       OnboardingSubjectRole `json:"subjectRole"`
+	StorageQuotaInGiB *uint                 `json:"storageQuotaInGiB,omitempty"`
 }

--- a/services/ux-backend/handlers/common.go
+++ b/services/ux-backend/handlers/common.go
@@ -1,5 +1,21 @@
 package handlers
 
+import "os"
+
 const (
 	ContentTypeTextPlain = "text/plain"
 )
+
+var namespace string
+
+// returns namespace found in pod
+func GetPodNamespace() string {
+	if namespace != "" {
+		return namespace
+	}
+	if ns := os.Getenv("OPERATOR_NAMESPACE"); ns != "" {
+		namespace = ns
+		return namespace
+	}
+	panic("Value for env var 'POD_NAMESPACE' is empty")
+}

--- a/services/ux-backend/handlers/onboarding/clienttokens/handler.go
+++ b/services/ux-backend/handlers/onboarding/clienttokens/handler.go
@@ -1,4 +1,4 @@
-package onboardingtokens
+package clienttokens
 
 import (
 	"encoding/json"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
@@ -57,8 +58,9 @@ func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int
 		}
 		storageQuotaInGiB = ptr.To(unitAsGiB * quota.Value)
 	}
-	if onboardingToken, err := util.GenerateOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, storageQuotaInGiB); err != nil {
-		klog.Errorf("failed to get onboardig token: %v", err)
+
+	if onboardingToken, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, storageQuotaInGiB); err != nil {
+		klog.Errorf("failed to get onboarding token: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
 
@@ -74,10 +76,11 @@ func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int
 			klog.Errorf("failed write data to response writer: %v", err)
 		}
 	}
+
 }
 
 func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
-	klog.Info("Only POST method should be used to send data to this endpoint /onboarding-tokens")
+	klog.Infof("Only POST method should be used to send data to this endpoint %s", r.URL.Path)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
 	w.Header().Set("Allow", "POST")

--- a/services/ux-backend/handlers/onboarding/clienttokens/handler.go
+++ b/services/ux-backend/handlers/onboarding/clienttokens/handler.go
@@ -11,10 +11,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-)
-
-const (
-	onboardingPrivateKeyFilePath = "/etc/private-key/key"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var unitToGib = map[string]uint{
@@ -23,20 +20,29 @@ var unitToGib = map[string]uint{
 	"Pi": 1024 * 1024,
 }
 
-func HandleMessage(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int) {
+func HandleMessage(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int, cl client.Client) {
 	switch r.Method {
 	case "POST":
-		handlePost(w, r, tokenLifetimeInHours)
+		handlePost(w, r, tokenLifetimeInHours, cl)
 	default:
 		handleUnsupportedMethod(w, r)
 	}
 }
 
-func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int) {
+func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int, cl client.Client) {
 	var storageQuotaInGiB *uint
 	// When ContentLength is 0 that means request body is empty and
 	// storage quota is unlimited
 	var err error
+
+	ns := handlers.GetPodNamespace()
+
+	privateKey, err := util.GetParsedPrivateKey(cl, ns)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to get private key: %v", err), http.StatusBadRequest)
+		return
+	}
+
 	if r.ContentLength != 0 {
 		var quota = struct {
 			Value uint   `json:"value"`
@@ -59,7 +65,7 @@ func handlePost(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int
 		storageQuotaInGiB = ptr.To(unitAsGiB * quota.Value)
 	}
 
-	if onboardingToken, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, storageQuotaInGiB); err != nil {
+	if onboardingToken, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, privateKey, storageQuotaInGiB); err != nil {
 		klog.Errorf("failed to get onboarding token: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)

--- a/services/ux-backend/handlers/onboarding/peertokens/handler.go
+++ b/services/ux-backend/handlers/onboarding/peertokens/handler.go
@@ -1,0 +1,55 @@
+package peertokens
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	onboardingPrivateKeyFilePath = "/etc/private-key/key"
+)
+
+func HandleMessage(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int) {
+	switch r.Method {
+	case "POST":
+		handlePost(w, r, tokenLifetimeInHours)
+	default:
+		handleUnsupportedMethod(w, r)
+	}
+}
+
+func handlePost(w http.ResponseWriter, _ *http.Request, tokenLifetimeInHours int) {
+	if onboardingToken, err := util.GeneratePeerOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath); err != nil {
+		klog.Errorf("failed to get onboarding token: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+
+		if _, err := w.Write([]byte("Failed to generate token")); err != nil {
+			klog.Errorf("failed write data to response writer, %v", err)
+		}
+	} else {
+		klog.Info("onboarding token generated successfully")
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+
+		if _, err = w.Write([]byte(onboardingToken)); err != nil {
+			klog.Errorf("failed write data to response writer: %v", err)
+		}
+	}
+}
+
+func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
+	klog.Infof("Only POST method should be used to send data to this endpoint %s", r.URL.Path)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	w.Header().Set("Allow", "POST")
+
+	if _, err := w.Write([]byte(fmt.Sprintf("Unsupported method : %s", r.Method))); err != nil {
+		klog.Errorf("failed write data to response writer: %v", err)
+	}
+}

--- a/services/ux-backend/handlers/onboarding/peertokens/handler.go
+++ b/services/ux-backend/handlers/onboarding/peertokens/handler.go
@@ -6,25 +6,35 @@ import (
 
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
-
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	onboardingPrivateKeyFilePath = "/etc/private-key/key"
 )
 
-func HandleMessage(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int) {
+func HandleMessage(w http.ResponseWriter, r *http.Request, tokenLifetimeInHours int, cl client.Client) {
 	switch r.Method {
 	case "POST":
-		handlePost(w, r, tokenLifetimeInHours)
+		handlePost(w, r, tokenLifetimeInHours, cl)
 	default:
 		handleUnsupportedMethod(w, r)
 	}
 }
 
-func handlePost(w http.ResponseWriter, _ *http.Request, tokenLifetimeInHours int) {
-	if onboardingToken, err := util.GeneratePeerOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath); err != nil {
+func handlePost(w http.ResponseWriter, _ *http.Request, tokenLifetimeInHours int, cl client.Client) {
+	var err error
+
+	ns := handlers.GetPodNamespace()
+
+	privateKey, err := util.GetParsedPrivateKey(cl, ns)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to get private key: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if onboardingToken, err := util.GeneratePeerOnboardingToken(tokenLifetimeInHours, privateKey); err != nil {
 		klog.Errorf("failed to get onboarding token: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)

--- a/services/ux-backend/main.go
+++ b/services/ux-backend/main.go
@@ -10,7 +10,12 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/onboarding/clienttokens"
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/onboarding/peertokens"
 
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type serverConfig struct {
@@ -63,18 +68,23 @@ func main() {
 		os.Exit(-1)
 	}
 
+	cl, err := newClient()
+	if err != nil {
+		klog.Exitf("failed to create client: %v", err)
+	}
+
 	// TODO: remove '/onboarding-tokens' in the future
 	http.HandleFunc("/onboarding-tokens", func(w http.ResponseWriter, r *http.Request) {
 		// Set the Deprecation header
 		w.Header().Set("Deprecation", "true") // Standard "Deprecation" header
 		w.Header().Set("Link", "/onboarding/client-tokens; rel=\"alternate\"")
-		clienttokens.HandleMessage(w, r, config.tokenLifetimeInHours)
+		clienttokens.HandleMessage(w, r, config.tokenLifetimeInHours, cl)
 	})
 	http.HandleFunc("/onboarding/client-tokens", func(w http.ResponseWriter, r *http.Request) {
-		clienttokens.HandleMessage(w, r, config.tokenLifetimeInHours)
+		clienttokens.HandleMessage(w, r, config.tokenLifetimeInHours, cl)
 	})
 	http.HandleFunc("/onboarding/peer-tokens", func(w http.ResponseWriter, r *http.Request) {
-		peertokens.HandleMessage(w, r, config.tokenLifetimeInHours)
+		peertokens.HandleMessage(w, r, config.tokenLifetimeInHours, cl)
 	})
 
 	klog.Info("ux backend server listening on port ", config.listenPort)
@@ -93,4 +103,26 @@ func main() {
 	}
 	log.Fatal(err)
 
+}
+
+func newClient() (client.Client, error) {
+	klog.Info("Setting up k8s client")
+	scheme := runtime.NewScheme()
+	if err := ocsv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	config, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sClient, nil
 }

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -645,10 +645,6 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 						Name: "ux-backend-server",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name:      "onboarding-private-key",
-								MountPath: "/etc/private-key",
-							},
-							{
 								Name:      "ux-cert-secret",
 								MountPath: "/etc/tls/private",
 							},
@@ -673,6 +669,14 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 							{
 								Name:  "TLS_ENABLED",
 								Value: os.Getenv("TLS_ENABLED"),
+							},
+							{
+								Name: util.OperatorNamespaceEnvVar,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
@@ -716,15 +720,6 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 					},
 				},
 				Volumes: []corev1.Volume{
-					{
-						Name: "onboarding-private-key",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: "onboarding-private-key",
-								Optional:   ptr.To(true),
-							},
-						},
-					},
 					{
 						Name: "ux-proxy-secret",
 						VolumeSource: corev1.VolumeSource{

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -198,21 +198,22 @@ type ManageCephCluster struct {
 	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
 	// The default value is `30` minutes.
 	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
-	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.95.
-	// +kubebuilder:validation:Minimum=0.0
-	// +kubebuilder:validation:Maximum=1.0
-	// +nullable
-	FullRatio *float64 `json:"fullRatio,omitempty"`
-	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
+	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.75.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	NearFullRatio *float64 `json:"nearFullRatio,omitempty"`
-	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
+	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.80.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	BackfillFullRatio *float64 `json:"backfillFullRatio,omitempty"`
+	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.85.
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=1.0
+	// +nullable
+	FullRatio *float64 `json:"fullRatio,omitempty"`
+
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
 }

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FullRatio != nil {
-		in, out := &in.FullRatio, &out.FullRatio
-		*out = new(float64)
-		**out = **in
-	}
 	if in.NearFullRatio != nil {
 		in, out := &in.NearFullRatio, &out.NearFullRatio
 		*out = new(float64)
@@ -323,6 +318,11 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 	}
 	if in.BackfillFullRatio != nil {
 		in, out := &in.BackfillFullRatio, &out.BackfillFullRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.FullRatio != nil {
+		in, out := &in.FullRatio, &out.FullRatio
 		*out = new(float64)
 		**out = **in
 	}


### PR DESCRIPTION
This PR is a copy PR of https://github.com/red-hat-storage/ocs-operator/pull/2715

I faced git account issues, I was not able to recover my account, so created a new PR with new account

This PR reads the secrets instead of reading the secrets from the volume mounts.
whenever the new onboarding secrets are created, it takes more time to read the secrets from the volume mounts,
The user clicks the rotate onboarding keys, the kubernetes still uses the old public, private keys , the new keys are mounted later, So this PR will read the secrets directly from the kubernetes secrets.