### PR TITLE
Use msgrv2 always for all ODF modes(internal,external,provider)

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -605,13 +605,11 @@ func getNetworkSpec(sc ocsv1.StorageCluster) rookCephv1.NetworkSpec {
 	// respect both the old way and the new way for enabling HostNetwork
 	networkSpec.HostNetwork = networkSpec.HostNetwork || sc.Spec.HostNetwork
 
-	// If it's not an external and not a provider cluster always require msgr2
-	if !sc.Spec.AllowRemoteStorageConsumers && !sc.Spec.ExternalStorage.Enable {
-		if networkSpec.Connections == nil {
-			networkSpec.Connections = &rookCephv1.ConnectionsSpec{}
-		}
-		networkSpec.Connections.RequireMsgr2 = true
+	if networkSpec.Connections == nil {
+		networkSpec.Connections = &rookCephv1.ConnectionsSpec{}
 	}
+	// Always require msgr2 for all modes of ODF
+	networkSpec.Connections.RequireMsgr2 = true
 
 	return networkSpec
 }

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -1290,7 +1290,9 @@ func TestCephClusterNetworkConnectionsSpec(t *testing.T) {
 			},
 			ccSpec: rookCephv1.ClusterSpec{
 				Network: rookCephv1.NetworkSpec{
-					Connections: &rookCephv1.ConnectionsSpec{},
+					Connections: &rookCephv1.ConnectionsSpec{
+						RequireMsgr2: true,
+					},
 				},
 			},
 		},
@@ -1308,6 +1310,7 @@ func TestCephClusterNetworkConnectionsSpec(t *testing.T) {
 			ccSpec: rookCephv1.ClusterSpec{
 				Network: rookCephv1.NetworkSpec{
 					Connections: &rookCephv1.ConnectionsSpec{
+						RequireMsgr2: true,
 						Encryption: &rookCephv1.EncryptionSpec{
 							Enabled: true,
 						},
@@ -1329,6 +1332,7 @@ func TestCephClusterNetworkConnectionsSpec(t *testing.T) {
 			ccSpec: rookCephv1.ClusterSpec{
 				Network: rookCephv1.NetworkSpec{
 					Connections: &rookCephv1.ConnectionsSpec{
+						RequireMsgr2: true,
 						Compression: &rookCephv1.CompressionSpec{
 							Enabled: true,
 						},
@@ -1353,6 +1357,7 @@ func TestCephClusterNetworkConnectionsSpec(t *testing.T) {
 			ccSpec: rookCephv1.ClusterSpec{
 				Network: rookCephv1.NetworkSpec{
 					Connections: &rookCephv1.ConnectionsSpec{
+						RequireMsgr2: true,
 						Encryption: &rookCephv1.EncryptionSpec{
 							Enabled: true,
 						},
@@ -1380,6 +1385,7 @@ func TestCephClusterNetworkConnectionsSpec(t *testing.T) {
 			ccSpec: rookCephv1.ClusterSpec{
 				Network: rookCephv1.NetworkSpec{
 					Connections: &rookCephv1.ConnectionsSpec{
+						RequireMsgr2: true,
 						Encryption: &rookCephv1.EncryptionSpec{
 							Enabled: false,
 						},

--- a/controllers/util/csi_options.go
+++ b/controllers/util/csi_options.go
@@ -13,22 +13,7 @@ func GetCephFSKernelMountOptions(sc *ocsv1.StorageCluster) string {
 		return "ms_mode=secure"
 	}
 
-	// If Encryption is not enabled, but Compression or RequireMsgr2 is enabled, use prefer-crc mode
-	if sc.Spec.Network != nil && sc.Spec.Network.Connections != nil &&
-		((sc.Spec.Network.Connections.Compression != nil && sc.Spec.Network.Connections.Compression.Enabled) ||
-			sc.Spec.Network.Connections.RequireMsgr2) {
-		return "ms_mode=prefer-crc"
-	}
-
-	// Network spec always has higher precedence even in the External or Provider cluster. so they are checked first above
-
-	// None of Encryption, Compression, RequireMsgr2 are enabled on the StorageCluster
-	// If it's an External or Provider cluster, We don't require msgr2 by default so no mount options are needed
-	if sc.Spec.ExternalStorage.Enable || sc.Spec.AllowRemoteStorageConsumers {
-		return "ms_mode=legacy"
-	}
-	// If none of the above cases apply, We set RequireMsgr2 true by default on the cephcluster
-	// so we need to set the mount options to prefer-crc
+	// If encryption is not enabled, use prefer-crc mode
 	return "ms_mode=prefer-crc"
 }
 

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -769,7 +769,7 @@ func TestOCSProviderServerGetStorageClaimConfig(t *testing.T) {
 					CephFs: &csiopv1a1.CephFsConfigSpec{
 						SubVolumeGroup: "cephFilesystemSubVolumeGroup",
 						KernelMountOptions: map[string]string{
-							"ms_mode": "legacy",
+							"ms_mode": "prefer-crc",
 						},
 					},
 				},


### PR DESCRIPTION
Initially in 4.13 when encryption in-transit was implemented we started
to use msgrv2 for internal mode only. External mode & Provider mode were
excluded.

For external mode the concern was the availability of msgrv2
port always on the RHCS cluster. But now we have reached ceph v18 &
msgrv2 is being by default on since ceph Nautilus 14.2. So we
can now use mgsr2 for external mode.

For provider mode the concern was availability of the required kernel
versions on old client clusters. But now that concern also seems no
longer valid. So we can now use msgrv2 for provider mode as well.

Also as we would always use msgrv2, we can now simplify the
GetCephFSKernelMountOptions function to remove the conditional checks.
If encryption is enabled use "secure" otherwise "prefer-crc".

*This change can still break external mode/provider mode CI. But as we are just getting started with 4.18 this seems like a safe time to test this out & fix any follow-up issues if they come.*