### PR TITLE
update the cephblockpool reonciler to disable mirroring

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -86,7 +86,7 @@ type StorageClusterSpec struct {
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
 	// Mirroring specifies data mirroring configuration for the storage cluster.
 	// This configuration will only be applied to resources managed by the operator.
-	Mirroring MirroringSpec `json:"mirroring,omitempty"`
+	Mirroring *MirroringSpec `json:"mirroring,omitempty"`
 	// OverprovisionControl specifies the allowed hard-limit PVs overprovisioning relative to
 	// the effective usable storage capacity.
 	OverprovisionControl []OverprovisionControlSpec `json:"overprovisionControl,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1048,7 +1048,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Arbiter.DeepCopyInto(&out.Arbiter)
-	in.Mirroring.DeepCopyInto(&out.Mirroring)
+	if in.Mirroring != nil {
+		in, out := &in.Mirroring, &out.Mirroring
+		*out = new(MirroringSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OverprovisionControl != nil {
 		in, out := &in.OverprovisionControl, &out.OverprovisionControl
 		*out = make([]OverprovisionControlSpec, len(*in))

--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -93,10 +93,14 @@ func (o *ocsCephBlockPools) reconcileCephBlockPool(r *StorageClusterReconciler, 
 		cephBlockPool.Spec.PoolSpec.Replicated = generateCephReplicatedSpec(storageCluster, "data")
 		cephBlockPool.Spec.PoolSpec.EnableRBDStats = true
 
-		if storageCluster.Spec.Mirroring.Enabled {
-			cephBlockPool.Spec.PoolSpec.Mirroring.Enabled = true
-			cephBlockPool.Spec.PoolSpec.Mirroring.Mode = "image"
-			cephBlockPool.Spec.PoolSpec.Mirroring.Peers = o.addPeerSecretsToCephBlockPool(r, storageCluster, cephBlockPool.Name, cephBlockPool.Namespace)
+		if storageCluster.Spec.Mirroring != nil {
+			if storageCluster.Spec.Mirroring.Enabled {
+				cephBlockPool.Spec.PoolSpec.Mirroring.Enabled = true
+				cephBlockPool.Spec.PoolSpec.Mirroring.Mode = "image"
+				cephBlockPool.Spec.PoolSpec.Mirroring.Peers = o.addPeerSecretsToCephBlockPool(r, storageCluster, cephBlockPool.Name, cephBlockPool.Namespace)
+			} else {
+				cephBlockPool.Spec.PoolSpec.Mirroring = cephv1.MirroringSpec{Enabled: false}
+			}
 		}
 		return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)
 	})
@@ -249,10 +253,14 @@ func (o *ocsCephBlockPools) reconcileNonResilientCephBlockPool(r *StorageCluster
 			}
 			cephBlockPool.Spec.PoolSpec.EnableRBDStats = true
 
-			if storageCluster.Spec.Mirroring.Enabled {
-				cephBlockPool.Spec.PoolSpec.Mirroring.Enabled = true
-				cephBlockPool.Spec.PoolSpec.Mirroring.Mode = "image"
-				cephBlockPool.Spec.PoolSpec.Mirroring.Peers = o.addPeerSecretsToCephBlockPool(r, storageCluster, cephBlockPool.Name, cephBlockPool.Namespace)
+			if storageCluster.Spec.Mirroring != nil {
+				if storageCluster.Spec.Mirroring.Enabled {
+					cephBlockPool.Spec.PoolSpec.Mirroring.Enabled = true
+					cephBlockPool.Spec.PoolSpec.Mirroring.Mode = "image"
+					cephBlockPool.Spec.PoolSpec.Mirroring.Peers = o.addPeerSecretsToCephBlockPool(r, storageCluster, cephBlockPool.Name, cephBlockPool.Namespace)
+				} else {
+					cephBlockPool.Spec.PoolSpec.Mirroring = cephv1.MirroringSpec{Enabled: false}
+				}
 			}
 			return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)
 		})

--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -55,7 +55,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			label:                "test-injecting-peer-token-to-cephblockpool",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{testPeerSecretName},
 				},
@@ -65,7 +65,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			label:                "test-injecting-empty-peer-token-to-cephblockpool",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{},
 				},
@@ -75,7 +75,7 @@ func TestInjectingPeerTokenToCephBlockPool(t *testing.T) {
 			label:                "test-injecting-invalid-peer-token-cephblockpool",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{"wrong-secret-name"},
 				},

--- a/controllers/storagecluster/cephrbdmirrors.go
+++ b/controllers/storagecluster/cephrbdmirrors.go
@@ -92,7 +92,7 @@ func (obj *ocsCephRbdMirrors) ensureCreated(r *StorageClusterReconciler, instanc
 		return reconcile.Result{}, err
 	}
 
-	if !instance.Spec.Mirroring.Enabled {
+	if instance.Spec.Mirroring == nil || !instance.Spec.Mirroring.Enabled {
 		return reconcile.Result{}, r.deleteCephRbdMirrorInstance(cephRbdMirrors)
 	}
 
@@ -168,7 +168,7 @@ ceph config rm mgr mgr/rbd_support/log_level
 		echo "completed"`
 
 	// Mirroring is enabled but the debug logging is disabled
-	if sc.Spec.Mirroring.Enabled && !rbdMirrorDebugLoggingEnabled {
+	if sc.Spec.Mirroring != nil && sc.Spec.Mirroring.Enabled && !rbdMirrorDebugLoggingEnabled {
 
 		err := r.Client.Create(r.ctx, getRbdMirrorDebugLoggingJob(sc, enableRbdMirrorDebugLoggingJobName, enableRbdMirrorDebugLoggingCommands))
 		if err != nil && !errors.IsAlreadyExists(err) {
@@ -190,7 +190,7 @@ ceph config rm mgr mgr/rbd_support/log_level
 		rbdMirrorDebugLoggingEnabled = true
 	}
 	// Mirroring is disabled but the debug logging is enabled
-	if !sc.Spec.Mirroring.Enabled && rbdMirrorDebugLoggingEnabled {
+	if (sc.Spec.Mirroring == nil || !sc.Spec.Mirroring.Enabled) && rbdMirrorDebugLoggingEnabled {
 		err := r.Client.Create(r.ctx, getRbdMirrorDebugLoggingJob(sc, disableRbdMirrorDebugLoggingJobName, disableRbdMirrorDebugLoggingCommands))
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return reconcile.Result{}, err

--- a/controllers/storagecluster/cephrbdmirrors_test.go
+++ b/controllers/storagecluster/cephrbdmirrors_test.go
@@ -24,7 +24,7 @@ func TestCephRbdMirror(t *testing.T) {
 			label:                "create-ceph-rbd-mirror",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled:         true,
 					PeerSecretNames: []string{testPeerSecretName},
 				},
@@ -34,7 +34,7 @@ func TestCephRbdMirror(t *testing.T) {
 			label:                "delete-ceph-rbd-mirror",
 			createRuntimeObjects: false,
 			spec: &api.StorageClusterSpec{
-				Mirroring: api.MirroringSpec{
+				Mirroring: &api.MirroringSpec{
 					Enabled: false,
 				},
 			},

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -86,7 +86,7 @@ type StorageClusterSpec struct {
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
 	// Mirroring specifies data mirroring configuration for the storage cluster.
 	// This configuration will only be applied to resources managed by the operator.
-	Mirroring MirroringSpec `json:"mirroring,omitempty"`
+	Mirroring *MirroringSpec `json:"mirroring,omitempty"`
 	// OverprovisionControl specifies the allowed hard-limit PVs overprovisioning relative to
 	// the effective usable storage capacity.
 	OverprovisionControl []OverprovisionControlSpec `json:"overprovisionControl,omitempty"`

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -1048,7 +1048,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Arbiter.DeepCopyInto(&out.Arbiter)
-	in.Mirroring.DeepCopyInto(&out.Mirroring)
+	if in.Mirroring != nil {
+		in, out := &in.Mirroring, &out.Mirroring
+		*out = new(MirroringSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OverprovisionControl != nil {
 		in, out := &in.OverprovisionControl, &out.OverprovisionControl
 		*out = make([]OverprovisionControlSpec, len(*in))

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -86,7 +86,7 @@ type StorageClusterSpec struct {
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
 	// Mirroring specifies data mirroring configuration for the storage cluster.
 	// This configuration will only be applied to resources managed by the operator.
-	Mirroring MirroringSpec `json:"mirroring,omitempty"`
+	Mirroring *MirroringSpec `json:"mirroring,omitempty"`
 	// OverprovisionControl specifies the allowed hard-limit PVs overprovisioning relative to
 	// the effective usable storage capacity.
 	OverprovisionControl []OverprovisionControlSpec `json:"overprovisionControl,omitempty"`

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -1048,7 +1048,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Arbiter.DeepCopyInto(&out.Arbiter)
-	in.Mirroring.DeepCopyInto(&out.Mirroring)
+	if in.Mirroring != nil {
+		in, out := &in.Mirroring, &out.Mirroring
+		*out = new(MirroringSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OverprovisionControl != nil {
 		in, out := &in.OverprovisionControl, &out.OverprovisionControl
 		*out = make([]OverprovisionControlSpec, len(*in))


### PR DESCRIPTION
When mirroring on storageCluster was disabled, the cephblockpool mirroring was not disabled, this could break the DR as MCO enables/disables the mirroring on the cephblockpool via storageCluster.

Hence, with this PR we are making the mirroring spec on the storageCluster as a pointer and enabling/disabling mirroring on cephblockpool only if the value is set. If mirroring is set to nil other controller will be able to make changes on the mirroring field on the cephblockpool.