### PR TITLE
restore default affinity for noobaa standalone

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -161,7 +161,10 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	placement := getPlacement(sc, component)
 
 	nb.Spec.Tolerations = placement.Tolerations
-	nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
+	// if we are "noobaa-standalone" and placement is not set - don't set affinity
+	if !r.IsNoobaaStandalone || ok {
+		nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
+	}
 	nb.Spec.DBVolumeResources = &corev1.VolumeResourceRequirements{
 		Limits:   dBVolumeResources.Limits,
 		Requests: dBVolumeResources.Requests,


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=2311551

We revert the nodeAffinity change to apply only to cases where users explicitly set nodeAffinity in storage cluster spec.