### PR TITLE
Bug 2313492: [release-4.14] Remove check of object type & return in enqueueStorageClusterRequest

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -128,16 +128,6 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	enqueueStorageClusterRequest := handler.EnqueueRequestsFromMapFunc(
 		func(context context.Context, obj client.Object) []reconcile.Request {
-
-			ocinit, ok := obj.(*ocsv1.OCSInitialization)
-			if !ok {
-				return []reconcile.Request{}
-			}
-
-			if ocinit.Status.Phase != util.PhaseReady {
-				return []reconcile.Request{}
-			}
-
 			// Get the StorageCluster objects
 			scList := &ocsv1.StorageClusterList{}
 			err := r.Client.List(context, scList, &client.ListOptions{Namespace: obj.GetNamespace()})

--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -10,7 +10,7 @@ GINKGO=$GOBIN/ginkgo
 
 if ! [ -x "$GINKGO" ]; then
 	echo "Installing GINKGO"
-	go install -v github.com/onsi/ginkgo/v2/ginkgo@latest
+	go install -v github.com/onsi/ginkgo/v2/ginkgo
 else
 	echo "GINKO binary found at $GINKGO"
 fi


### PR DESCRIPTION
The enqueueStorageClusterRequest event handler is used to enqueue a reconcile request for the controller from the watched objects. Although the handle is being used by all the watched objects, but it checks the object type and returns if the object is not of type OCSInitialization. Due to this when any thing happens with the watched objects other than OCSInitialization, the reconcile request is not enqueued and the controller does not reconcile the object.

The watch process on certain resources we had on our code is broken in 4.14. But the issue was being masked due to the side effect of other problem where we were doing continuous reconcile each second.Recently Nitin fixed that Bug so now unnecessary reconciles don't happen anymore,https://github.com/red-hat-storage/ocs-operator/pull/2624.

So, Now the issue was noticed as creation of the Virtual Machine CRD was not triggering a reconcile and thus not creating the special Storageclass that it should have. Upon debugging we found the enqueue function we use on 4.14 just returns if the resource is not OCSInitialization, but we are still using that enqueue function for all the watches we have. Hence a reconcile request never gets queued for the Watched Resources.

The issue is not present on 4.15 onwards as I had unintentionally fixed the bug while working on the Separation of ceph toolbox from ocsinitialization as a part of the Multiple Storagecluster Epic in 4.15, https://github.com/red-hat-storage/ocs-operator/pull/2240.

### Hence this bug requires specific fix only in 4.14.z.