### PR TITLE
remove resource limits on ocs-metrics-exporter

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -69,10 +69,6 @@ var (
 				"memory": resource.MustParse("50Mi"),
 				"cpu":    resource.MustParse("50m"),
 			},
-			Limits: corev1.ResourceList{
-				"memory": resource.MustParse("150Mi"),
-				"cpu":    resource.MustParse("150m"),
-			},
 		},
 	}
 

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -92,9 +92,6 @@ spec:
           readOnly: true
           mountPath: /etc/kube-rbac-policy
       - resources:
-          limits:
-            cpu: 150m
-            memory: 150Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -145,4 +142,3 @@ spec:
       - name: ocs-metrics-exporter-kube-rbac-proxy-config
         secret:
           secretName: ocs-metrics-exporter-kube-rbac-proxy-config
-


### PR DESCRIPTION
removing the limits on ocs-metrics-exporter, the in memory cache scales
with the amount of PVs in the cluster making it hard to point out an
upper limit for the memory.

Signed-off-by: Divyansh Kamboj <dkamboj@redhat.com>