### PR TITLE
Update the Prometheus rule alerts acc to specified value & correct the default values in API desc

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -198,21 +198,22 @@ type ManageCephCluster struct {
 	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
 	// The default value is `30` minutes.
 	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
-	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.95.
-	// +kubebuilder:validation:Minimum=0.0
-	// +kubebuilder:validation:Maximum=1.0
-	// +nullable
-	FullRatio *float64 `json:"fullRatio,omitempty"`
-	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
+	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.75.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	NearFullRatio *float64 `json:"nearFullRatio,omitempty"`
-	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
+	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.80.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	BackfillFullRatio *float64 `json:"backfillFullRatio,omitempty"`
+	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.85.
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=1.0
+	// +nullable
+	FullRatio *float64 `json:"fullRatio,omitempty"`
+
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FullRatio != nil {
-		in, out := &in.FullRatio, &out.FullRatio
-		*out = new(float64)
-		**out = **in
-	}
 	if in.NearFullRatio != nil {
 		in, out := &in.NearFullRatio, &out.NearFullRatio
 		*out = new(float64)
@@ -323,6 +318,11 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 	}
 	if in.BackfillFullRatio != nil {
 		in, out := &in.BackfillFullRatio, &out.BackfillFullRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.FullRatio != nil {
+		in, out := &in.FullRatio, &out.FullRatio
 		*out = new(float64)
 		**out = **in
 	}

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -752,7 +752,7 @@ spec:
                       backfillFullRatio:
                         description: BackfillFullRatio is the ratio at which the cluster
                           is too full for backfill. Backfill will be disabled if above
-                          this threshold. Default is 0.90.
+                          this threshold. Default is 0.80.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -764,7 +764,7 @@ spec:
                       fullRatio:
                         description: FullRatio is the ratio at which the cluster is
                           considered full and ceph will stop accepting writes. Default
-                          is 0.95.
+                          is 0.85.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -782,7 +782,7 @@ spec:
                       nearFullRatio:
                         description: NearFullRatio is the ratio at which the cluster
                           is considered nearly full and will raise a ceph health warning.
-                          Default is 0.85.
+                          Default is 0.75.
                         maximum: 1
                         minimum: 0
                         nullable: true

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -752,7 +752,7 @@ spec:
                       backfillFullRatio:
                         description: BackfillFullRatio is the ratio at which the cluster
                           is too full for backfill. Backfill will be disabled if above
-                          this threshold. Default is 0.90.
+                          this threshold. Default is 0.80.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -764,7 +764,7 @@ spec:
                       fullRatio:
                         description: FullRatio is the ratio at which the cluster is
                           considered full and ceph will stop accepting writes. Default
-                          is 0.95.
+                          is 0.85.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -782,7 +782,7 @@ spec:
                       nearFullRatio:
                         description: NearFullRatio is the ratio at which the cluster
                           is considered nearly full and will raise a ceph health warning.
-                          Default is 0.85.
+                          Default is 0.75.
                         maximum: 1
                         minimum: 0
                         nullable: true

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -752,7 +752,7 @@ spec:
                       backfillFullRatio:
                         description: BackfillFullRatio is the ratio at which the cluster
                           is too full for backfill. Backfill will be disabled if above
-                          this threshold. Default is 0.90.
+                          this threshold. Default is 0.80.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -764,7 +764,7 @@ spec:
                       fullRatio:
                         description: FullRatio is the ratio at which the cluster is
                           considered full and ceph will stop accepting writes. Default
-                          is 0.95.
+                          is 0.85.
                         maximum: 1
                         minimum: 0
                         nullable: true
@@ -782,7 +782,7 @@ spec:
                       nearFullRatio:
                         description: NearFullRatio is the ratio at which the cluster
                           is considered nearly full and will raise a ceph health warning.
-                          Default is 0.85.
+                          Default is 0.75.
                         maximum: 1
                         minimum: 0
                         nullable: true

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -198,21 +198,22 @@ type ManageCephCluster struct {
 	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
 	// The default value is `30` minutes.
 	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
-	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.95.
-	// +kubebuilder:validation:Minimum=0.0
-	// +kubebuilder:validation:Maximum=1.0
-	// +nullable
-	FullRatio *float64 `json:"fullRatio,omitempty"`
-	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
+	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.75.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	NearFullRatio *float64 `json:"nearFullRatio,omitempty"`
-	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
+	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.80.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	BackfillFullRatio *float64 `json:"backfillFullRatio,omitempty"`
+	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.85.
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=1.0
+	// +nullable
+	FullRatio *float64 `json:"fullRatio,omitempty"`
+
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FullRatio != nil {
-		in, out := &in.FullRatio, &out.FullRatio
-		*out = new(float64)
-		**out = **in
-	}
 	if in.NearFullRatio != nil {
 		in, out := &in.NearFullRatio, &out.NearFullRatio
 		*out = new(float64)
@@ -323,6 +318,11 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 	}
 	if in.BackfillFullRatio != nil {
 		in, out := &in.BackfillFullRatio, &out.BackfillFullRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.FullRatio != nil {
+		in, out := &in.FullRatio, &out.FullRatio
 		*out = new(float64)
 		**out = **in
 	}

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -198,21 +198,22 @@ type ManageCephCluster struct {
 	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
 	// The default value is `30` minutes.
 	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
-	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.95.
-	// +kubebuilder:validation:Minimum=0.0
-	// +kubebuilder:validation:Maximum=1.0
-	// +nullable
-	FullRatio *float64 `json:"fullRatio,omitempty"`
-	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
+	// NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.75.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	NearFullRatio *float64 `json:"nearFullRatio,omitempty"`
-	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
+	// BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.80.
 	// +kubebuilder:validation:Minimum=0.0
 	// +kubebuilder:validation:Maximum=1.0
 	// +nullable
 	BackfillFullRatio *float64 `json:"backfillFullRatio,omitempty"`
+	// FullRatio is the ratio at which the cluster is considered full and ceph will stop accepting writes. Default is 0.85.
+	// +kubebuilder:validation:Minimum=0.0
+	// +kubebuilder:validation:Maximum=1.0
+	// +nullable
+	FullRatio *float64 `json:"fullRatio,omitempty"`
+
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
 }

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FullRatio != nil {
-		in, out := &in.FullRatio, &out.FullRatio
-		*out = new(float64)
-		**out = **in
-	}
 	if in.NearFullRatio != nil {
 		in, out := &in.NearFullRatio, &out.NearFullRatio
 		*out = new(float64)
@@ -323,6 +318,11 @@ func (in *ManageCephCluster) DeepCopyInto(out *ManageCephCluster) {
 	}
 	if in.BackfillFullRatio != nil {
 		in, out := &in.BackfillFullRatio, &out.BackfillFullRatio
+		*out = new(float64)
+		**out = **in
+	}
+	if in.FullRatio != nil {
+		in, out := &in.FullRatio, &out.FullRatio
 		*out = new(float64)
 		**out = **in
 	}


### PR DESCRIPTION
### Update prometheusRule to use the fullRatio values from storageCluster CR
Earlier the cluster utilization alert rules (CephClusterNearFull,
CephClusterCriticallyFull, CephClusterReadOnly) and the osd alert rules
(CephOSDNearFull, CephOSDCriticallyFull) were hardcoded to use the
nearFullRatio 0.75, criticallyFullRatio 0.80, and fullRatio 0.85 values.

But these values are now configurable on the storageCluster CR. So the
prometheus rules for these alerts will now be updated to use the
specified values if provided in the storageCluster CR.

This also includes the refactor of the changing the prometheus rule
process. The function is now easier to read, maintain & expand.
Also add tests for prometheus rule changing process.

### Correct the API desc about the defaults for Full Ratios in OCS-Operator
While adding the fields the description of the fields were directly
lifted off from rook-operator. The values of NearFull, BackfillFull &
Full in rook are 0.85, 0.90 & 0.95 respectively. But in OCS Operator
we set these values to 0.75, 0.80 & 0.85 respectively with the help
of the rook-config-override ConfigMap. So the description of the fields
in the API should reflect the actual values that are set in OCS.

Story-https://issues.redhat.com/browse/RHSTOR-6497
BZ-https://bugzilla.redhat.com/show_bug.cgi?id=2303342
