### PR TITLE
Prevent noobaaccount creation in provider cluster

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -437,6 +437,11 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 	noobaaOperatorSecret.Namespace = s.namespace
 
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(noobaaOperatorSecret), noobaaOperatorSecret); err != nil {
+		if kerrors.IsNotFound(err) {
+			// ignoring because it is a provider cluster and the noobaa secret does not exist
+			return extR, nil
+
+		}
 		return nil, fmt.Errorf("failed to get %s secret. %v", noobaaOperatorSecret.Name, err)
 	}
 
@@ -463,9 +468,9 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 	extR = append(extR, &pb.ExternalResource{
 		Name: "noobaa-remote-join-secret",
 		Kind: "Secret",
-		Data: mustMarshal(map[string][]byte{
-			"auth_token": authToken,
-			"mgmt_addr":  []byte(noobaaMgmtAddress),
+		Data: mustMarshal(map[string]string{
+			"auth_token": string(authToken),
+			"mgmt_addr":  noobaaMgmtAddress,
 		}),
 	})
 

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -64,9 +64,9 @@ var noobaaSpec = &nbv1.NooBaaSpec{
 	},
 }
 
-var joinSecret = map[string][]byte{
-	"auth_token": []byte("authToken"),
-	"mgmt_addr":  []byte("noobaaMgmtAddress"),
+var joinSecret = map[string]string{
+	"auth_token": "authToken",
+	"mgmt_addr":  "noobaaMgmtAddress",
 }
 
 var mockExtR = map[string]*externalResource{


### PR DESCRIPTION
Since a provider cluster already has a NooBaa system and does not require a NooBaa account to connect to a remote cluster, unlike client clusters. A NooBaa account only needs to be created if the storage consumer is for a client cluster.
Changes in this PR -
- Ignore Creation of noobaa account if cluster is a provider cluster by match cluster id
- Ignore adding noobaa resources to Storage config if on provider cluster