### PR TITLE
Fix metrics params for k8s service monitor

### DIFF
--- a/templates/k8smetricsservicemonitor.go
+++ b/templates/k8smetricsservicemonitor.go
@@ -8,18 +8,18 @@ import (
 
 var params = map[string][]string{
 	"match[]": {
-		"{__name__='kube_node_status_condition'}",
-		"{__name__='kube_persistentvolume_info'}",
-		"{__name__='kube_storageclass_info'}",
-		"{__name__='kube_persistentvolumeclaim_info'}",
-		"{__name__='kube_deployment_spec_replicas'}",
-		"{__name__='kube_pod_status_phase'}",
-		"{__name__='kubelet_volume_stats_capacity_bytes'}",
-		"{__name__='kubelet_volume_stats_used_bytes'}",
-		"{__name__='node_disk_read_time_seconds_total'}",
-		"{__name__='node_disk_write_time_seconds_total'}",
-		"{__name__='node_disk_reads_completed_total'}",
-		"{__name__='node_disk_writes_completed_total'}",
+		"{__name__=\"kube_node_status_condition\"}",
+		"{__name__=\"kube_persistentvolume_info\"}",
+		"{__name__=\"kube_storageclass_info\"}",
+		"{__name__=\"kube_persistentvolumeclaim_info\"}",
+		"{__name__=\"kube_deployment_spec_replicas\"}",
+		"{__name__=\"kube_pod_status_phase\"}",
+		"{__name__=\"kubelet_volume_stats_capacity_bytes\"}",
+		"{__name__=\"kubelet_volume_stats_used_bytes\"}",
+		"{__name__=\"node_disk_read_time_seconds_total\"}",
+		"{__name__=\"node_disk_write_time_seconds_total\"}",
+		"{__name__=\"node_disk_reads_completed_total\"}",
+		"{__name__=\"node_disk_writes_completed_total\"}",
 	},
 }
 

--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"os"
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
@@ -29,9 +30,8 @@ var PrometheusSpecTemplate = promv1.PrometheusSpec{
 		ListenLocal:            true,
 		Resources:              defaults.MonitoringResources["prometheus"],
 		Containers: []corev1.Container{{
-			Name: "kube-rbac-proxy",
-			// Tech-debt to include kube-rbac-proxy image from environment
-			Image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0",
+			Name:  "kube-rbac-proxy",
+			Image: os.Getenv("KUBE_RBAC_PROXY_IMAGE"),
 			Args: []string{
 				fmt.Sprintf("--secure-listen-address=0.0.0.0:%d", KubeRBACProxyPortNumber),
 				"--upstream=http://127.0.0.1:9090/",


### PR DESCRIPTION
Currently the params are generated in k8sservice monitor to federate in-cluster kube metrics as below which is wrong. This patch fixes the correct string params.
```
params:
      match[]:
      - '{__name__=''kube_node_status_condition''}'
      - '{__name__=''kube_persistentvolume_info''}'
      - '{__name__=''kube_storageclass_info''}'
      - '{__name__=''kube_persistentvolumeclaim_info''}'
      - '{__name__=''kube_deployment_spec_replicas''}'
      - '{__name__=''kube_pod_status_phase''}'
      - '{__name__=''kubelet_volume_stats_capacity_bytes''}'
      - '{__name__=''kubelet_volume_stats_used_bytes''}'
      - '{__name__=''node_disk_read_time_seconds_total''}'
      - '{__name__=''node_disk_write_time_seconds_total''}'
      - '{__name__=''node_disk_reads_completed_total''}'
      - '{__name__=''node_disk_writes_completed_total''}'
```

Also fixed tech debt to fetch kube-rbac-proxy image from environment variables