### PR TITLE
Read secrets for client-onboarding-token-validation

### DIFF
--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	tokenLifetimeInHours         = 48
-	onboardingPrivateKeyFilePath = "/etc/private-key/key"
+	tokenLifetimeInHours = 48
 
 	ocsClientConfigMapName = "ocs-client-operator-config"
 	manageNoobaaSubKey     = "manageNoobaaSubscription"
@@ -47,7 +46,11 @@ func (s *storageClient) ensureCreated(r *StorageClusterReconciler, storagecluste
 	storageClient.Name = storagecluster.Name
 	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, storageClient, func() error {
 		if storageClient.Status.ConsumerID == "" {
-			token, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, onboardingPrivateKeyFilePath, nil, storagecluster.UID)
+			privateKey, err := util.LoadOnboardingValidationPrivateKey(r.ctx, r.Client, r.OperatorNamespace)
+			if err != nil {
+				return fmt.Errorf("unable to get Parsed Private Key: %v", err)
+			}
+			token, err := util.GenerateClientOnboardingToken(tokenLifetimeInHours, privateKey, nil, storagecluster.UID)
 			if err != nil {
 				return fmt.Errorf("unable to generate onboarding token: %v", err)
 			}

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -647,8 +647,6 @@ spec:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
                 volumeMounts:
-                - mountPath: /etc/private-key
-                  name: onboarding-private-key
                 - mountPath: /etc/tls/private
                   name: ux-cert-secret
               - args:
@@ -684,10 +682,6 @@ spec:
                 operator: Equal
                 value: "true"
               volumes:
-              - name: onboarding-private-key
-                secret:
-                  optional: true
-                  secretName: onboarding-private-key
               - name: ux-proxy-secret
                 secret:
                   secretName: ux-backend-proxy

--- a/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-role.yaml
+++ b/deploy/ocs-operator/manifests/onboarding-validation-keys-generator-role.yaml
@@ -19,3 +19,10 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters/finalizers
+    verbs:
+      - update
+

--- a/onboarding-validation-keys-generator/main.go
+++ b/onboarding-validation-keys-generator/main.go
@@ -81,7 +81,7 @@ func main() {
 		klog.Exitf("failed to delete public secret: %v", err)
 	}
 
-	err = controllerutil.SetOwnerReference(storageCluster, privateSecret, cl.Scheme())
+	err = controllerutil.SetControllerReference(storageCluster, privateSecret, cl.Scheme())
 	if err != nil {
 		klog.Exitf("failed to set owner reference for private secret: %v", err)
 	}
@@ -95,7 +95,7 @@ func main() {
 		klog.Exitf("failed to create private secret: %v", err)
 	}
 
-	err = controllerutil.SetOwnerReference(storageCluster, publicSecret, cl.Scheme())
+	err = controllerutil.SetControllerReference(storageCluster, publicSecret, cl.Scheme())
 	if err != nil {
 		klog.Exitf("failed to set owner reference for public secret: %v", err)
 	}

--- a/rbac/onboarding-validation-keys-generator-role.yaml
+++ b/rbac/onboarding-validation-keys-generator-role.yaml
@@ -19,3 +19,10 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters/finalizers
+    verbs:
+      - update
+

--- a/services/ux-backend/main.go
+++ b/services/ux-backend/main.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/klog/v2"
 )
 

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -645,10 +645,6 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 						Name: "ux-backend-server",
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name:      "onboarding-private-key",
-								MountPath: "/etc/private-key",
-							},
-							{
 								Name:      "ux-cert-secret",
 								MountPath: "/etc/tls/private",
 							},
@@ -724,15 +720,6 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 					},
 				},
 				Volumes: []corev1.Volume{
-					{
-						Name: "onboarding-private-key",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: "onboarding-private-key",
-								Optional:   ptr.To(true),
-							},
-						},
-					},
 					{
 						Name: "ux-proxy-secret",
 						VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
This PR reads the secrets instead of reading the secrets from the volume mounts.
whenever the new onboarding secrets are created, it takes more time to read the secrets from the volume mounts,
The user clicks the rotate onboarding keys, the kubernetes still uses the old public, private keys , the new keys are mounted later, So this PR will read the secrets directly from the kubernetes secrets.