### PR TITLE
Include Encryption In-Transit state as part of the desired state hash sent to clients

### DIFF
--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -275,6 +275,15 @@ func TestGetExternalResources(t *testing.T) {
 	ocsSubscription.Spec = ocsSubscriptionSpec
 	assert.NoError(t, client.Create(ctx, ocsSubscription))
 
+	storageCluster := &ocsv1.StorageCluster{
+		Spec: ocsv1.StorageClusterSpec{
+			AllowRemoteStorageConsumers: true,
+		},
+	}
+	storageCluster.Name = "test-storagecluster"
+	storageCluster.Namespace = serverNamespace
+	assert.NoError(t, client.Create(ctx, storageCluster))
+
 	// When ocsv1alpha1.StorageConsumerStateReady
 	req := pb.StorageConfigRequest{
 		StorageConsumerUUID: string(consumerResource.UID),


### PR DESCRIPTION
When in-transit encryption is enabled/disabled the kernel mount option for cephFS needs to be updated between prefer-crc/secure. So the desired state hash needs to include the EiT state, so that if the EiT state is changed the desired state hash will change and the client will reconcile to get the updated mount option.
