### PR TITLE
Fix an incorrect log statement

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -11,13 +11,14 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"math"
 	"net"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/utils/ptr"
 
 	"github.com/blang/semver/v4"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
@@ -247,7 +248,7 @@ func newClient() (client.Client, error) {
 	}
 	err = corev1.AddToScheme(scheme)
 	if err != nil {
-		return nil, fmt.Errorf("failed to add ocsv1alpha1 to scheme. %v", err)
+		return nil, fmt.Errorf("failed to add corev1 to scheme. %v", err)
 	}
 	err = rookCephv1.AddToScheme(scheme)
 	if err != nil {


### PR DESCRIPTION
Currently the log displayed when there is a failure to add corev1 to provider server scheme is incorrect and shows
`failed to add ocsv1alpha1 to scheme`. This patch fixes the above