### PR TITLE
controller: update the odf-info to include client identification info

### DIFF
--- a/api/v1alpha1/odfinfoconfig.go
+++ b/api/v1alpha1/odfinfoconfig.go
@@ -22,6 +22,7 @@ import "k8s.io/apimachinery/pkg/types"
 type ConnectedClient struct {
 	Name      string `yaml:"name"`
 	ClusterID string `yaml:"clusterId"`
+	ClientID  string `yaml:"clientId"`
 }
 
 // InfoStorageCluster describes information regarding a storage cluster key
@@ -29,6 +30,7 @@ type InfoStorageCluster struct {
 	NamespacedName          types.NamespacedName `yaml:"namespacedName"`
 	StorageProviderEndpoint string               `yaml:"storageProviderEndpoint"`
 	CephClusterFSID         string               `yaml:"cephClusterFSID"`
+	StorageClusterUID       string               `yaml:"storageClusterUID"`
 }
 
 // OdfInfoData describes odf-info CM's data

--- a/controllers/storagecluster/odfinfoconfig.go
+++ b/controllers/storagecluster/odfinfoconfig.go
@@ -151,6 +151,7 @@ func getOdfInfoData(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCl
 			NamespacedName:          client.ObjectKeyFromObject(storageCluster),
 			StorageProviderEndpoint: storageCluster.Status.StorageProviderEndpoint,
 			CephClusterFSID:         cephFSId,
+			StorageClusterUID:       string(storageCluster.UID),
 		},
 	}
 	yamlData, err := yaml.Marshal(data)
@@ -176,6 +177,7 @@ func getConnectedClients(r *StorageClusterReconciler, storageCluster *ocsv1.Stor
 		newConnectedClient := ocsv1a1.ConnectedClient{
 			Name:      name,
 			ClusterID: clusterID,
+			ClientID:  string(storageConsumer.UID),
 		}
 		connectedClients = append(connectedClients, newConnectedClient)
 	}

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/odfinfoconfig.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/odfinfoconfig.go
@@ -22,6 +22,7 @@ import "k8s.io/apimachinery/pkg/types"
 type ConnectedClient struct {
 	Name      string `yaml:"name"`
 	ClusterID string `yaml:"clusterId"`
+	ClientID  string `yaml:"clientId"`
 }
 
 // InfoStorageCluster describes information regarding a storage cluster key
@@ -29,6 +30,7 @@ type InfoStorageCluster struct {
 	NamespacedName          types.NamespacedName `yaml:"namespacedName"`
 	StorageProviderEndpoint string               `yaml:"storageProviderEndpoint"`
 	CephClusterFSID         string               `yaml:"cephClusterFSID"`
+	StorageClusterUID       string               `yaml:"storageClusterUID"`
 }
 
 // OdfInfoData describes odf-info CM's data

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/odfinfoconfig.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/odfinfoconfig.go
@@ -22,6 +22,7 @@ import "k8s.io/apimachinery/pkg/types"
 type ConnectedClient struct {
 	Name      string `yaml:"name"`
 	ClusterID string `yaml:"clusterId"`
+	ClientID  string `yaml:"clientId"`
 }
 
 // InfoStorageCluster describes information regarding a storage cluster key
@@ -29,6 +30,7 @@ type InfoStorageCluster struct {
 	NamespacedName          types.NamespacedName `yaml:"namespacedName"`
 	StorageProviderEndpoint string               `yaml:"storageProviderEndpoint"`
 	CephClusterFSID         string               `yaml:"cephClusterFSID"`
+	StorageClusterUID       string               `yaml:"storageClusterUID"`
 }
 
 // OdfInfoData describes odf-info CM's data


### PR DESCRIPTION
To uniquely indentify a storageConsumer from outside a cluster we need StorageClusterUID and ClientID (storageConsumerUID). Add this information to the odf-info configMap so that MCO or any other component can easily identify the consumer from these two information.