### PR TITLE
Reducing the core group privileges

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -109,27 +109,24 @@ rules:
   - events
   - nodes
   - persistentvolumeclaims
+  - persistentvolumes
   - pods
   - secrets
   - serviceaccounts
   - services
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - '*'
-  - get
-  - list
-  - watch
 - apiGroups:
   - k8s.cni.cncf.io
   resources:

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -114,7 +114,7 @@ var validTopologyLabelKeys = []string{
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclusters;cephblockpools;cephfilesystems;cephnfses;cephobjectstores;cephobjectstoreusers;cephrbdmirrors;cephblockpoolradosnamespaces,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=watch;create;delete;get;list
-// +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
+// +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -280,27 +280,24 @@ spec:
           - events
           - nodes
           - persistentvolumeclaims
+          - persistentvolumes
           - pods
           - secrets
           - serviceaccounts
           - services
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
           - namespaces
           verbs:
           - get
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumes
-          verbs:
-          - '*'
-          - get
-          - list
-          - watch
         - apiGroups:
           - k8s.cni.cncf.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -289,27 +289,24 @@ spec:
           - events
           - nodes
           - persistentvolumeclaims
+          - persistentvolumes
           - pods
           - secrets
           - serviceaccounts
           - services
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
           - namespaces
           verbs:
           - get
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumes
-          verbs:
-          - '*'
-          - get
-          - list
-          - watch
         - apiGroups:
           - k8s.cni.cncf.io
           resources:


### PR DESCRIPTION
```
Procedure:
1. Deploy OCP4.17 [4.17.0-0.nightly-2024-10-06-021039]

2. Deploy OCS4.17 [4.17.0-117.stable]

3.Verify storagecluster in Ready State
$ oc get storagecluster
NAME                 AGE   PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   37h   Ready              2024-10-08T16:24:24Z   4.17.0

4.Check clusterrole status:
// +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=*
$ oc edit clusterrole ocs-operator.v4.17.0-117-arcDX0KWGNx65tdjyZ3BPWOaOrKVTvxGaY4Adk
- apiGroups:
  - ""
  resources:
  - configmaps
  - endpoints
  - events
  - nodes
  - persistentvolumeclaims
  - pods
  - secrets
  - serviceaccounts
  - services
  verbs:
  - '*'

5. Add "create" and "delete" verbs
- apiGroups:
  - ""
  resources:
  - configmaps
  - endpoints
  - events
  - nodes
  - persistentvolumeclaims
  - pods
  - secrets
  - serviceaccounts
  - services
  verbs:
  - create
  - delete

6.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
E1010 09:57:25.116815       1 reflector.go:158] "Unhandled Error" err="sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot list resource \"secrets\" in API group \"\" in the namespace \"openshift-storage-extended\"" logger="UnhandledError"
{"level":"error","ts":"2024-10-10T09:58:43Z","logger":"controller-runtime.source.EventHandler","msg":"failed to get informer from cache","error":"Timeout: failed waiting for *v1.PersistentVolumeClaim Informer to sync","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:76\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1\n\t/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/loop.go:53\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/loop.go:54\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:64"}

7. Add "list" and "get" verbs
- apiGroups:
  - ""
  resources:
  - configmaps
  - endpoints
  - events
  - nodes
  - persistentvolumeclaims
  - pods
  - secrets
  - serviceaccounts
  - services
  verbs:
  - create
  - delete
  - get
  - list

8.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
E1010 10:02:37.316837       1 reflector.go:158] "Unhandled Error" err="sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106: Failed to watch *v1.Secret: unknown (get secrets)" logger="UnhandledError"

{"level":"error","ts":"2024-10-10T10:03:06Z","logger":"controllers.OCSInitialization","msg":"Failed to create/update ux-backend secret","Request.Namespace":"openshift-storage","Request.Name":"ocsinit","error":"secrets \"ux-backend-proxy\" is forbidden: User \"system:serviceaccount:openshift-storage:ocs-operator\" cannot update resource \"secrets\" in API group \"\" in the namespace \"openshift-storage\"","stacktrace":"github.com/red-hat-storage/ocs-operator/v4/controllers/ocsinitialization.(*OCSInitializationReconciler).reconcileUXBackendSecret\n\t/remote-source/app/controllers/ocsinitialization/ocsinitialization_controller.go:629\ngithub.com/red-hat-storage/ocs-operator/v4/controllers/ocsinitialization.(*OCSInitializationReconciler).Reconcile\n\t/remote-source/app/controllers/ocsinitialization/ocsinitialization_controller.go:202\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}

9. Add "update" and "watch" verb:
- apiGroups:
  - ""
  resources:
  - configmaps
  - endpoints
  - events
  - nodes
  - persistentvolumeclaims
  - pods
  - secrets
  - serviceaccounts
  - services
  verbs:
  - create
  - delete
  - get
  - list
  - watch
  - update

10.Delete ocs-operator pod and check ocs-operator pod logs:
$ oc delete pod ocs-operator

$ oc logs ocs-operator
No errors
11. Change code:
// // +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=get;list;watch;create;update;delete

12.make gen-latest-csv:
export REGISTRY_NAMESPACE=ocs-dev
export IMAGE_TAG=latest
make gen-latest-csv



```
```