### PR TITLE
services: remove Getter as they generated as part of proto

### DIFF
--- a/services/provider/api/interfaces/interfaces.go
+++ b/services/provider/api/interfaces/interfaces.go
@@ -6,11 +6,6 @@ type StorageClientStatus interface {
 	// no client is using it
 	GetPlatformVersion() string
 	GetOperatorVersion() string
-	GetClusterID() string
-	GetClusterName() string
-	GetClientName() string
-	GetClientID() string
-	GetStorageQuotaUtilizationRatio() float64
 
 	SetPlatformVersion(string) StorageClientStatus
 	SetOperatorVersion(string) StorageClientStatus

--- a/services/provider/server/consumer.go
+++ b/services/provider/server/consumer.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	pb "github.com/red-hat-storage/ocs-operator/services/provider/api/v4"
 	ifaces "github.com/red-hat-storage/ocs-operator/services/provider/api/v4/interfaces"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 
@@ -209,7 +210,7 @@ func (c *ocsConsumerManager) Get(ctx context.Context, id string) (*ocsv1alpha1.S
 	return consumerObj, nil
 }
 
-func (c *ocsConsumerManager) UpdateConsumerStatus(ctx context.Context, id string, status ifaces.StorageClientStatus) error {
+func (c *ocsConsumerManager) UpdateConsumerStatus(ctx context.Context, id string, status *pb.ReportStatusRequest) error {
 	consumerObj, err := c.Get(ctx, id)
 	if err != nil {
 		return err

--- a/services/provider/server/consumer_test.go
+++ b/services/provider/server/consumer_test.go
@@ -8,6 +8,7 @@ import (
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	pb "github.com/red-hat-storage/ocs-operator/services/provider/api/v4"
 	providerClient "github.com/red-hat-storage/ocs-operator/services/provider/api/v4/client"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
@@ -217,7 +218,8 @@ func TestUpdateConsumerStatus(t *testing.T) {
 	fields := providerClient.NewStorageClientStatus().
 		SetPlatformVersion("1.0.0").
 		SetOperatorVersion("1.0.0")
-	err = consumerManager.UpdateConsumerStatus(ctx, "uid1", fields)
+	status := fields.(*pb.ReportStatusRequest)
+	err = consumerManager.UpdateConsumerStatus(ctx, "uid1", status)
 	assert.NoError(t, err)
 
 	c1, err := consumerManager.Get(ctx, "uid1")

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -238,7 +238,7 @@ func (s *OCSProviderServer) GetStorageConfig(ctx context.Context, req *pb.Storag
 		isConsumerMirrorEnabled, err := s.isConsumerMirrorEnabled(ctx, consumerObj)
 		if err != nil {
 			klog.Error(err)
-			return nil, status.Errorf(codes.Internal, "Failed to get maintenance mode status.")
+			return nil, status.Errorf(codes.Internal, "Failed to get mirroring status for consumer.")
 		}
 
 		desiredClientConfigHash := getDesiredClientConfigHash(
@@ -1016,7 +1016,7 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 	isConsumerMirrorEnabled, err := s.isConsumerMirrorEnabled(ctx, storageConsumer)
 	if err != nil {
 		klog.Error(err)
-		return nil, status.Errorf(codes.Internal, "Failed to get maintenance mode status.")
+		return nil, status.Errorf(codes.Internal, "Failed to get mirroring status for consumer.")
 	}
 
 	desiredClientConfigHash := getDesiredClientConfigHash(
@@ -1273,7 +1273,7 @@ func (s *OCSProviderServer) isSystemInMaintenanceMode(ctx context.Context) (bool
 func (s *OCSProviderServer) isConsumerMirrorEnabled(ctx context.Context, consumer *ocsv1alpha1.StorageConsumer) (bool, error) {
 	clientMappingConfig := &corev1.ConfigMap{}
 	clientMappingConfig.Name = util.StorageClientMappingConfigName
-	clientMappingConfig.Name = s.namespace
+	clientMappingConfig.Namespace = s.namespace
 
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(clientMappingConfig), clientMappingConfig); err != nil {
 		return false, client.IgnoreNotFound(err)

--- a/vendor/github.com/red-hat-storage/ocs-operator/services/provider/api/v4/interfaces/interfaces.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/services/provider/api/v4/interfaces/interfaces.go
@@ -6,11 +6,6 @@ type StorageClientStatus interface {
 	// no client is using it
 	GetPlatformVersion() string
 	GetOperatorVersion() string
-	GetClusterID() string
-	GetClusterName() string
-	GetClientName() string
-	GetClientID() string
-	GetStorageQuotaUtilizationRatio() float64
 
 	SetPlatformVersion(string) StorageClientStatus
 	SetOperatorVersion(string) StorageClientStatus


### PR DESCRIPTION
- remove Getter as they are generated as part of proto
- not removing GetPlatformVersion() & GetOperatorVersion() as they are already used. Leela will take care of removing this.