### PR TITLE
scale down ocs-client-operator deployments in CI

### DIFF
--- a/hack/install-ocs-operator.sh
+++ b/hack/install-ocs-operator.sh
@@ -33,12 +33,18 @@ data:
 EOF
 
 
-patch_ocs_client_operator_config_configmap() {
+scale_down_ocs_client_operator_deployments() {
     while true; do
-        if oc get cm ocs-client-operator-config -n openshift-storage; then
-            oc patch cm ocs-client-operator-config -n openshift-storage --type merge -p '{"data":{"DEPLOY_CSI":"false"}}'
-            sleep 2
+        if oc get deployment ocs-client-operator-controller-manager ocs-client-operator-console -n "$INSTALL_NAMESPACE" >/dev/null 2>&1; then
+            # Get the current replica count for the deployments
+            current_replicas_manager=$(oc get deployment ocs-client-operator-controller-manager -n "$INSTALL_NAMESPACE" -o=jsonpath='{.spec.replicas}')
+            current_replicas_console=$(oc get deployment ocs-client-operator-console -n "$INSTALL_NAMESPACE" -o=jsonpath='{.spec.replicas}')
+            # Scale down only if the replica count is 1
+            if [ "$current_replicas_manager" -eq 1 ] || [ "$current_replicas_console" -eq 1 ]; then
+                oc scale deployments ocs-client-operator-controller-manager ocs-client-operator-console --replicas=0 -n "$INSTALL_NAMESPACE"
+            fi
         fi
+        sleep 1
     done
 }
 
@@ -46,15 +52,10 @@ patch_ocs_client_operator_config_configmap() {
 "$OPERATOR_SDK" run bundle "$ROOK_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"
 "$OPERATOR_SDK" run bundle "$CSI_ADDONS_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"
 "$OPERATOR_SDK" run bundle "$CEPH_CSI_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"
-# Patch the ConfigMap in the background because an empty ConfigMap is initially created by the OLM as it is part of the ocs-client-operator bundle.
-# Patching is done in the background to ensure that it happens immediately after creation, preventing the operator from running with the default
-# configuration and deploying the CSI. This approach allows us to stop the CSI deployment by patching the ConfigMap as soon as it's created.
-# We cannot create the ConfigMap early in the process because OLM overwrites it with an empty one later in the cycle.
-patch_ocs_client_operator_config_configmap &
-# Get the process ID (PID) of the background process
-bg_pid=$!
-# Trap to kill the process when the script exits
-trap 'kill $bg_pid' EXIT
+# Normally, the ODF operator would handle scaling down the ocs-client-operator-controller-manager and ocs-client-operator-console deployments.
+# However, in the ocs-operator CI environment, since the ODF operator is not running, we manually scale down these deployments within this script.
+# We keep the process running in the background to ensure that if OLM attempts to bring the deployments back up, we can immediately scale them down again.
+scale_down_ocs_client_operator_deployments &
 
 "$OPERATOR_SDK" run bundle "$OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"
 "$OPERATOR_SDK" run bundle "$NOOBAA_BUNDLE_FULL_IMAGE_NAME" --timeout=10m --security-context-config restricted -n "$INSTALL_NAMESPACE"


### PR DESCRIPTION
In the ocs-operator CI, since the ODF operator is not running scale down the ocs-client-operator deployments via install script itself.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
