### PR TITLE
Fix broken watch for CRDs on storageCluster controller

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -235,8 +235,6 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(
 				util.NamePredicate(VirtualMachineCrdName),
 				util.CrdCreateAndDeletePredicate(&r.Log, VirtualMachineCrdName, r.AvailableCrds[VirtualMachineCrdName]),
-			),
-			builder.WithPredicates(
 				util.NamePredicate(StorageClientCrdName),
 				util.CrdCreateAndDeletePredicate(&r.Log, StorageClientCrdName, r.AvailableCrds[StorageClientCrdName]),
 			),


### PR DESCRIPTION
The watch had builder.WithPredicates twice, which was causing the watch to not work as expected. Thus even after the CRD was created the controller was not able to detect it and queue a reconcile. Now the predicates are combined under one builder.WithPredicates.