### PR TITLE
Fix replication flag assignment

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -680,7 +680,7 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 	if err = s.client.List(ctx, scp, client.InNamespace(s.namespace)); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get StorageClusterPeerList. %v", err)
 	}
-	replicationEnabled := len(scp.Items) > 1
+	replicationEnabled := len(scp.Items) > 0
 	var replicationID string
 	if replicationEnabled {
 		replicationID = util.CalculateMD5Hash(req.StorageClaimName)


### PR DESCRIPTION
When there are at least two connected peers, the replication flag needs to be enabled for the correct labeling to take place.