### PR TITLE
saving quota in GiB instead GB

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -61,6 +61,7 @@ const (
 	ramenDRStorageIDKey     = "ramendr.openshift.io/storageID"
 	ramenDRReplicationIDKey = "ramendr.openshift.io/replicationid"
 	ramenDRFlattenModeKey   = "replication.storage.openshift.io/flatten-mode"
+	oneGibInBytes           = 1024 * 1024 * 1024
 )
 
 const (
@@ -407,9 +408,9 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 				},
 			},
 			Quota: corev1.ResourceQuotaSpec{
-				Hard: corev1.ResourceList{"requests.storage": *resource.NewScaledQuantity(
-					int64(consumerResource.Spec.StorageQuotaInGiB),
-					resource.Giga,
+				Hard: corev1.ResourceList{"requests.storage": *resource.NewQuantity(
+					int64(consumerResource.Spec.StorageQuotaInGiB)*oneGibInBytes,
+					resource.BinarySI,
 				)},
 			},
 		}

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -49,9 +49,9 @@ var clusterResourceQuotaSpec = &quotav1.ClusterResourceQuotaSpec{
 		},
 	},
 	Quota: corev1.ResourceQuotaSpec{
-		Hard: corev1.ResourceList{"requests.storage": *resource.NewScaledQuantity(
-			int64(consumerResource.Spec.StorageQuotaInGiB),
-			resource.Giga,
+		Hard: corev1.ResourceList{"requests.storage": *resource.NewQuantity(
+			int64(consumerResource.Spec.StorageQuotaInGiB)*oneGibInBytes,
+			resource.BinarySI,
 		)},
 	},
 }
@@ -337,8 +337,9 @@ func TestGetExternalResources(t *testing.T) {
 			var clusterResourceQuotaSpec quotav1.ClusterResourceQuotaSpec
 			err = json.Unmarshal([]byte(extResource.Data), &clusterResourceQuotaSpec)
 			assert.NoError(t, err)
-			quantity, _ := resource.ParseQuantity("10240G")
-			assert.Equal(t, clusterResourceQuotaSpec.Quota.Hard["requests.storage"], quantity)
+			expected := resource.NewQuantity(int64(10240)*oneGibInBytes, resource.BinarySI)
+			actual := clusterResourceQuotaSpec.Quota.Hard["requests.storage"]
+			assert.Equal(t, actual.Value(), expected.Value())
 		} else if extResource.Kind == "Noobaa" {
 			var extNoobaaSpec, mockNoobaaSpec nbv1.NooBaaSpec
 			err = json.Unmarshal(extResource.Data, &extNoobaaSpec)


### PR DESCRIPTION
-  PVCs are in Gib and quota is in GB because of which pvc creation is restricted when the quota reaches around 95%
- Fix for https://issues.redhat.com/browse/DFBUGS-559