### PR TITLE
DFBUGS-872: [release-4.17] server: saving quota in GiB instead GB

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -56,6 +56,7 @@ const (
 	onboardingTicketKeySecret = "onboarding-ticket-key"
 	storageRequestNameLabel   = "ocs.openshift.io/storagerequest-name"
 	notAvailable              = "N/A"
+	oneGibInBytes             = 1024 * 1024 * 1024
 )
 
 const (
@@ -370,9 +371,9 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 				},
 			},
 			Quota: corev1.ResourceQuotaSpec{
-				Hard: corev1.ResourceList{"requests.storage": *resource.NewScaledQuantity(
-					int64(consumerResource.Spec.StorageQuotaInGiB),
-					resource.Giga,
+				Hard: corev1.ResourceList{"requests.storage": *resource.NewQuantity(
+					int64(consumerResource.Spec.StorageQuotaInGiB)*oneGibInBytes,
+					resource.BinarySI,
 				)},
 			},
 		}

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -47,9 +47,9 @@ var clusterResourceQuotaSpec = &quotav1.ClusterResourceQuotaSpec{
 		},
 	},
 	Quota: corev1.ResourceQuotaSpec{
-		Hard: corev1.ResourceList{"requests.storage": *resource.NewScaledQuantity(
-			int64(consumerResource.Spec.StorageQuotaInGiB),
-			resource.Giga,
+		Hard: corev1.ResourceList{"requests.storage": *resource.NewQuantity(
+			int64(consumerResource.Spec.StorageQuotaInGiB)*oneGibInBytes,
+			resource.BinarySI,
 		)},
 	},
 }
@@ -324,8 +324,9 @@ func TestGetExternalResources(t *testing.T) {
 			var clusterResourceQuotaSpec quotav1.ClusterResourceQuotaSpec
 			err = json.Unmarshal([]byte(extResource.Data), &clusterResourceQuotaSpec)
 			assert.NoError(t, err)
-			quantity, _ := resource.ParseQuantity("10240G")
-			assert.Equal(t, clusterResourceQuotaSpec.Quota.Hard["requests.storage"], quantity)
+			expected := resource.NewQuantity(int64(10240)*oneGibInBytes, resource.BinarySI)
+			actual := clusterResourceQuotaSpec.Quota.Hard["requests.storage"]
+			assert.Equal(t, actual.Value(), expected.Value())
 		} else if extResource.Kind == "Noobaa" {
 			var extNoobaaSpec, mockNoobaaSpec nbv1.NooBaaSpec
 			err = json.Unmarshal(extResource.Data, &extNoobaaSpec)


### PR DESCRIPTION
- PVCs are in Gib and quota is in GB because of which pvc creation is restricted when the quota reaches around 95%
- manual Cherry-pick of https://github.com/red-hat-storage/ocs-operator/pull/2895