### PR TITLE
controllers: fix dynamic crd predicate

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -355,7 +355,12 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			enqueueOCSInit,
 			builder.WithPredicates(
 				util.NamePredicate(ClusterClaimCrdName),
-				util.CrdCreateAndDeletePredicate(&r.Log, ClusterClaimCrdName, r.AvailableCrds[ClusterClaimCrdName]),
+				util.EventTypePredicate(
+					!r.AvailableCrds[ClusterClaimCrdName],
+					false,
+					true,
+					false,
+				),
 			),
 			builder.OnlyMetadata,
 		)

--- a/controllers/util/predicates.go
+++ b/controllers/util/predicates.go
@@ -1,10 +1,8 @@
 package util
 
 import (
-	"fmt"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -81,25 +79,23 @@ func NamePredicate(name string) predicate.Predicate {
 	})
 }
 
-func CrdCreateAndDeletePredicate(log *logr.Logger, crdName string, crdExists bool) predicate.Predicate {
+// EventTypePredicate return a predicate to filter events based on their
+// respective event type. This helper allows for the selection of multiple
+// types resulting in a predicate that can filter in more than a single event
+// type
+func EventTypePredicate(create, update, del, generic bool) predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(_ event.CreateEvent) bool {
-			if !crdExists {
-				log.Info(fmt.Sprintf("CustomResourceDefinition %s was Created.", crdName))
-			}
-			return !crdExists
-		},
-		DeleteFunc: func(_ event.DeleteEvent) bool {
-			if crdExists {
-				log.Info(fmt.Sprintf("CustomResourceDefinition %s was Deleted.", crdName))
-			}
-			return crdExists
+			return create
 		},
 		UpdateFunc: func(_ event.UpdateEvent) bool {
-			return false
+			return update
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return del
 		},
 		GenericFunc: func(_ event.GenericEvent) bool {
-			return false
+			return generic
 		},
 	}
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/predicates.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/predicates.go
@@ -1,10 +1,8 @@
 package util
 
 import (
-	"fmt"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -81,25 +79,23 @@ func NamePredicate(name string) predicate.Predicate {
 	})
 }
 
-func CrdCreateAndDeletePredicate(log *logr.Logger, crdName string, crdExists bool) predicate.Predicate {
+// EventTypePredicate return a predicate to filter events based on their
+// respective event type. This helper allows for the selection of multiple
+// types resulting in a predicate that can filter in more than a single event
+// type
+func EventTypePredicate(create, update, del, generic bool) predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(_ event.CreateEvent) bool {
-			if !crdExists {
-				log.Info(fmt.Sprintf("CustomResourceDefinition %s was Created.", crdName))
-			}
-			return !crdExists
-		},
-		DeleteFunc: func(_ event.DeleteEvent) bool {
-			if crdExists {
-				log.Info(fmt.Sprintf("CustomResourceDefinition %s was Deleted.", crdName))
-			}
-			return crdExists
+			return create
 		},
 		UpdateFunc: func(_ event.UpdateEvent) bool {
-			return false
+			return update
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return del
 		},
 		GenericFunc: func(_ event.GenericEvent) bool {
-			return false
+			return generic
 		},
 	}
 }


### PR DESCRIPTION
if a single predicate reject the event then the runtime doesn't queue the reconcile for that controller and for dynamic crd feature multiple crds should be checked for event and at the same time presence of a single matching crd with corresponding predicate functions should initiate the reconcile.

this commit uses helper function in predicate and creates the required logical conditions and refactor the crd predicate to directly take bools based on crd availability.