### PR TITLE
filesystem: correct the pool name in the ux backend handler

### DIFF
--- a/services/ux-backend/handlers/expandstorage/handler.go
+++ b/services/ux-backend/handlers/expandstorage/handler.go
@@ -268,7 +268,7 @@ func createCephFilesystemStorageClass(w http.ResponseWriter, r *http.Request, cl
 		Parameters: map[string]string{
 			"clusterID": namespace,
 			"fsName":    filesystemName,
-			"pool":      poolName,
+			"pool":      fmt.Sprintf("%s-%s", filesystemName, poolName),
 			"csi.storage.k8s.io/provisioner-secret-name":            "rook-csi-cephfs-provisioner",
 			"csi.storage.k8s.io/provisioner-secret-namespace":       namespace,
 			"csi.storage.k8s.io/node-stage-secret-name":             "rook-csi-cephfs-node",


### PR DESCRIPTION
In the expandstorage handler pool name is incorrect,

Rook adds the filesystemName prefix to every datapool, which was missing in the storageclass parameter
https://github.com/rook/rook/blob/44e96c8ab67a27121354a04b121b7f16b6a38894/pkg/operator/ceph/file/filesystem.go#L321