### PR TITLE
remove MDSCacheUsageHigh prometheus alert

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -367,19 +367,6 @@ spec:
         severity: info
   - name: ceph-daemon-performance-alerts.rules
     rules:
-    - alert: MDSCacheUsageHigh
-      annotations:
-        description: MDS cache usage for the daemon {{ $labels.ceph_daemon }} has
-          exceeded above 95% of the requested value. Increase the memory request for
-          {{ $labels.ceph_daemon }} pod.
-        message: High MDS cache usage for the daemon {{ $labels.ceph_daemon }}.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephMdsCacheUsageHigh.md
-        severity_level: error
-      expr: |
-        (ceph_mds_mem_rss * 1000) / on(ceph_daemon) group_left(job)(label_replace(kube_pod_container_resource_requests{container="mds", resource="memory"}, "ceph_daemon", "mds.$1", "pod", "rook-ceph-mds-(.*)-(.*)") * .5) > .95
-      for: 5m
-      labels:
-        severity: critical
     - alert: OSDCPULoadHigh
       annotations:
         description: CPU usage for osd on pod {{ $labels.pod }} has exceeded 80%.


### PR DESCRIPTION
This is related to - https://issues.redhat.com/browse/DFBUGS-368 

Customers are complaining about erroneous MDS cache usage alerts. Ceph team suggested that `ceph_mds_mem_rss` might not be the right metric to capture this cache usage. So this alert needs to looked at again. For the time being, we can just remove this alert while looking for a better solution.  Decision to remove this was discussed in Weekly meeting.


Details about the discussion with the Ceph team:

`rss` is not right metric for cache warning. `mds_co_bytes` is the correct metric but its not exposed by Ceph.
MDS pod memory is 8Gi set by ODF is low. (Not related to this issue but just a general observation)
Possible Resolution:

Operator should be able to read the MDS cache warning from the Ceph health and raise a promethus alert.
If MDS pod memory usage breaches 5/10/15% of the allocated memory size (8Gi), raise a prometheus alert.