### PR TITLE
Add StorageCluster.spec.nfs.LogLevel in storagecluster CR

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -475,6 +475,11 @@ type NFSSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	StorageClassName string `json:"storageClassName,omitempty"`
+	// LogLevel set logging level
+	// Log levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL
+	// +optional
+	LogLevel          string `json:"logLevel,omitempty"`
+	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 }
 
 // MonitoringSpec controls the configuration of resources for exposing OCS metrics

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -2618,6 +2618,13 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  logLevel:
+                    description: |-
+                      LogLevel set logging level
+                      Log levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL
+                    type: string
+                  reconcileStrategy:
+                    type: string
                   storageClassName:
                     description: StorageClassName specifies the name of the storage
                       class created for NFS

--- a/controllers/storagecluster/cephnfs_test.go
+++ b/controllers/storagecluster/cephnfs_test.go
@@ -72,3 +72,13 @@ func assertCephNFSService(t *testing.T, reconciler StorageClusterReconciler, cr 
 	assert.Equal(t, expectedAf[0].ObjectMeta.Name, actualNFSService.ObjectMeta.Name)
 	assert.Equal(t, expectedAf[0].Spec, actualNFSService.Spec)
 }
+
+func TestNfsLogLevelParam(t *testing.T) {
+	var objects []client.Object
+	t, reconciler, cr, _ := initStorageClusterResourceCreateUpdateTest(t, objects, nil)
+	cr.Spec.NFS = &api.NFSSpec{
+		LogLevel: "NIV_DEBUG",
+	}
+	expectedAf, _ := reconciler.newCephNFSInstances(cr)
+	assert.Equal(t, "NIV_DEBUG", expectedAf[0].Spec.Server.LogLevel)
+}

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -2618,6 +2618,13 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  logLevel:
+                    description: |-
+                      LogLevel set logging level
+                      Log levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL
+                    type: string
+                  reconcileStrategy:
+                    type: string
                   storageClassName:
                     description: StorageClassName specifies the name of the storage
                       class created for NFS

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -2618,6 +2618,13 @@ spec:
                   enable:
                     description: Enable specifies whether to enable NFS.
                     type: boolean
+                  logLevel:
+                    description: |-
+                      LogLevel set logging level
+                      Log levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL
+                    type: string
+                  reconcileStrategy:
+                    type: string
                   storageClassName:
                     description: StorageClassName specifies the name of the storage
                       class created for NFS

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -475,6 +475,11 @@ type NFSSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	StorageClassName string `json:"storageClassName,omitempty"`
+	// LogLevel set logging level
+	// Log levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL
+	// +optional
+	LogLevel          string `json:"logLevel,omitempty"`
+	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 }
 
 // MonitoringSpec controls the configuration of resources for exposing OCS metrics

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -475,6 +475,11 @@ type NFSSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	StorageClassName string `json:"storageClassName,omitempty"`
+	// LogLevel set logging level
+	// Log levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL
+	// +optional
+	LogLevel          string `json:"logLevel,omitempty"`
+	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 }
 
 // MonitoringSpec controls the configuration of resources for exposing OCS metrics


### PR DESCRIPTION
This PR introduces a new parameter, spec.nfs.LogLevel, to the StorageCluster CR.
The LogLevel parameter allows users to configure the log level for NFS, providing greater flexibility and control over logging behavior.

This enhancement aims to improve the user experience by enabling more precise logging settings for debugging and monitoring purposes.

Additionally, a unit test has been added to verify that the StorageCluster CR exports the Rook NFS CR, ensuring proper integration between the OCS operator CR and the Rook operator CR.