### PR TITLE
external: fix sc name for rados namespace #2955

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -25,15 +25,15 @@ import (
 )
 
 const (
-	externalClusterDetailsSecret          = "rook-ceph-external-cluster-details"
-	externalClusterDetailsKey             = "external_cluster_details"
-	cephFsStorageClassName                = "cephfs"
-	cephRbdStorageClassName               = "ceph-rbd"
-	cephRbdRadosNamespaceStorageClassName = "ceph-rbd-rados-namespace"
-	cephRbdTopologyStorageClassName       = "ceph-rbd-topology"
-	cephRgwStorageClassName               = "ceph-rgw"
-	externalCephRgwEndpointKey            = "endpoint"
-	cephRgwTLSSecretKey                   = "ceph-rgw-tls-cert"
+	externalClusterDetailsSecret                = "rook-ceph-external-cluster-details"
+	externalClusterDetailsKey                   = "external_cluster_details"
+	cephFsStorageClassName                      = "cephfs"
+	cephRbdStorageClassName                     = "ceph-rbd"
+	cephRbdRadosNamespaceStorageClassNamePrefix = "ceph-rbd-rados-namespace"
+	cephRbdTopologyStorageClassName             = "ceph-rbd-topology"
+	cephRgwStorageClassName                     = "ceph-rgw"
+	externalCephRgwEndpointKey                  = "endpoint"
+	cephRgwTLSSecretKey                         = "ceph-rgw-tls-cert"
 )
 
 const (
@@ -375,7 +375,7 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 				enableRookCSICephFS = true
 			} else if d.Name == cephRbdStorageClassName {
 				scc = newCephBlockPoolStorageClassConfiguration(instance)
-			} else if d.Name == cephRbdRadosNamespaceStorageClassName {
+			} else if strings.HasPrefix(d.Name, cephRbdRadosNamespaceStorageClassNamePrefix) { // ceph-rbd-rados-namespace-<radosNamespaceName>
 				scc = newCephBlockPoolStorageClassConfiguration(instance)
 				// update the storageclass name to rados storagesclass name
 				scc.storageClass.Name = fmt.Sprintf("%s-%s", instance.Name, d.Name)


### PR DESCRIPTION
Currently, the sc name is hardcoded,
in future if we support multiple rados namespace per tenant we need a variable name 
updating sc names to contain rados-namespace name
rook pr: https://github.com/rook/rook/pull/15243