### PR TITLE
odf-info: stop owning the odf-info configMap

### DIFF
--- a/controllers/storagecluster/odfinfoconfig.go
+++ b/controllers/storagecluster/odfinfoconfig.go
@@ -9,13 +9,13 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1a1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -54,11 +54,6 @@ func (obj *odfInfoConfig) ensureCreated(r *StorageClusterReconciler, storageClus
 	mutex.Lock()
 	defer mutex.Unlock()
 	_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, odfInfoConfigMap, func() error {
-		// Note: purposely setting OwnerRef instead of ControllerRef, which alongside MatchEveryOwner
-		// sent in to OwnsOptions in the ConfigMap Owns, guarantees relevant events will be triggered
-		if err = controllerutil.SetOwnerReference(storageCluster, odfInfoConfigMap, r.Scheme); err != nil {
-			return err
-		}
 		r.Log.Info("Creating or updating odf-info config map", odfInfoMapKind, client.ObjectKeyFromObject(odfInfoConfigMap))
 		odfInfoKey := obj.getOdfInfoKeyName(storageCluster)
 

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -252,7 +252,15 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&volumesnapshotv1.VolumeSnapshotClass{}, enqueueStorageClusterRequest).
 		Watches(&ocsv1.StorageProfile{}, enqueueStorageClusterRequest).
 		Watches(&ocsv1alpha1.StorageConsumer{}, enqueueStorageClusterRequest, builder.WithPredicates(storageConsumerStatusPredicate)).
-		Watches(&ocsv1.StorageClusterPeer{}, enqueueStorageClusterRequest, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+		Watches(&ocsv1.StorageClusterPeer{}, enqueueStorageClusterRequest, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.ConfigMap{},
+			enqueueStorageClusterRequest,
+			builder.WithPredicates(
+				util.NamePredicate(OdfInfoConfigMapName),
+				util.NamespacePredicate(r.OperatorNamespace),
+			),
+		)
 
 	if os.Getenv("SKIP_NOOBAA_CRD_WATCH") != "true" {
 		build.Owns(&nbv1.NooBaa{}, builder.WithPredicates(noobaaIgnoreTimeUpdatePredicate))

--- a/controllers/util/predicates.go
+++ b/controllers/util/predicates.go
@@ -79,6 +79,12 @@ func NamePredicate(name string) predicate.Predicate {
 	})
 }
 
+func NamespacePredicate(namespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetNamespace() == namespace
+	})
+}
+
 // EventTypePredicate return a predicate to filter events based on their
 // respective event type. This helper allows for the selection of multiple
 // types resulting in a predicate that can filter in more than a single event

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/predicates.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/predicates.go
@@ -79,6 +79,12 @@ func NamePredicate(name string) predicate.Predicate {
 	})
 }
 
+func NamespacePredicate(namespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetNamespace() == namespace
+	})
+}
+
 // EventTypePredicate return a predicate to filter events based on their
 // respective event type. This helper allows for the selection of multiple
 // types resulting in a predicate that can filter in more than a single event


### PR DESCRIPTION
Since odf-info is created in operator namespace, in case of multi- storageCluster, we get a "cross-namespace owner references are disallowed" issue. To address this, stop owning the configMap and watch the configMap from storageCluster reconciler

More info on "cross-namespace owner references are disallowed" [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications). 

Bug: https://issues.redhat.com/browse/DFBUGS-1266