### PR TITLE
osd: add tunefastdeviceclass: true for all ssd disk

### DIFF
--- a/services/ux-backend/handlers/expandstorage/handler.go
+++ b/services/ux-backend/handlers/expandstorage/handler.go
@@ -115,6 +115,7 @@ func updateStorageCluster(w http.ResponseWriter, r *http.Request, client client.
 		Portable:    false,
 		Encrypted:   &enableEncryption,
 		DeviceClass: storageClassForOSDs,
+		DeviceType:  "SSD",
 		DataPVCTemplate: corev1.PersistentVolumeClaim{
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes:      []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"},


### PR DESCRIPTION
with exandstorage ux-backend handler we will be
adding ssd disk always,
So by default make the deviceSet spec, `deviceType: ssd`