### PR TITLE
DFBUGS-1326: [release-4.17] odf-info: stop owning the odf-info configMap

### DIFF
--- a/controllers/storagecluster/odfinfoconfig.go
+++ b/controllers/storagecluster/odfinfoconfig.go
@@ -11,13 +11,13 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1a1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -58,11 +58,6 @@ func (obj *odfInfoConfig) ensureCreated(r *StorageClusterReconciler, storageClus
 	mutex.Lock()
 	defer mutex.Unlock()
 	_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, odfInfoConfigMap, func() error {
-		// Note: purposely setting OwnerRef instead of ControllerRef, which alongside MatchEveryOwner
-		// sent in to OwnsOptions in the ConfigMap Owns, guarantees relevant events will be triggered
-		if err = controllerutil.SetOwnerReference(storageCluster, odfInfoConfigMap, r.Scheme); err != nil {
-			return err
-		}
 		r.Log.Info("Creating or updating odf-info config map", odfInfoMapKind, client.ObjectKeyFromObject(odfInfoConfigMap))
 		odfInfoKey := obj.getOdfInfoKeyName(storageCluster)
 

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -234,7 +234,15 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 			enqueueStorageClusterRequest,
 		).
-		Watches(&ocsv1alpha1.StorageConsumer{}, enqueueStorageClusterRequest, builder.WithPredicates(storageConsumerStatusPredicate))
+		Watches(&ocsv1alpha1.StorageConsumer{}, enqueueStorageClusterRequest, builder.WithPredicates(storageConsumerStatusPredicate)).
+		Watches(
+			&corev1.ConfigMap{},
+			enqueueStorageClusterRequest,
+			builder.WithPredicates(
+				util.NamePredicate(OdfInfoConfigMapName),
+				util.NamespacePredicate(r.OperatorNamespace),
+			),
+		)
 
 	if os.Getenv("SKIP_NOOBAA_CRD_WATCH") != "true" {
 		build.Owns(&nbv1.NooBaa{}, builder.WithPredicates(noobaaIgnoreTimeUpdatePredicate))

--- a/controllers/util/predicates.go
+++ b/controllers/util/predicates.go
@@ -3,6 +3,7 @@ package util
 import (
 	"reflect"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -67,4 +68,18 @@ func (p MetadataChangedPredicate) Update(e event.UpdateEvent) bool {
 		!reflect.DeepEqual(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers())
 
 	return metaChanged
+}
+
+// Name Predicate return a predicate the filter events produced
+// by resources that matches the given name
+func NamePredicate(name string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == name
+	})
+}
+
+func NamespacePredicate(namespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetNamespace() == namespace
+	})
 }


### PR DESCRIPTION
Since odf-info is created in operator namespace, in case of multi storageCluster, we get a "cross-namespace owner references are disallowed" issue. To address this, stop owning the configMap and watch the configMap from storageCluster reconciler

Signed-off-by: Rewant Soni <resoni@redhat.com>
(cherry picked from commit ccbefaab3c4ac7a6ca985131acc959e46d998737)

Manual backport for https://github.com/red-hat-storage/ocs-operator/pull/2959