### PR TITLE
DFBUGS-1272: [release-4.18] Add node toleration to alertmanager and prometheus pods

### DIFF
--- a/templates/alertmanager.go
+++ b/templates/alertmanager.go
@@ -3,10 +3,17 @@ package templates
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
 
 var AlertmanagerSpecTemplate = promv1.AlertmanagerSpec{
 	Replicas:  ptr.To(int32(1)),
 	Resources: defaults.MonitoringResources["alertmanager"],
+	Tolerations: []corev1.Toleration{{
+		Key:      defaults.NodeTolerationKey,
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}},
 }

--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -78,6 +78,12 @@ var PrometheusSpecTemplate = promv1.PrometheusSpec{
 				},
 			},
 		},
+		Tolerations: []corev1.Toleration{{
+			Key:      defaults.NodeTolerationKey,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}},
 	},
 	RuleSelector:   &ruleSelector,
 	EnableAdminAPI: false,


### PR DESCRIPTION
Platform related  metrics and alerts pods deployed by ODF do not have spec.tolerations with node.ocs.openshift.io/storage when taint nodes performed. This PR adds the required tolerations