### PR TITLE
Avoid reconciling rook-ceph-operator-config via the external controller

### DIFF
--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -445,6 +445,9 @@ func (r *OCSInitializationReconciler) ensureRookCephOperatorConfigExists(initial
 			return err // nolint:revive
 		}
 
+		// TODO: remove this in the next release, look at commit msg for more info
+		delete(rookCephOperatorConfig.Data, "ROOK_CSI_ENABLE_CEPHFS")
+
 		return nil
 	})
 


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://issues.redhat.com/browse/DFBUGS-1357
