### PR TITLE
Set bulk flag to true on intended pools for performance gain

### DIFF
--- a/controllers/storagecluster/cephblockpools_test.go
+++ b/controllers/storagecluster/cephblockpools_test.go
@@ -2,6 +2,7 @@ package storagecluster
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/imdario/mergo"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -159,6 +161,9 @@ func assertCephBlockPools(t *testing.T, reconciler StorageClusterReconciler, cr 
 				FailureDomain:      getFailureDomain(cr),
 				Replicated:         generateCephReplicatedSpec(cr, poolTypeData),
 				EnableRBDStats:     true,
+				Parameters: map[string]string{
+					"bulk": "true",
+				},
 			},
 		},
 	}
@@ -214,4 +219,329 @@ func assertCephNFSBlockPool(t *testing.T, reconciler StorageClusterReconciler, c
 	assert.Equal(t, len(expectedCbp.OwnerReferences), 1)
 	assert.Equal(t, expectedCbp.ObjectMeta.Name, actualNFSBlockPool.ObjectMeta.Name)
 	assert.Equal(t, expectedCbp.Spec, actualNFSBlockPool.Spec)
+}
+
+func TestBulkFlagBehaviorCephBlockPool(t *testing.T) {
+	var cases = []struct {
+		description        string
+		existingPool       *cephv1.CephBlockPool
+		storageClusterSpec *api.StorageClusterSpec
+		expectedBulk       string
+	}{
+		{
+			description:  "case 1: New pool creation - bulk flag should be set automatically",
+			expectedBulk: "true",
+		},
+		{
+			description: "case 2: New pool creation, CR specifies bulk flag false - should respect CR setting",
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephBlockPools: api.ManageCephBlockPools{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "false",
+							},
+						},
+					},
+				},
+			},
+			expectedBulk: "false",
+		},
+		{
+			description: "case 3: Existing pool with bulk flag - should preserve flag",
+			existingPool: &cephv1.CephBlockPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ocsinit-cephblockpool",
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: cephv1.NamedBlockPoolSpec{
+					PoolSpec: cephv1.PoolSpec{
+						Parameters: map[string]string{
+							"bulk": "true",
+						},
+					},
+				},
+			},
+			expectedBulk: "true",
+		},
+		{
+			description: "case 4: Existing pool without bulk flag - should not set flag",
+			existingPool: &cephv1.CephBlockPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ocsinit-cephblockpool",
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: cephv1.NamedBlockPoolSpec{
+					PoolSpec: cephv1.PoolSpec{},
+				},
+			},
+			expectedBulk: "",
+		},
+		{
+			description: "case 5: Existing pool without bulk flag - CR specifies bulk flag true - should respect CR setting",
+			existingPool: &cephv1.CephBlockPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ocsinit-cephblockpool",
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: cephv1.NamedBlockPoolSpec{
+					PoolSpec: cephv1.PoolSpec{},
+				},
+			},
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephBlockPools: api.ManageCephBlockPools{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+			},
+			expectedBulk: "true",
+		},
+	}
+
+	for _, c := range cases {
+		t.Logf("Running %s", c.description)
+		var objects []runtime.Object
+		reconciler := createFakeStorageClusterReconciler(t, objects...)
+		cr := createDefaultStorageCluster()
+		if c.storageClusterSpec != nil {
+			_ = mergo.Merge(&cr.Spec, c.storageClusterSpec)
+		}
+		err := reconciler.Client.Create(context.TODO(), cr)
+		assert.NoError(t, err)
+
+		if c.existingPool != nil {
+			err := reconciler.Client.Create(context.TODO(), c.existingPool)
+			assert.NoError(t, err)
+		}
+
+		obj := &ocsCephBlockPools{}
+		_, err = obj.ensureCreated(&reconciler, cr)
+		assert.NoError(t, err)
+
+		actualCbp := &cephv1.CephBlockPool{}
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "ocsinit-cephblockpool"}, actualCbp)
+		assert.NoError(t, err)
+
+		bulkValue, exists := actualCbp.Spec.Parameters["bulk"]
+		if c.expectedBulk == "" {
+			assert.False(t, exists, "bulk parameter should not exist")
+		} else {
+			assert.True(t, exists, "bulk parameter should exist")
+			assert.Equal(t, c.expectedBulk, bulkValue, "bulk parameter value mismatch")
+		}
+	}
+}
+
+func TestBulkFlagBehaviorNonResilientCephBlockPool(t *testing.T) {
+	var cases = []struct {
+		description        string
+		existingPools      []*cephv1.CephBlockPool
+		storageClusterSpec *api.StorageClusterSpec
+		expectedBulk       string
+		expectedPgNum      string
+		expectedPgpNum     string
+	}{
+		{
+			description:  "case 1: New non-resilient pool creation - bulk flag should be set automatically",
+			expectedBulk: "true",
+		},
+		{
+			description: "case 2: New non-resilient pool creation, CR specifies bulk flag false - should respect CR setting and set pg numbers",
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephNonResilientPools: api.ManageCephNonResilientPools{
+						Enable: true,
+						Parameters: map[string]string{
+							"bulk": "false",
+						},
+					},
+				},
+			},
+			expectedBulk:   "false",
+			expectedPgNum:  "16",
+			expectedPgpNum: "16",
+		},
+		{
+			description: "case 3: Existing non-resilient pools with bulk flag - should preserve flag",
+			existingPools: []*cephv1.CephBlockPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone1",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone2",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone3",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+			},
+			expectedBulk: "true",
+		},
+		{
+			description: "case 4: Existing non-resilient pools without bulk flag - should not set flag but set pg numbers",
+			existingPools: []*cephv1.CephBlockPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone1",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone2",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone3",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+				},
+			},
+			expectedBulk:   "",
+			expectedPgNum:  "16",
+			expectedPgpNum: "16",
+		},
+		{
+			description: "case 5: Existing non-resilient pools without bulk flag - CR specifies bulk flag true - should respect CR setting",
+			existingPools: []*cephv1.CephBlockPool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone1",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone2",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ocsinit-nonresilient-zone3",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: cephv1.NamedBlockPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+				},
+			},
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephNonResilientPools: api.ManageCephNonResilientPools{
+						Enable: true,
+						Parameters: map[string]string{
+							"bulk": "true",
+						},
+					},
+				},
+			},
+			expectedBulk: "true",
+		},
+	}
+
+	for _, c := range cases {
+		t.Logf("Running %s", c.description)
+		var objects []runtime.Object
+		reconciler := createFakeStorageClusterReconciler(t, objects...)
+		cr := createDefaultStorageCluster()
+
+		cr.Spec.ManagedResources.CephNonResilientPools.Enable = true
+		cr.Status.FailureDomainKey, cr.Status.FailureDomainValues = cr.Status.NodeTopologies.GetKeyValues(cr.Status.FailureDomain)
+		if c.storageClusterSpec != nil {
+			_ = mergo.Merge(&cr.Spec, c.storageClusterSpec)
+		}
+		err := reconciler.Client.Create(context.TODO(), cr)
+		assert.NoError(t, err)
+
+		if c.existingPools != nil {
+			for _, pool := range c.existingPools {
+				err := reconciler.Client.Create(context.TODO(), pool)
+				assert.NoError(t, err)
+			}
+		}
+
+		obj := &ocsCephBlockPools{}
+		_, err = obj.ensureCreated(&reconciler, cr)
+		assert.NoError(t, err)
+
+		// Verify each failure domain has a pool with correct settings
+		for _, failureDomain := range cr.Status.FailureDomainValues {
+			poolName := fmt.Sprintf("ocsinit-nonresilient-%s", failureDomain)
+			actualCbp := &cephv1.CephBlockPool{}
+			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: poolName, Namespace: cr.Namespace}, actualCbp)
+			assert.NoError(t, err)
+
+			// Verify bulk flag
+			bulkValue, exists := actualCbp.Spec.Parameters["bulk"]
+			if c.expectedBulk == "" {
+				assert.False(t, exists, "bulk parameter should not exist for pool %s", poolName)
+			} else {
+				assert.True(t, exists, "bulk parameter should exist for pool %s", poolName)
+				assert.Equal(t, c.expectedBulk, bulkValue, "bulk parameter value mismatch for pool %s", poolName)
+			}
+
+			// Verify pg numbers when bulk is false or not set
+			if c.expectedBulk == "false" || c.expectedBulk == "" {
+				pgNum, exists := actualCbp.Spec.Parameters["pg_num"]
+				assert.True(t, exists, "pg_num parameter should exist for pool %s", poolName)
+				assert.Equal(t, c.expectedPgNum, pgNum, "pg_num parameter value mismatch for pool %s", poolName)
+
+				pgpNum, exists := actualCbp.Spec.Parameters["pgp_num"]
+				assert.True(t, exists, "pgp_num parameter should exist for pool %s", poolName)
+				assert.Equal(t, c.expectedPgpNum, pgpNum, "pgp_num parameter value mismatch for pool %s", poolName)
+			}
+		}
+	}
 }

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -1525,3 +1525,25 @@ func setDefaultDataPoolSpec(poolSpec *rookCephv1.PoolSpec, sc *ocsv1.StorageClus
 		poolSpec.Replicated.TargetSizeRatio = defaultReplicatedSpec.TargetSizeRatio
 	}
 }
+
+// setBulkFlagParameter sets the bulk flag if unset in the given poolSpec parameters
+func setBulkFlagParameter(parameters *map[string]string) {
+	if _, exists := (*parameters)["bulk"]; !exists {
+		if *parameters == nil {
+			*parameters = make(map[string]string)
+		}
+		(*parameters)["bulk"] = "true"
+	}
+}
+
+// preserveBulkFlagParameter preserves the "bulk" key if it exists in the existing parameters but is missing in the updated parameters
+func preserveBulkFlagParameter(existingParameters map[string]string, updatedParameters *map[string]string) {
+	if bulk, exists := existingParameters["bulk"]; exists {
+		if _, exists := (*updatedParameters)["bulk"]; !exists {
+			if *updatedParameters == nil {
+				*updatedParameters = make(map[string]string)
+			}
+			(*updatedParameters)["bulk"] = bulk
+		}
+	}
+}

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -98,6 +98,13 @@ func (obj *ocsCephFilesystems) ensureCreated(r *StorageClusterReconciler, instan
 
 			r.Log.Info("Restoring original CephFilesystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
 			existing.ObjectMeta.OwnerReferences = cephFilesystem.ObjectMeta.OwnerReferences
+
+			// Ensures the bulk flag set during new pool creation is not removed during updates.
+			preserveBulkFlagParameter(existing.Spec.MetadataPool.PoolSpec.Parameters, &cephFilesystem.Spec.MetadataPool.PoolSpec.Parameters)
+			for i := range existing.Spec.DataPools {
+				preserveBulkFlagParameter(existing.Spec.DataPools[i].PoolSpec.Parameters, &cephFilesystem.Spec.DataPools[i].PoolSpec.Parameters)
+			}
+
 			existing.Spec = cephFilesystem.Spec
 			err = r.Client.Update(context.TODO(), &existing)
 			if err != nil {
@@ -106,6 +113,13 @@ func (obj *ocsCephFilesystems) ensureCreated(r *StorageClusterReconciler, instan
 			}
 		case errors.IsNotFound(err):
 			r.Log.Info("Creating CephFileSystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))
+
+			// The bulk flag is set to true only during new pool creation, as setting it on existing pools can cause data movement.
+			setBulkFlagParameter(&cephFilesystem.Spec.MetadataPool.PoolSpec.Parameters)
+			for i := range cephFilesystem.Spec.DataPools {
+				setBulkFlagParameter(&cephFilesystem.Spec.DataPools[i].PoolSpec.Parameters)
+			}
+
 			err = r.Client.Create(context.TODO(), cephFilesystem)
 			if err != nil {
 				r.Log.Error(err, "Unable to create CephFileSystem.", "CephFileSystem", klog.KRef(cephFilesystem.Namespace, cephFilesystem.Name))

--- a/controllers/storagecluster/cephfilesystem_test.go
+++ b/controllers/storagecluster/cephfilesystem_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/imdario/mergo"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -356,5 +358,281 @@ func TestCephFileSystemDataPools(t *testing.T) {
 		assert.NoError(t, err)
 		actualDataPools := filesystem[0].Spec.DataPools
 		assert.Equal(t, c.expectedDataPools, actualDataPools)
+	}
+}
+
+func TestBulkFlagBehaviorCephFilesystem(t *testing.T) {
+	var cases = []struct {
+		description          string
+		existingFS           *cephv1.CephFilesystem
+		storageClusterSpec   *api.StorageClusterSpec
+		expectedMetadataBulk string
+		expectedDataBulk     string
+	}{
+		{
+			description:          "case 1: New filesystem creation - bulk flag should be set automatically for both pools",
+			expectedMetadataBulk: "true",
+			expectedDataBulk:     "true",
+		},
+		{
+			description: "case 2: New filesystem creation, CR specifies bulk flag false - should respect CR setting",
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephFilesystems: api.ManageCephFilesystems{
+						MetadataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "false",
+							},
+						},
+						DataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "false",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "false",
+			expectedDataBulk:     "false",
+		},
+		{
+			description: "case 3: Existing filesystem with bulk flags - should preserve flags",
+			existingFS: &cephv1.CephFilesystem{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ocsinit-cephfilesystem",
+				},
+				Spec: cephv1.FilesystemSpec{
+					MetadataPool: cephv1.NamedPoolSpec{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+					DataPools: []cephv1.NamedPoolSpec{
+						{
+							PoolSpec: cephv1.PoolSpec{
+								Parameters: map[string]string{
+									"bulk": "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "true",
+			expectedDataBulk:     "true",
+		},
+		{
+			description: "case 4: Existing filesystem without bulk flags - should not set flags",
+			existingFS: &cephv1.CephFilesystem{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ocsinit-cephfilesystem",
+				},
+				Spec: cephv1.FilesystemSpec{
+					MetadataPool: cephv1.NamedPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+					DataPools: []cephv1.NamedPoolSpec{
+						{
+							PoolSpec: cephv1.PoolSpec{},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "",
+			expectedDataBulk:     "",
+		},
+		{
+			description: "case 5: Existing filesystem without bulk flags - CR specifies bulk flags - should respect CR setting",
+			existingFS: &cephv1.CephFilesystem{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ocsinit-cephfilesystem",
+				},
+				Spec: cephv1.FilesystemSpec{
+					MetadataPool: cephv1.NamedPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+					DataPools: []cephv1.NamedPoolSpec{
+						{
+							PoolSpec: cephv1.PoolSpec{},
+						},
+					},
+				},
+			},
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephFilesystems: api.ManageCephFilesystems{
+						MetadataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+						DataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "true",
+			expectedDataBulk:     "true",
+		},
+		{
+			description: "case 6: New filesystem creation - only metadata pool bulk flag should be set",
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephFilesystems: api.ManageCephFilesystems{
+						MetadataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+						DataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "false",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "true",
+			expectedDataBulk:     "false",
+		},
+		{
+			description: "case 7: New filesystem creation - only data pool bulk flag should be set",
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephFilesystems: api.ManageCephFilesystems{
+						MetadataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "false",
+							},
+						},
+						DataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "false",
+			expectedDataBulk:     "true",
+		},
+		{
+			description: "case 8: Existing filesystem - preserve metadata pool bulk flag, set data pool bulk flag",
+			existingFS: &cephv1.CephFilesystem{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ocsinit-cephfilesystem",
+				},
+				Spec: cephv1.FilesystemSpec{
+					MetadataPool: cephv1.NamedPoolSpec{
+						PoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+					DataPools: []cephv1.NamedPoolSpec{
+						{
+							PoolSpec: cephv1.PoolSpec{},
+						},
+					},
+				},
+			},
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephFilesystems: api.ManageCephFilesystems{
+						DataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "true",
+			expectedDataBulk:     "true",
+		},
+		{
+			description: "case 9: Existing filesystem - preserve data pool bulk flag, set metadata pool bulk flag",
+			existingFS: &cephv1.CephFilesystem{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ocsinit-cephfilesystem",
+				},
+				Spec: cephv1.FilesystemSpec{
+					MetadataPool: cephv1.NamedPoolSpec{
+						PoolSpec: cephv1.PoolSpec{},
+					},
+					DataPools: []cephv1.NamedPoolSpec{
+						{
+							PoolSpec: cephv1.PoolSpec{
+								Parameters: map[string]string{
+									"bulk": "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			storageClusterSpec: &api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephFilesystems: api.ManageCephFilesystems{
+						MetadataPoolSpec: cephv1.PoolSpec{
+							Parameters: map[string]string{
+								"bulk": "true",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadataBulk: "true",
+			expectedDataBulk:     "true",
+		},
+	}
+
+	for _, c := range cases {
+		t.Logf("Running %s", c.description)
+		var objects []runtime.Object
+		reconciler := createFakeStorageClusterReconciler(t, objects...)
+		cr := createDefaultStorageCluster()
+		if c.storageClusterSpec != nil {
+			_ = mergo.Merge(&cr.Spec, c.storageClusterSpec)
+		}
+		err := reconciler.Client.Create(context.TODO(), cr)
+		assert.NoError(t, err)
+
+		if c.existingFS != nil {
+			err := reconciler.Client.Create(context.TODO(), c.existingFS)
+			assert.NoError(t, err)
+		}
+
+		obj := &ocsCephFilesystems{}
+		_, err = obj.ensureCreated(&reconciler, cr)
+		assert.NoError(t, err)
+
+		actualFS := &cephv1.CephFilesystem{}
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "ocsinit-cephfilesystem"}, actualFS)
+		assert.NoError(t, err)
+
+		// Check metadata pool bulk flag
+		metadataBulkValue, metadataExists := actualFS.Spec.MetadataPool.PoolSpec.Parameters["bulk"]
+		if c.expectedMetadataBulk == "" {
+			assert.False(t, metadataExists, "metadata pool bulk parameter should not exist")
+		} else {
+			assert.True(t, metadataExists, "metadata pool bulk parameter should exist")
+			assert.Equal(t, c.expectedMetadataBulk, metadataBulkValue, "metadata pool bulk parameter value mismatch")
+		}
+
+		// Check data pool bulk flag
+		dataBulkValue, dataExists := actualFS.Spec.DataPools[0].PoolSpec.Parameters["bulk"]
+		if c.expectedDataBulk == "" {
+			assert.False(t, dataExists, "data pool bulk parameter should not exist")
+		} else {
+			assert.True(t, dataExists, "data pool bulk parameter should exist")
+			assert.Equal(t, c.expectedDataBulk, dataBulkValue, "data pool bulk parameter value mismatch")
+		}
 	}
 }

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -140,6 +140,11 @@ func (r *StorageClusterReconciler) createCephObjectStores(cephObjectStores []*ce
 			r.Log.Info("Restoring original CephObjectStore.", "CephObjectStore", klog.KRef(cephObjectStore.Namespace, cephObjectStore.Name))
 			existing.ObjectMeta.OwnerReferences = cephObjectStore.ObjectMeta.OwnerReferences
 			cephObjectStore.ObjectMeta = existing.ObjectMeta
+
+			// Ensures the bulk flag set during new pool creation is not removed during updates.
+			preserveBulkFlagParameter(existing.Spec.MetadataPool.Parameters, &cephObjectStore.Spec.MetadataPool.Parameters)
+			preserveBulkFlagParameter(existing.Spec.DataPool.Parameters, &cephObjectStore.Spec.DataPool.Parameters)
+
 			err = r.Client.Update(context.TODO(), cephObjectStore)
 			if err != nil {
 				r.Log.Error(err, "Failed to update CephObjectStore.", "CephObjectStore", klog.KRef(cephObjectStore.Namespace, cephObjectStore.Name))
@@ -147,6 +152,11 @@ func (r *StorageClusterReconciler) createCephObjectStores(cephObjectStores []*ce
 			}
 		case errors.IsNotFound(err):
 			r.Log.Info("Creating CephObjectStore.", "CephObjectStore", klog.KRef(cephObjectStore.Namespace, cephObjectStore.Name))
+
+			// The bulk flag is set to true only during new pool creation, as setting it on existing pools can cause data movement.
+			setBulkFlagParameter(&cephObjectStore.Spec.MetadataPool.Parameters)
+			setBulkFlagParameter(&cephObjectStore.Spec.DataPool.Parameters)
+
 			err = r.Client.Create(context.TODO(), cephObjectStore)
 			if err != nil {
 				r.Log.Error(err, "Failed to create CephObjectStore.", "CephObjectStore", klog.KRef(cephObjectStore.Namespace, cephObjectStore.Name))


### PR DESCRIPTION
The bulk flag makes the autoscaler start with the max number of PGs, and the autoscaler then decreases the pg count only if the PG usage starts to skew too much. This could improve performance for ODF users due to great amount of parallelism during read/write on large clusters.

We are going to set the bulk flag for now on the default cephBlockPool & replica-1 cephBlockpools, default cephFS metadata pool & data pools, default cephObjectStore metadata pool & data pool.

The flag is set to true only during new pool creation, as setting it on existing pools can cause data movement.

Ref-https://issues.redhat.com/browse/RHSTOR-6774