### PR TITLE
Fix casing do not match warning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage 1
 
-FROM docker.io/library/golang:1.23 as builder
+FROM docker.io/library/golang:1.23 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Docker requires consistent casing for keywords.
If a keyword is in uppercase, all keywords should be in uppercase. If a keyword is in lowercase, all keywords should be in lowercase.