### PR TITLE
Rename hostname key to host in supportedLabels to resolve mismatch

### DIFF
--- a/api/v1/topologymap.go
+++ b/api/v1/topologymap.go
@@ -68,9 +68,9 @@ func (m *NodeTopologyMap) GetKeyValues(topologyKey string) (string, []string) {
 
 	// Supported failure domain labels
 	supportedLabels := map[string]string{
-		"rack":     "topology.rook.io/rack",
-		"hostname": corev1.LabelHostname,
-		"zone":     corev1.LabelZoneFailureDomainStable,
+		"rack": "topology.rook.io/rack",
+		"host": corev1.LabelHostname,
+		"zone": corev1.LabelZoneFailureDomainStable,
 	}
 
 	// Get the specific label based on the topologyKey

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/topologymap.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/topologymap.go
@@ -68,9 +68,9 @@ func (m *NodeTopologyMap) GetKeyValues(topologyKey string) (string, []string) {
 
 	// Supported failure domain labels
 	supportedLabels := map[string]string{
-		"rack":     "topology.rook.io/rack",
-		"hostname": corev1.LabelHostname,
-		"zone":     corev1.LabelZoneFailureDomainStable,
+		"rack": "topology.rook.io/rack",
+		"host": corev1.LabelHostname,
+		"zone": corev1.LabelZoneFailureDomainStable,
 	}
 
 	// Get the specific label based on the topologyKey

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/topologymap.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/topologymap.go
@@ -68,9 +68,9 @@ func (m *NodeTopologyMap) GetKeyValues(topologyKey string) (string, []string) {
 
 	// Supported failure domain labels
 	supportedLabels := map[string]string{
-		"rack":     "topology.rook.io/rack",
-		"hostname": corev1.LabelHostname,
-		"zone":     corev1.LabelZoneFailureDomainStable,
+		"rack": "topology.rook.io/rack",
+		"host": corev1.LabelHostname,
+		"zone": corev1.LabelZoneFailureDomainStable,
 	}
 
 	// Get the specific label based on the topologyKey


### PR DESCRIPTION
The failure domain is determined as "host", but the supportedLabels list used "hostname". This mismatch caused the topologyKey in the spec to be empty during topology generation, as the "host" key was not present. Updated the key in supportedLabels to "host" to resolve the issue.

It was introduced in https://github.com/red-hat-storage/ocs-operator/pull/2965

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
