### PR TITLE
provider: update the replicationID for ramen

### DIFF
--- a/controllers/mirroring/mirroring_controller.go
+++ b/controllers/mirroring/mirroring_controller.go
@@ -355,7 +355,7 @@ func (r *MirroringReconciler) reconcileBlockPoolMirroring(
 				cephBlockPool := blockPoolByName[blockPoolName]
 
 				mirroringToken := response.BlockPoolsInfo[i].MirroringToken
-				secretName := fmt.Sprintf("rbd-mirroring-token-%s", util.CalculateMD5Hash(blockPoolName))
+				secretName := GetMirroringSecretName(blockPoolName)
 				if mirroringToken != "" {
 					mirroringSecret := &corev1.Secret{}
 					mirroringSecret.Name = secretName
@@ -569,4 +569,8 @@ func (r *MirroringReconciler) delete(obj client.Object, opts ...client.DeleteOpt
 
 func (r *MirroringReconciler) own(owner *corev1.ConfigMap, obj client.Object) error {
 	return controllerutil.SetControllerReference(owner, obj, r.Scheme)
+}
+
+func GetMirroringSecretName(blockPoolName string) string {
+	return fmt.Sprintf("rbd-mirroring-token-%s", util.CalculateMD5Hash(blockPoolName))
 }


### PR DESCRIPTION
Ramen's replication ID is combination of storageIDs.

storageID is a combination of cephfsid,cephblockpool id and the rns name
To generate the peerStorageID, 
- use the blockpool's mirroring token to get the peer cephfsid.
- to the cephblockpool id from the peer cluster, use the annotation on the blockpool
- use the rns.Spec.Mirroring.RemoteNamespace to fetch the remote namespace


