### PR TITLE
osd: delete completed prepare pod jobs

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -23,11 +23,13 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	statusutil "github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
@@ -94,6 +96,50 @@ func arbiterEnabled(sc *ocsv1.StorageCluster) bool {
 	return sc.Spec.Arbiter.Enable
 }
 
+func (r *StorageClusterReconciler) deleteJobsWithDuplicateTolerations(sc *ocsv1.StorageCluster) error {
+	// delete the osd prepare jobs which are completed and have duplicate placements
+	jobName := "rook-ceph-osd-prepare"
+	listOpts := &client.ListOptions{
+		Namespace: sc.Namespace,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app": jobName,
+		}),
+	}
+
+	jobs := &batchv1.JobList{}
+	// list all the prepare jobs
+	err := r.Client.List(r.ctx, jobs, listOpts)
+	if err != nil {
+		r.Log.Error(err, "failed to list OSD prepare pod jobs")
+		return err
+	}
+
+	// filter out the completed jobs
+	for _, job := range jobs.Items {
+		if job.Status.Succeeded == 1 {
+			// filter the jobs that has duplicated tolerations
+			tolerations := job.Spec.Template.Spec.Tolerations
+
+			duplicate := make(map[corev1.Toleration]bool)
+			for _, toleration := range tolerations {
+				if duplicate[toleration] {
+					r.Log.Info("deleting completed OSD prepare jobs with duplicate tolerations", "name", klog.KRef(job.Namespace, job.Name))
+					deletePolicy := metav1.DeletePropagationForeground
+					err := r.Client.Delete(r.ctx, &job, &client.DeleteOptions{PropagationPolicy: &deletePolicy})
+					if err != nil {
+						r.Log.Error(err, "failed to delete OSD prepare pod job", "name", klog.KRef(job.Namespace, job.Name))
+						return err
+					}
+					break
+				}
+				duplicate[toleration] = true
+			}
+		}
+	}
+
+	return nil
+}
+
 // ensureCreated ensures that a CephCluster resource exists with its Spec in
 // the desired state.
 func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (reconcile.Result, error) {
@@ -108,6 +154,15 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 
 	if sc.Spec.ExternalStorage.Enable && len(sc.Spec.StorageDeviceSets) != 0 {
 		return reconcile.Result{}, fmt.Errorf("'StorageDeviceSets' should not be initialized in an external CephCluster")
+	}
+
+	// TODO: remove the fix in the next release 4.19
+	// as it is needed only for the upgrade to 4.18
+	if !sc.Spec.ExternalStorage.Enable {
+		err = r.deleteJobsWithDuplicateTolerations(sc)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	for i, ds := range sc.Spec.StorageDeviceSets {


### PR DESCRIPTION
sometimes jobs has duplicate toleartions,
and kube-state-metrics complaints about it
So deleting the jobs that have duplciate toleartions