### PR TITLE
Fix broken dev build process on Mac OS & cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,12 @@ WORKDIR /workspace
 
 COPY . .
 
-ARG GOOS=linux
-ARG GOARCH=amd64
 ARG LDFLAGS
 
-RUN GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o ocs-operator main.go
-RUN GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o provider-api services/provider/main.go
-RUN GOOS="$GOOS" GOARCH="$GOARCH" go build -tags netgo,osusergo -o onboarding-validation-keys-gen onboarding-validation-keys-generator/main.go
-RUN GOOS="$GOOS" GOARCH="$GOARCH" go build -tags netgo,osusergo -o ux-backend-server services/ux-backend/main.go
+RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o ocs-operator main.go
+RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o provider-api services/provider/main.go
+RUN go build -tags netgo,osusergo -o onboarding-validation-keys-gen onboarding-validation-keys-generator/main.go
+RUN go build -tags netgo,osusergo -o ux-backend-server services/ux-backend/main.go
 
 # Build stage 2
 

--- a/hack/build-metrics-exporter.sh
+++ b/hack/build-metrics-exporter.sh
@@ -6,6 +6,6 @@ source hack/common.sh
 source hack/docker-common.sh
 
 pushd metrics
-${IMAGE_BUILD_CMD} build --no-cache -f Dockerfile -t "${METRICS_EXPORTER_FULL_IMAGE_NAME}" . \
-    --build-arg="GOOS=${GOOS}" --build-arg="GOARCH=${GOARCH}" --build-arg="LDFLAGS=${LDFLAGS}"
+${IMAGE_BUILD_CMD} build -f Dockerfile -t "${METRICS_EXPORTER_FULL_IMAGE_NAME}" . \
+    --build-arg="LDFLAGS=${LDFLAGS}" --platform="${TARGET_OS}"/"${TARGET_ARCH}"
 popd

--- a/hack/build-operator-bundle.sh
+++ b/hack/build-operator-bundle.sh
@@ -5,6 +5,6 @@ set -e
 source hack/common.sh
 source hack/docker-common.sh
 
-${IMAGE_BUILD_CMD} build --platform="${GOOS}"/"${GOARCH}" --no-cache -t "$BUNDLE_FULL_IMAGE_NAME" -f Dockerfile.bundle .
+${IMAGE_BUILD_CMD} build --platform="${TARGET_OS}"/"${TARGET_ARCH}" -t "$BUNDLE_FULL_IMAGE_NAME" -f Dockerfile.bundle .
 echo
 echo "Run '${IMAGE_BUILD_CMD} push ${BUNDLE_FULL_IMAGE_NAME}' to push operator bundle to image registry."

--- a/hack/build-operator-catalog.sh
+++ b/hack/build-operator-catalog.sh
@@ -17,6 +17,6 @@ ${OPM} validate catalog
 ${OPM} generate dockerfile catalog
 
 mv catalog.Dockerfile Dockerfile.catalog
-${IMAGE_BUILD_CMD} build --platform="${GOOS}"/"${GOARCH}" --no-cache -t "${FILE_BASED_CATALOG_FULL_IMAGE_NAME}" -f Dockerfile.catalog .
+${IMAGE_BUILD_CMD} build --platform="${TARGET_OS}"/"${TARGET_ARCH}" --no-cache -t "${FILE_BASED_CATALOG_FULL_IMAGE_NAME}" -f Dockerfile.catalog .
 
 echo "Run '${IMAGE_BUILD_CMD} push ${FILE_BASED_CATALOG_FULL_IMAGE_NAME}' to push operator catalog image to image registry."

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -5,5 +5,5 @@ set -e
 source hack/common.sh
 source hack/docker-common.sh
 
-${IMAGE_BUILD_CMD} build --no-cache -t "${OPERATOR_FULL_IMAGE_NAME}" . \
-    --build-arg="GOOS=${GOOS}" --build-arg="GOARCH=${GOARCH}" --build-arg="LDFLAGS=${LDFLAGS}"
+${IMAGE_BUILD_CMD} build -t "${OPERATOR_FULL_IMAGE_NAME}" . \
+    --build-arg="LDFLAGS=${LDFLAGS}" --platform="${TARGET_OS}"/"${TARGET_ARCH}"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -3,10 +3,10 @@
 # shellcheck disable=SC2034
 # disable unused variable warnings
 
-GOOS="${GOOS:-linux}"
-GOARCH="${GOARCH:-amd64}"
-GOHOSTOS="$(go env GOHOSTOS)"
-GOHOSTARCH="$(go env GOHOSTARCH)"
+TARGET_OS="${TARGET_OS:-linux}"
+TARGET_ARCH="${TARGET_ARCH:-amd64}"
+HOST_OS="$(go env GOHOSTOS)"
+HOST_ARCH="$(go env GOHOSTARCH)"
 
 GO_LINT_IMG_LOCATION="${GO_LINT_IMG_LOCATION:-golangci/golangci-lint}"
 GO_LINT_IMG_TAG="${GO_LINT_IMG_TAG:-v1.49.0}"

--- a/hack/ensure-operator-sdk.sh
+++ b/hack/ensure-operator-sdk.sh
@@ -4,7 +4,7 @@ set -e
 
 source hack/common.sh
 
-OPERATOR_SDK_DL_URL="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_${GOHOSTOS}_${GOHOSTARCH}"
+OPERATOR_SDK_DL_URL="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_${HOST_OS}_${HOST_ARCH}"
 
 mkdir -p "${LOCALBIN}"
 

--- a/hack/ensure-opm.sh
+++ b/hack/ensure-opm.sh
@@ -4,7 +4,7 @@ set -e
 
 source hack/common.sh
 
-OPM_DL_URL="https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/${GOHOSTOS}-${GOHOSTARCH}-opm"
+OPM_DL_URL="https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/${HOST_OS}-${HOST_ARCH}-opm"
 mkdir -p "${LOCALBIN}"
 
 if [ ! -x "${OPM}" ]; then

--- a/hack/gen-protobuf.sh
+++ b/hack/gen-protobuf.sh
@@ -6,15 +6,15 @@ source hack/common.sh
 
 mkdir -p "${LOCALBIN}" "${GRPC_BIN}" "${PROTO_GOOGLE}"
 
-if [[ ${GOHOSTOS} == "linux" ]]; then
+if [[ ${HOST_OS} == "linux" ]]; then
 	PROTOC_OS="linux"
-elif [[ ${GOHOSTOS} == "darwin" ]]; then
+elif [[ ${HOST_OS} == "darwin" ]]; then
 	PROTOC_OS="osx"
 fi
 
-if [[ ${GOHOSTARCH} == "amd64" ]]; then
+if [[ ${HOST_ARCH} == "amd64" ]]; then
 	PROTOC_ARCH="x86_64"
-elif [[ ${GOHOSTARCH} == "arm64" ]]; then
+elif [[ ${HOST_ARCH} == "arm64" ]]; then
 	PROTOC_ARCH="aarch_64"
 fi
 

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -6,13 +6,13 @@ source hack/common.sh
 
 mkdir -p "${LOCALBIN}"
 
-if [[ ${GOHOSTARCH} == "amd64" ]]; then
+if [[ ${HOST_ARCH} == "amd64" ]]; then
         SHELLCHECK_ARCH="x86_64"
-elif [[ ${GOHOSTARCH} == "arm64" ]]; then
+elif [[ ${HOST_ARCH} == "arm64" ]]; then
         SHELLCHECK_ARCH="aarch64"
 fi
 
-SHELLCHECK_TAR="shellcheck-${SHELLCHECK_VERSION}.${GOHOSTOS}.${SHELLCHECK_ARCH}.tar.gz"
+SHELLCHECK_TAR="shellcheck-${SHELLCHECK_VERSION}.${HOST_OS}.${SHELLCHECK_ARCH}.tar.gz"
 SHELLCHECK_DL_URL="https://github.com/vscode-shellcheck/shellcheck-binaries/releases/download/${SHELLCHECK_VERSION}/${SHELLCHECK_TAR}"
 
 #install shellcheck

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -6,11 +6,9 @@ WORKDIR /workspace
 
 COPY . .
 
-ARG GOOS=linux
-ARG GOARCH=amd64
 ARG LDFLAGS
 
-RUN GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o metrics-exporter main.go
+RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o metrics-exporter main.go
 
 # Build stage 2
 


### PR DESCRIPTION
The development build for the ocs-operator image on macOS/arm64 was broken due to the `hack/entrypoint.sh` script being copied as a arm64 binary during the Docker build process. This caused execution failures on the amd64 based OpenShift cluster.
To resolve this, the `--platform` flag has been added to the Docker build command to ensure the base image and build process match the target OS/architecture. This ensures that the built binaries and shell script are correctly generated for the target environment.