### PR TITLE
DFBUGS-1659: [release-4.15] Restore default affinity for noobaa standalone & clear if set previously

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -157,7 +157,15 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	placement := getPlacement(sc, component)
 
 	nb.Spec.Tolerations = placement.Tolerations
-	nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
+
+	if !r.IsNoobaaStandalone || ok {
+		// Add affinity if not in noobaa-standalone mode or if placement is specified
+		nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
+	} else if nb.Spec.Affinity != nil {
+		// Clear the affinity if it was set previously to handle upgrades
+		nb.Spec.Affinity = nil
+	}
+
 	nb.Spec.DBVolumeResources = &dBVolumeResources
 	nb.Spec.Image = &r.images.NooBaaCore
 	nb.Spec.DBImage = &r.images.NooBaaDB


### PR DESCRIPTION
We are adding affinity to Noobaa if not in noobaa-standalone mode or if placement is specified. We are also clearing the affinity if it was set previously to handle upgrade.

Combined manual backport of https://github.com/red-hat-storage/ocs-operator/pull/2797, https://github.com/red-hat-storage/ocs-operator/pull/2851