### PR TITLE
DFBUGS-1603: [release-4.17] Use Required Pod anti affinity if Active MDS is not more than 1

### DIFF
--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -75,7 +75,7 @@ var (
 				getOcsToleration(),
 			},
 			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 					// left the selector value empty as it will be updated later in the getPlacement()
 				},
 			},

--- a/controllers/storagecluster/placement_test.go
+++ b/controllers/storagecluster/placement_test.go
@@ -368,21 +368,18 @@ func TestGetPlacement(t *testing.T) {
 					NodeAffinity: defaults.DefaultNodeAffinity,
 					Tolerations:  defaults.DaemonPlacements["mds"].Tolerations,
 					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "rook_file_system",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"storage-test-cephfilesystem"},
-											},
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "rook_file_system",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"storage-test-cephfilesystem"},
 										},
 									},
-									TopologyKey: zoneTopologyLabel,
 								},
+								TopologyKey: zoneTopologyLabel,
 							},
 						},
 					},
@@ -508,18 +505,18 @@ func TestGetPlacement(t *testing.T) {
 
 		expectedPlacement = c.expectedPlacements["mds"]
 		testPodAffinity := &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				defaults.GetMdsWeightedPodAffinityTerm(100, generateNameForCephFilesystem(sc)),
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				defaults.GetMdsWeightedPodAffinityTerm(100, generateNameForCephFilesystem(sc)).PodAffinityTerm,
 			},
 		}
 		if expectedPlacement.PodAntiAffinity != nil {
 			topologyKeys := ""
-			if len(expectedPlacement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0 {
-				topologyKeys = expectedPlacement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey
+			if len(expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 {
+				topologyKeys = expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].TopologyKey
 			}
-			expectedPlacement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = testPodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = testPodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 			if topologyKeys != "" {
-				expectedPlacement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey = topologyKeys
+				expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].TopologyKey = topologyKeys
 			}
 		}
 		actualPlacement = getPlacement(sc, "mds")


### PR DESCRIPTION
When Active MDS is 1, there would be 2 mds pods & we want them to be scheduled on different nodes always. So we use the required pod anti-affinity. If Active MDS are more than 1 then in a 3 node cluster scheduling issues would be there, so we switch to using preferred anti-affinity.

Manual backport of https://github.com/red-hat-storage/ocs-operator/pull/3035