### PR TITLE
DFBUGS-1668: [release-4.16] Fix conflict between SSD and HDD device classes causing CRUSH rule issue

### DIFF
--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -1770,6 +1770,76 @@ func TestDetermineDefaultCephDeviceClass(t *testing.T) {
 			},
 			expectedDeviceClass: "gold",
 		},
+		{
+			label: "Case 10: Replica 1 is not enabled, both hdd & ssd are in status, with hdd coming 1st",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "hdd",
+				},
+				{
+					Name: "ssd",
+				},
+			},
+			expectedDeviceClass: "ssd",
+		},
+		{
+			label: "Case 11: Replica 1 is not enabled, hdd with few other device classes are in status with hdd coming 1st",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "hdd",
+				},
+				{
+					Name: "gold",
+				},
+				{
+					Name: "silver",
+				},
+			},
+			expectedDeviceClass: "hdd",
+		},
+		{
+			label: "Case 12: Replica 1 is enabled, both hdd & ssd are in status along with replica-1 deviceclasses, with hdd coming 1st",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "hdd",
+				},
+				{
+					Name: "zone1",
+				},
+				{
+					Name: "zone2",
+				},
+				{
+					Name: "zone3",
+				},
+				{
+					Name: "ssd",
+				},
+			},
+			isReplica1:            true,
+			replica1DeviceClasses: []string{"zone1", "zone2", "zone3"},
+			expectedDeviceClass:   "ssd",
+		},
+		{
+			label: "Case 13: Replica 1 is enabled, hdd is in status along with replica-1 deviceclasses",
+			foundDeviceClasses: []rookCephv1.DeviceClasses{
+				{
+					Name: "zone1",
+				},
+				{
+					Name: "zone2",
+				},
+				{
+					Name: "zone3",
+				},
+				{
+					Name: "hdd",
+				},
+			},
+			isReplica1:            true,
+			replica1DeviceClasses: []string{"zone1", "zone2", "zone3"},
+			expectedDeviceClass:   "hdd",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
In clusters where the devices were initially of type hdd and later replaced with ssd, Ceph continues to list hdd in the available device classes under ceph osd crush class ls. This occurs even after all devices have been replaced with ssd. As rook populates the available device classes from this list, the hdd device class persists in the CephCluster status.

Starting from OCS 4.16, OCS operator determines and assigns a defaultCephDeviceClass to all pools by selecting the first non-replica-1 entry in the CephCluster status. Due to the persistence of the hdd device class, the OCS operator incorrectly selects hdd as the default device class, even though all underlying device sets have been updated to ssd.

To address this issue, we are introducing a hardcoded check in the OCS operator: if both hdd and ssd device classes are present in the CephCluster status, the operator will prioritize and select the ssd device class as the default. Ideally Ceph should automatically update the device class list when devices are replaced, so may be a fix is required on ceph side as well.