### PR TITLE
mirroring: requeue if mirroring token is not generated

### DIFF
--- a/controllers/mirroring/mirroring_controller.go
+++ b/controllers/mirroring/mirroring_controller.go
@@ -375,6 +375,14 @@ func (r *MirroringReconciler) reconcileBlockPoolMirroring(
 						errorOccurred = true
 						continue
 					}
+				} else {
+					// Mirroring Token is generated only after mirroring is enabled. If both sides reconcile at the
+					// same time the mirroring token won't be fetched. Hence, re-queuing to avoid this
+					r.log.Error(
+						fmt.Errorf("peer's CephBlockPool mirroring token is not generated"),
+						"Re-queuing as peer's CephBlockPool mirroring token is not generated",
+					)
+					errorOccurred = true
 				}
 
 				// We need to enable mirroring for the blockPool, else the mirroring secret will not be generated

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -826,7 +826,7 @@ func (s *OCSProviderServer) GetStorageClaimConfig(ctx context.Context, req *pb.S
 					blockPool.Namespace,
 				)
 				if err != nil {
-					klog.Errorf("failed to get peer Ceph FSIS. %v", err)
+					klog.Errorf("failed to get peer Ceph FSID. %v", err)
 				}
 
 				peerStorageID := calculateCephRbdStorageID(


### PR DESCRIPTION
mirroring token is generated only after mirroring is enabled. If both sides reconcile simultaneously (in parallel) the mirroring token won't be fetched. Hence, we re-queue when an empty mirroring token is fetched.


[DFBUGS-1682](https://issues.redhat.com/browse/DFBUGS-1682)