### PR TITLE
DFBUGS-1702: [release-4.16] Delete the succeeded pods with duplicate tolerations to avoid alert

### DIFF
--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -113,6 +113,21 @@ func GetPodsWithLabels(ctx context.Context, kubeClient client.Client, namespace 
 	return podList, nil
 }
 
+// HasDuplicateTolerations returns true if a list has duplicate tolerations
+func HasDuplicateTolerations(tolerations []corev1.Toleration) bool {
+	if len(tolerations) < 2 {
+		return false
+	}
+	duplicate := make(map[corev1.Toleration]bool)
+	for _, toleration := range tolerations {
+		if duplicate[toleration] {
+			return true
+		}
+		duplicate[toleration] = true
+	}
+	return false
+}
+
 // GetStorageClassWithName returns the storage class object by name
 func GetStorageClassWithName(ctx context.Context, kubeClient client.Client, name string) *storagev1.StorageClass {
 	sc := &storagev1.StorageClass{}


### PR DESCRIPTION
PrometheusDuplicateTimestamps alert is generated due to the presence of duplicate tolerations on the osd-prepare job pods & osd-key-rotation cronjob pods. Although the root of the issue has been fixed with another fix, the existing succeeded pods need to be cleaned up to stop the alert.
Manual backport of https://github.com/red-hat-storage/ocs-operator/pull/3056