### PR TITLE
Set mon_target_pg_per_osd to 400 for better performance from higher PG count

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -570,6 +570,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 			UpgradeOSDRequiresHealthyPGs: sc.Spec.ManagedResources.CephCluster.UpgradeOSDRequiresHealthyPGs,
 			// if resource profile change is in progress, then set this flag to false
 			ContinueUpgradeAfterChecksEvenIfNotHealthy: sc.Spec.ResourceProfile == sc.Status.LastAppliedResourceProfile,
+			CephConfig: map[string]map[string]string{
+				"global": {
+					"mon_target_pg_per_osd": "400",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
The mon_target_pg_per_osd parameter determines the recommended total PG count and PG-per-OSD ratio. The default value is 100, but setting it to 400 improves performance by increasing parallelism through a higher PG count. 
On existing clusters this can trigger data movement and rebalancing.
https://issues.redhat.com/browse/DFBUGS-2249