### PR TITLE
mgr: disable mgr liveness and startup probe

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -546,6 +546,18 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 				rookCephv1.KeyMonitoring:   getCephClusterMonitoringLabels(*sc),
 				rookCephv1.KeyCephExporter: getCephClusterMonitoringLabels(*sc),
 			},
+			HealthCheck: rookCephv1.CephClusterHealthCheckSpec{
+				LivenessProbe: map[rookCephv1.KeyType]*rookCephv1.ProbeSpec{
+					rookCephv1.KeyMgr: {
+						Disabled: true,
+					},
+				},
+				StartupProbe: map[rookCephv1.KeyType]*rookCephv1.ProbeSpec{
+					rookCephv1.KeyMgr: {
+						Disabled: true,
+					},
+				},
+			},
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: util.GetReadAffinityOptions(sc),
 				CephFS: rookCephv1.CSICephFSSpec{


### PR DESCRIPTION
there is a bug in ceph https://tracker.ceph.com/issues/70571 until that is fixed diabling the probes