### PR TITLE
unless explicitly mentioned infer providerApiServerService type from hostNetwork

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -97,7 +97,8 @@ type StorageClusterSpec struct {
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
-	// The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+	// The default ServiceType is derived from hostNetwork field.
+	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	ProviderAPIServerServiceType corev1.ServiceType `json:"providerAPIServerServiceType,omitempty"`
 
 	// EnableCephTools toggles on whether or not the ceph tools pod

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -5135,7 +5135,11 @@ spec:
               providerAPIServerServiceType:
                 description: |-
                   ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
-                  The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+                  The default ServiceType is derived from hostNetwork field.
+                enum:
+                - ClusterIP
+                - NodePort
+                - LoadBalancer
                 type: string
               resourceProfile:
                 description: |-

--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -64,8 +64,11 @@ func (o *ocsProviderServer) ensureDeleted(r *StorageClusterReconciler, instance 
 
 	var finalErr error
 
+	apiServerService := &corev1.Service{}
+	apiServerService.Name = ocsProviderServerName
+	apiServerService.Namespace = instance.Namespace
 	for _, resource := range []client.Object{
-		GetProviderAPIServerService(instance),
+		apiServerService,
 		GetProviderAPIServerDeployment(instance),
 	} {
 		err := r.Client.Delete(r.ctx, resource)
@@ -128,18 +131,6 @@ func (o *ocsProviderServer) createDeployment(r *StorageClusterReconciler, instan
 
 func (o *ocsProviderServer) createService(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
-	if instance.Spec.ProviderAPIServerServiceType != "" {
-		switch instance.Spec.ProviderAPIServerServiceType {
-		case corev1.ServiceTypeClusterIP, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort:
-		default:
-			err := fmt.Errorf("providerAPIServer only supports service of type %s, %s and %s",
-				corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeClusterIP)
-			r.Log.Error(err, "Failed to create/update service, Requested ServiceType is", "ServiceType", instance.Spec.ProviderAPIServerServiceType)
-			return reconcile.Result{}, err
-		}
-
-	}
-
 	desiredService := GetProviderAPIServerService(instance)
 	actualService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -170,7 +161,7 @@ func (o *ocsProviderServer) createService(r *StorageClusterReconciler, instance 
 
 	r.Log.Info("Service create/update succeeded")
 
-	switch instance.Spec.ProviderAPIServerServiceType {
+	switch desiredService.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		endpoint := o.getLoadBalancerServiceEndpoint(actualService)
 
@@ -185,7 +176,7 @@ func (o *ocsProviderServer) createService(r *StorageClusterReconciler, instance 
 	case corev1.ServiceTypeClusterIP:
 		instance.Status.StorageProviderEndpoint = fmt.Sprintf("%s:%d", actualService.Spec.ClusterIP, ocsProviderServicePort)
 
-	default: // Nodeport is the default ServiceType for the provider server
+	case corev1.ServiceTypeNodePort:
 		nodeAddresses, err := o.getWorkerNodesInternalIPAddresses(r)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -333,11 +324,12 @@ func GetProviderAPIServerDeployment(instance *ocsv1.StorageCluster) *appsv1.Depl
 }
 
 func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service {
-
-	if instance.Spec.ProviderAPIServerServiceType == "" {
-		instance.Spec.ProviderAPIServerServiceType = corev1.ServiceTypeNodePort
+	serviceType := corev1.ServiceTypeClusterIP
+	if instance.Spec.ProviderAPIServerServiceType != "" {
+		serviceType = instance.Spec.ProviderAPIServerServiceType
+	} else if instance.Spec.HostNetwork {
+		serviceType = corev1.ServiceTypeNodePort
 	}
-
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ocsProviderServerName,
@@ -354,7 +346,7 @@ func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service
 				{
 					NodePort: func() int32 {
 						// ClusterIP service doesn't need nodePort
-						if instance.Spec.ProviderAPIServerServiceType == corev1.ServiceTypeClusterIP {
+						if serviceType == corev1.ServiceTypeClusterIP {
 							return 0
 						}
 						return ocsProviderServiceNodePort
@@ -363,7 +355,7 @@ func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service
 					TargetPort: intstr.FromString("ocs-provider"),
 				},
 			},
-			Type: instance.Spec.ProviderAPIServerServiceType,
+			Type: serviceType,
 		},
 	}
 }

--- a/controllers/storagecluster/provider_server_test.go
+++ b/controllers/storagecluster/provider_server_test.go
@@ -27,7 +27,7 @@ func TestOcsProviderServerEnsureCreated(t *testing.T) {
 
 	t.Run("Ensure that Deployment,Service is created when storageCluster is created", func(t *testing.T) {
 
-		r, instance := createSetupForOcsProviderTest(t, "")
+		r, instance := createSetupForOcsProviderTest(t, corev1.ServiceTypeNodePort)
 
 		obj := &ocsProviderServer{}
 		res, err := obj.ensureCreated(r, instance)
@@ -194,18 +194,6 @@ func TestOcsProviderServerEnsureCreated(t *testing.T) {
 		assert.Equal(t, expectedService.Spec, service.Spec)
 	})
 
-	t.Run("Ensure that Service is not created when ProviderAPIServerServiceType is set to any other value than NodePort, ClusterIP or LoadBalancer", func(t *testing.T) {
-
-		r, instance := createSetupForOcsProviderTest(t, corev1.ServiceTypeExternalName)
-
-		obj := &ocsProviderServer{}
-		_, err := obj.ensureCreated(r, instance)
-		assert.Errorf(t, err, "only supports service of type")
-		service := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{Name: ocsProviderServerName},
-		}
-		assert.True(t, errors.IsNotFound(r.Client.Get(context.TODO(), client.ObjectKeyFromObject(service), service)))
-	})
 }
 
 func TestOcsProviderServerEnsureDeleted(t *testing.T) {

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -5135,7 +5135,11 @@ spec:
               providerAPIServerServiceType:
                 description: |-
                   ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
-                  The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+                  The default ServiceType is derived from hostNetwork field.
+                enum:
+                - ClusterIP
+                - NodePort
+                - LoadBalancer
                 type: string
               resourceProfile:
                 description: |-

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -5137,7 +5137,11 @@ spec:
               providerAPIServerServiceType:
                 description: |-
                   ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
-                  The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+                  The default ServiceType is derived from hostNetwork field.
+                enum:
+                - ClusterIP
+                - NodePort
+                - LoadBalancer
                 type: string
               resourceProfile:
                 description: |-

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -97,7 +97,8 @@ type StorageClusterSpec struct {
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
-	// The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+	// The default ServiceType is derived from hostNetwork field.
+	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	ProviderAPIServerServiceType corev1.ServiceType `json:"providerAPIServerServiceType,omitempty"`
 
 	// EnableCephTools toggles on whether or not the ceph tools pod

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -97,7 +97,8 @@ type StorageClusterSpec struct {
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.
-	// The supported values are NodePort or LoadBalancer. The default ServiceType is NodePort if the value is empty.
+	// The default ServiceType is derived from hostNetwork field.
+	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	ProviderAPIServerServiceType corev1.ServiceType `json:"providerAPIServerServiceType,omitempty"`
 
 	// EnableCephTools toggles on whether or not the ceph tools pod


### PR DESCRIPTION
only serving storage to external clients requires provider api server reach-ability which can be inferred from storagecluster hostNetwork field and in other scenarios clusterIP is used as default to serve local client.