### PR TITLE
set noobaa account availability explicitly for reconciling the resource

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -296,15 +296,10 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 				return reconcile.Result{}, err
 			}
 
-		}
-
-		// A provider cluster already has a NooBaa system and does not require a NooBaa account
-		// to connect to a remote cluster, unlike client clusters.
-		// A NooBaa account only needs to be created if the storage consumer is for a client cluster.
-		clusterID := util.GetClusterID(r.ctx, r.Client, &r.Log)
-		if clusterID != "" && r.storageConsumer.Status.Client.ClusterID != clusterID {
-			if err := r.reconcileNoobaaAccount(); err != nil {
-				return reconcile.Result{}, err
+			if consumerResources.GetNoobaaAccountApplicability() != util.ValueNotApplicable {
+				if err := r.reconcileNoobaaAccount(); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 

--- a/controllers/util/storageconsumer.go
+++ b/controllers/util/storageconsumer.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 )
 
-// Constants for ConfigMap keys
 const (
+	ValueNotApplicable = "N/A"
+
+	// Constants for ConfigMap keys
 	rbdRadosNamespaceKey            = "rbd-rados-ns"
 	subVolumeGroupKey               = "cephfs-subvolumegroup"
 	subVolumeGroupRadosNamespaceKey = "cephfs-subvolumegroup-rados-ns"
@@ -18,6 +20,7 @@ const (
 	rbdClientProfileKey             = "csiop-rbd-client-profile"
 	cephFsClientProfileKey          = "csiop-cephfs-client-profile"
 	nfsClientProfileKey             = "csiop-nfs-client-profile"
+	noobaaAccountKey                = "noobaa-account"
 )
 
 type StorageConsumerResources interface {
@@ -34,6 +37,7 @@ type StorageConsumerResources interface {
 	GetRbdClientProfileName() string
 	GetCephFsClientProfileName() string
 	GetNfsClientProfileName() string
+	GetNoobaaAccountApplicability() string
 
 	// Setters
 	SetRbdRadosNamespaceName(string)
@@ -48,6 +52,7 @@ type StorageConsumerResources interface {
 	SetRbdClientProfileName(string)
 	SetCephFsClientProfileName(string)
 	SetNfsClientProfileName(string)
+	MarkNoobaaAccountNotApplicable()
 }
 
 type storageConsumerResourceMapWrapper struct {
@@ -107,6 +112,10 @@ func (wrapper storageConsumerResourceMapWrapper) GetNfsClientProfileName() strin
 	return wrapper.data[nfsClientProfileKey]
 }
 
+func (wrapper storageConsumerResourceMapWrapper) GetNoobaaAccountApplicability() string {
+	return wrapper.data[noobaaAccountKey]
+}
+
 // Setters
 func (wrapper storageConsumerResourceMapWrapper) SetRbdRadosNamespaceName(name string) {
 	wrapper.data[rbdRadosNamespaceKey] = name
@@ -154,6 +163,10 @@ func (wrapper storageConsumerResourceMapWrapper) SetCephFsClientProfileName(name
 
 func (wrapper storageConsumerResourceMapWrapper) SetNfsClientProfileName(name string) {
 	wrapper.data[nfsClientProfileKey] = name
+}
+
+func (wrapper storageConsumerResourceMapWrapper) MarkNoobaaAccountNotApplicable() {
+	wrapper.data[noobaaAccountKey] = ValueNotApplicable
 }
 
 func GetStorageConsumerDefaultResourceNames(storageConsumerName, fsid string) map[string]string {

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 )
 
-// Constants for ConfigMap keys
 const (
+	ValueNotApplicable = "N/A"
+
+	// Constants for ConfigMap keys
 	rbdRadosNamespaceKey            = "rbd-rados-ns"
 	subVolumeGroupKey               = "cephfs-subvolumegroup"
 	subVolumeGroupRadosNamespaceKey = "cephfs-subvolumegroup-rados-ns"
@@ -18,6 +20,7 @@ const (
 	rbdClientProfileKey             = "csiop-rbd-client-profile"
 	cephFsClientProfileKey          = "csiop-cephfs-client-profile"
 	nfsClientProfileKey             = "csiop-nfs-client-profile"
+	noobaaAccountKey                = "noobaa-account"
 )
 
 type StorageConsumerResources interface {
@@ -34,6 +37,7 @@ type StorageConsumerResources interface {
 	GetRbdClientProfileName() string
 	GetCephFsClientProfileName() string
 	GetNfsClientProfileName() string
+	GetNoobaaAccountApplicability() string
 
 	// Setters
 	SetRbdRadosNamespaceName(string)
@@ -48,6 +52,7 @@ type StorageConsumerResources interface {
 	SetRbdClientProfileName(string)
 	SetCephFsClientProfileName(string)
 	SetNfsClientProfileName(string)
+	MarkNoobaaAccountNotApplicable()
 }
 
 type storageConsumerResourceMapWrapper struct {
@@ -107,6 +112,10 @@ func (wrapper storageConsumerResourceMapWrapper) GetNfsClientProfileName() strin
 	return wrapper.data[nfsClientProfileKey]
 }
 
+func (wrapper storageConsumerResourceMapWrapper) GetNoobaaAccountApplicability() string {
+	return wrapper.data[noobaaAccountKey]
+}
+
 // Setters
 func (wrapper storageConsumerResourceMapWrapper) SetRbdRadosNamespaceName(name string) {
 	wrapper.data[rbdRadosNamespaceKey] = name
@@ -154,6 +163,10 @@ func (wrapper storageConsumerResourceMapWrapper) SetCephFsClientProfileName(name
 
 func (wrapper storageConsumerResourceMapWrapper) SetNfsClientProfileName(name string) {
 	wrapper.data[nfsClientProfileKey] = name
+}
+
+func (wrapper storageConsumerResourceMapWrapper) MarkNoobaaAccountNotApplicable() {
+	wrapper.data[noobaaAccountKey] = ValueNotApplicable
 }
 
 func GetStorageConsumerDefaultResourceNames(storageConsumerName, fsid string) map[string]string {


### PR DESCRIPTION
after consumer is enabled, client doesn't report status instantaneously
and if it's empty we reconcileNoobaaAccount once, which'll get into a
deadlock as noobaa will not be ready until we send storageconfig for
storageclass creation which will check for consumer readiness and it'll
never be ready.

to fix above and introduce configurability we introduce a new option
for explicity mentioning the need of noobaa account while creating
storageconsumer.