### PR TITLE
rdr: update the controller/server for rdr after convergence

### DIFF
--- a/controllers/storagecluster/odfinfoconfig.go
+++ b/controllers/storagecluster/odfinfoconfig.go
@@ -171,6 +171,9 @@ func getConnectedClients(r *StorageClusterReconciler, storageCluster *ocsv1.Stor
 
 	for storageConsumerIdx := range storageConsumers.Items {
 		storageConsumer := &storageConsumers.Items[storageConsumerIdx]
+		if !storageConsumer.Spec.Enable {
+			continue
+		}
 		clusterID := storageConsumer.Status.Client.ClusterID
 		name := storageConsumer.Status.Client.Name
 		newConnectedClient := ocsv1a1.ConnectedClient{

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1636,17 +1636,19 @@ func (s *OCSProviderServer) GetStorageClientsInfo(ctx context.Context, req *pb.S
 			continue
 		}
 
+		if !consumer.Spec.Enable {
+			klog.Infof("consumer is not yet enaled skipping %v", req.ClientIDs[i])
+			continue
+		}
+
 		idx := slices.IndexFunc(consumer.OwnerReferences, func(ref metav1.OwnerReference) bool {
 			return ref.Kind == "StorageCluster"
 		})
-
 		if idx == -1 {
 			klog.Infof("no owner found for consumer %v", req.ClientIDs[i])
 			continue
 		}
-
 		owner := &consumer.OwnerReferences[idx]
-
 		if owner.UID != types.UID(req.StorageClusterUID) {
 			klog.Infof("storageCluster specified on the req does not own the client %v", req.ClientIDs[i])
 			continue
@@ -1666,10 +1668,12 @@ func (s *OCSProviderServer) GetStorageClientsInfo(ctx context.Context, req *pb.S
 			klog.Error(err)
 			continue
 		}
+
 		clientInfo := &pb.ClientInfo{ClientID: req.ClientIDs[i]}
 
-		if radosNamespace := consumerConfigMap.Data["rados-namespace-name"]; radosNamespace != "" {
-			clientInfo.RadosNamespace = radosNamespace
+		consumerConfig := util.WrapStorageConsumerResourceMap(consumerConfigMap.Data)
+		if consumerConfig.GetRbdRadosNamespaceName() != "" {
+			clientInfo.RadosNamespace = consumerConfig.GetRbdRadosNamespaceName()
 		}
 
 		response.ClientsInfo = append(response.ClientsInfo, clientInfo)


### PR DESCRIPTION
This PR does the following:
- update the blockpool mirroring mode to init-only - ceph requires the blockpools to be enabled for mirroring before we enable mirroring for the rns. The init-only mode specifies that a particular blockpool's rns are ready to be mirrored 
- send consumers/client info in odf-info if they are enabled - If a consumer is not enabled, we shouldn't let ACM read the information about the consumer
- use StorageConsumerResources in GetStorageClientsInfo to fetch the right rns - Till 4.18 we had one rns per consumer hence the assumption that we had to send the rns held. But with 4.19 we are moving to multiple rns with the same rns name and which is stored in a configmap, hence moving to fetch the configmap and using the rns name in the configmap
- fetch the rns using ownerRef instead of labels - till 4.18, we didn't have an ownerRef of consumer on the rns as it was created by StorageRequest controller. So we relied on labels. From 4.19 we are directly creating the rns CR and hence we can add the ownerRef