### PR TITLE
check consumer status for clusterid before reconciling noobaaaccount

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -302,7 +302,10 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 		// to connect to a remote cluster, unlike client clusters.
 		// A NooBaa account only needs to be created if the storage consumer is for a client cluster.
 		clusterID := util.GetClusterID(r.ctx, r.Client, &r.Log)
-		if clusterID != "" && r.storageConsumer.Status.Client.ClusterID != clusterID {
+		clientStatus := &r.storageConsumer.Status.Client
+		if clusterID != "" &&
+			clientStatus.ClusterID != "" &&
+			clientStatus.ClusterID != clusterID {
 			if err := r.reconcileNoobaaAccount(); err != nil {
 				return reconcile.Result{}, err
 			}


### PR DESCRIPTION
after consumer is enabled, client doesn't report status instantaneously and if it's empty we reconcileNoobaaAccount once, which'll get into a deadlock as noobaa will not be ready until we send storageconfig for storageclass creation which will check for consumer readiness and it'll never be ready.