### PR TITLE
Set metadata pool spec on the cephFS metadata pool

### DIFF
--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -72,7 +72,7 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 	}
 
 	// Set default values in the metadata pool spec as necessary
-	setDefaultDataPoolSpec(&ret.Spec.MetadataPool.PoolSpec, initStorageCluster)
+	setDefaultMetadataPoolSpec(&ret.Spec.MetadataPool.PoolSpec, initStorageCluster)
 
 	err := controllerutil.SetControllerReference(initStorageCluster, ret, r.Scheme)
 	if err != nil {


### PR DESCRIPTION
We were mistakenly using the data pool spec
for the metadata pool.