### PR TITLE
storageautoscaler: match the storagecluster uid with storageutoscaler

### DIFF
--- a/api/v1/storageautoscaler_types.go
+++ b/api/v1/storageautoscaler_types.go
@@ -26,7 +26,7 @@ import (
 type StorageAutoScalerSpec struct {
 	// StorageCluster is the name of the storage cluster for which the storage scaling is to be done.
 	// +kubebuilder:validation:Required
-	StorageCluster corev1.LocalObjectReference `json:"storageCluster,omitempty"`
+	StorageCluster corev1.ObjectReference `json:"storageCluster,omitempty"`
 	// DeviceClass is the name of the device class for which the storage scaling is to be done.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="ssd"

--- a/config/crd/bases/ocs.openshift.io_storageautoscalers.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageautoscalers.yaml
@@ -87,14 +87,43 @@ spec:
                 description: StorageCluster is the name of the storage cluster for
                   which the storage scaling is to be done.
                 properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
                   name:
-                    default: ""
                     description: |-
                       Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageautoscalers.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageautoscalers.yaml
@@ -87,14 +87,43 @@ spec:
                 description: StorageCluster is the name of the storage cluster for
                   which the storage scaling is to be done.
                 properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
                   name:
-                    default: ""
                     description: |-
                       Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/deploy/ocs-operator/manifests/storageautoscaler.crd.yaml
+++ b/deploy/ocs-operator/manifests/storageautoscaler.crd.yaml
@@ -87,14 +87,43 @@ spec:
                 description: StorageCluster is the name of the storage cluster for
                   which the storage scaling is to be done.
                 properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
                   name:
-                    default: ""
                     description: |-
                       Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/deploy/storageautoscaler.yaml
+++ b/deploy/storageautoscaler.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   storageCluster:
     name: ocs-storagecluster
+    namespace: openshift-storage
   deviceClass: ssd
   storageCapacityLimit: 100Ti
   maxOsdSize: 8Ti

--- a/docs/design/storage-auto-scale.md
+++ b/docs/design/storage-auto-scale.md
@@ -23,6 +23,8 @@ Implement auto storage scale CR per device class of a specific Storagecluster.
     spec:
         storageCluster: 
             name: <storageclusterName>
+            namespace: <storageclusterNamespace>
+            uid: <storageclusterUid>
         deviceClass: ssd
         storageCapacityLimit: <capacity>
         storageScalingThresholdPercent: 70  # should be less than osd nearfull percentage 

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storageautoscaler_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storageautoscaler_types.go
@@ -26,7 +26,7 @@ import (
 type StorageAutoScalerSpec struct {
 	// StorageCluster is the name of the storage cluster for which the storage scaling is to be done.
 	// +kubebuilder:validation:Required
-	StorageCluster corev1.LocalObjectReference `json:"storageCluster,omitempty"`
+	StorageCluster corev1.ObjectReference `json:"storageCluster,omitempty"`
 	// DeviceClass is the name of the device class for which the storage scaling is to be done.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="ssd"

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storageautoscaler_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storageautoscaler_types.go
@@ -26,7 +26,7 @@ import (
 type StorageAutoScalerSpec struct {
 	// StorageCluster is the name of the storage cluster for which the storage scaling is to be done.
 	// +kubebuilder:validation:Required
-	StorageCluster corev1.LocalObjectReference `json:"storageCluster,omitempty"`
+	StorageCluster corev1.ObjectReference `json:"storageCluster,omitempty"`
 	// DeviceClass is the name of the device class for which the storage scaling is to be done.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="ssd"


### PR DESCRIPTION
there can be a storageautocaler instance left in the system
that was created for older storagecluster,
So match the uid for which storagecluster instance it was
created and then only reconcile.