### PR TITLE
api: make allowRemoteStorageConsumers immutable

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -94,6 +94,7 @@ type StorageClusterSpec struct {
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
 	// +kubebuilder:deprecatedversion:warning="AllowRemoteStorageConsumers field has been deprecated and will be ignored within the reconcile."
+	// +kubebuilder:validation:XValidation:rule="oldSelf == self",message="allowRemoteStorageConsumers is immutable"
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -64,6 +64,9 @@ spec:
                   AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
                   components to enable connections from remote consumers.
                 type: boolean
+                x-kubernetes-validations:
+                - message: allowRemoteStorageConsumers is immutable
+                  rule: oldSelf == self
               arbiter:
                 description: |-
                   ArbiterSpec specifies the storage cluster options related to arbiter.

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -64,6 +64,9 @@ spec:
                   AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
                   components to enable connections from remote consumers.
                 type: boolean
+                x-kubernetes-validations:
+                - message: allowRemoteStorageConsumers is immutable
+                  rule: oldSelf == self
               arbiter:
                 description: |-
                   ArbiterSpec specifies the storage cluster options related to arbiter.

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -66,6 +66,9 @@ spec:
                   AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
                   components to enable connections from remote consumers.
                 type: boolean
+                x-kubernetes-validations:
+                - message: allowRemoteStorageConsumers is immutable
+                  rule: oldSelf == self
               arbiter:
                 description: |-
                   ArbiterSpec specifies the storage cluster options related to arbiter.

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -94,6 +94,7 @@ type StorageClusterSpec struct {
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
 	// +kubebuilder:deprecatedversion:warning="AllowRemoteStorageConsumers field has been deprecated and will be ignored within the reconcile."
+	// +kubebuilder:validation:XValidation:rule="oldSelf == self",message="allowRemoteStorageConsumers is immutable"
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -94,6 +94,7 @@ type StorageClusterSpec struct {
 	// AllowRemoteStorageConsumers Indicates that the OCS cluster should deploy the needed
 	// components to enable connections from remote consumers.
 	// +kubebuilder:deprecatedversion:warning="AllowRemoteStorageConsumers field has been deprecated and will be ignored within the reconcile."
+	// +kubebuilder:validation:XValidation:rule="oldSelf == self",message="allowRemoteStorageConsumers is immutable"
 	AllowRemoteStorageConsumers bool `json:"allowRemoteStorageConsumers,omitempty"`
 
 	// ProviderAPIServerServiceType Indicates the ServiceType for OCS Provider API Server Service.


### PR DESCRIPTION
Make the allowRemoteStorageConsumers immutable for the provider mode upgrade to 4.19 internal mode