### PR TITLE
osd: add a new ceph config to prevent slow ops

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -39,6 +39,7 @@ mon_pg_warn_max_object_skew = 0
 mon_data_avail_warn = 15
 mon_warn_on_pool_no_redundancy = false
 bluestore_prefer_deferred_size_hdd = 0
+bluestore_slow_ops_warn_lifetime = 0
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.8
 `


### PR DESCRIPTION
a new ceph config bluestore_slow_ops_warn_lifetime:0 needed to be set to avoid slow ops warning
coming from latest 19.2.1.x release

On 4.19 build we didn't see the issue after deployment of ODF, but after triggering the regression test suit we saw the issue.