### PR TITLE
DFBUGS-2062: [release-4.16] add osdMaintenanceTimeout field in storagecluster CR

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -185,6 +185,10 @@ type ManageCephCluster struct {
 	// This timeout won't be applied if `skipUpgradeChecks` is `true`.
 	// The default wait timeout is 10 minutes.
 	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
+	// A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
+	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
+	// The default value is `30` minutes.
+	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -735,6 +735,14 @@ spec:
                         - 3
                         - 5
                         type: integer
+                      osdMaintenanceTimeout:
+                        description: A duration in minutes that determines how long
+                          an entire failureDomain like `region/zone/host` will be
+                          held in `noout` (in addition to the default DOWN/OUT interval)
+                          when it is draining. This is only relevant when  `managePodBudgets`
+                          is `true` in cephCluster CR. The default value is `30` minutes.
+                        format: int64
+                        type: integer
                       reconcileStrategy:
                         type: string
                       waitTimeoutForHealthyOSDInMinutes:

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -502,6 +502,10 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, serverVersion *v
 		cephCluster.Spec.WaitTimeoutForHealthyOSDInMinutes = sc.Spec.ManagedResources.CephCluster.WaitTimeoutForHealthyOSDInMinutes
 	}
 
+	if sc.Spec.ManagedResources.CephCluster.OsdMaintenanceTimeout != 0 {
+		cephCluster.Spec.DisruptionManagement.OSDMaintenanceTimeout = sc.Spec.ManagedResources.CephCluster.OsdMaintenanceTimeout
+	}
+
 	if sc.Spec.LogCollector != nil {
 		if sc.Spec.LogCollector.Periodicity != "" {
 			cephCluster.Spec.LogCollector.Periodicity = sc.Spec.LogCollector.Periodicity

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -735,6 +735,14 @@ spec:
                         - 3
                         - 5
                         type: integer
+                      osdMaintenanceTimeout:
+                        description: A duration in minutes that determines how long
+                          an entire failureDomain like `region/zone/host` will be
+                          held in `noout` (in addition to the default DOWN/OUT interval)
+                          when it is draining. This is only relevant when  `managePodBudgets`
+                          is `true` in cephCluster CR. The default value is `30` minutes.
+                        format: int64
+                        type: integer
                       reconcileStrategy:
                         type: string
                       waitTimeoutForHealthyOSDInMinutes:

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -734,6 +734,14 @@ spec:
                         - 3
                         - 5
                         type: integer
+                      osdMaintenanceTimeout:
+                        description: A duration in minutes that determines how long
+                          an entire failureDomain like `region/zone/host` will be
+                          held in `noout` (in addition to the default DOWN/OUT interval)
+                          when it is draining. This is only relevant when  `managePodBudgets`
+                          is `true` in cephCluster CR. The default value is `30` minutes.
+                        format: int64
+                        type: integer
                       reconcileStrategy:
                         type: string
                       waitTimeoutForHealthyOSDInMinutes:

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -185,6 +185,10 @@ type ManageCephCluster struct {
 	// This timeout won't be applied if `skipUpgradeChecks` is `true`.
 	// The default wait timeout is 10 minutes.
 	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
+	// A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
+	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
+	// The default value is `30` minutes.
+	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -185,6 +185,10 @@ type ManageCephCluster struct {
 	// This timeout won't be applied if `skipUpgradeChecks` is `true`.
 	// The default wait timeout is 10 minutes.
 	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
+	// A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
+	// default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true` in cephCluster CR.
+	// The default value is `30` minutes.
+	OsdMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration


### PR DESCRIPTION
Add new `osdMaintenanceTimeout` field under ManageCephCluster in the storagecluster CR, to allow users to override defaults in the CephCluster.

Manual backport of PR: https://github.com/red-hat-storage/ocs-operator/pull/2613 with only `osdMaintenanceTimeout` field.