### PR TITLE
controller: handle internal client in provider mode upgrade 

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -235,6 +235,18 @@ rules:
 - apiGroups:
   - ocs.openshift.io
   resources:
+  - storageclients
+  verbs:
+  - get
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclients/status
+  verbs:
+  - patch
+- apiGroups:
+  - ocs.openshift.io
+  resources:
   - storageclusterpeers/finalizers
   - storagerequests/finalizers
   verbs:

--- a/controllers/defaults/defaults.go
+++ b/controllers/defaults/defaults.go
@@ -25,8 +25,9 @@ const (
 	// propagated to the associated StorageClasses.
 	KeyRotationEnableAnnotation = "keyrotation.csiaddons.openshift.io/enable"
 	// OnboardingTokenKey is the name of the field in the OnboardingSecret data
-	OnboardingTokenKey       = "onboarding-token"
-	LocalStorageConsumerName = "internal"
+	OnboardingTokenKey                = "onboarding-token"
+	LocalStorageConsumerName          = "internal"
+	LocalStorageConsumerConfigMapName = "storageconsumer-internal"
 	// KMSConfigMapName is the name configmap which has KMS config details
 	KMSConfigMapName = "ocs-kms-connection-details"
 )

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -75,7 +75,12 @@ const (
 	StorageConsumerMirroringInfoAnnotation = "ocs.openshift.io/consumer-mirroring-info"
 	ForceDeletionAnnotationKey             = "ocs.openshift.io/force-deletion"
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
+	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
 )
+
+type BackwardCompatabilityInfo struct {
+	Pre4_19InternalConsumer string `json:"pre4_19InternalConsumer"`
+}
 
 var podNamespace = os.Getenv(PodNamespaceEnvVar)
 

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -392,6 +392,18 @@ spec:
         - apiGroups:
           - ocs.openshift.io
           resources:
+          - storageclients
+          verbs:
+          - get
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclients/status
+          verbs:
+          - patch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
           - storageclusterpeers/finalizers
           - storagerequests/finalizers
           verbs:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -411,6 +411,18 @@ spec:
         - apiGroups:
           - ocs.openshift.io
           resources:
+          - storageclients
+          verbs:
+          - get
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclients/status
+          verbs:
+          - patch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
           - storageclusterpeers/finalizers
           - storagerequests/finalizers
           verbs:

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/defaults.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/defaults.go
@@ -25,8 +25,9 @@ const (
 	// propagated to the associated StorageClasses.
 	KeyRotationEnableAnnotation = "keyrotation.csiaddons.openshift.io/enable"
 	// OnboardingTokenKey is the name of the field in the OnboardingSecret data
-	OnboardingTokenKey       = "onboarding-token"
-	LocalStorageConsumerName = "internal"
+	OnboardingTokenKey                = "onboarding-token"
+	LocalStorageConsumerName          = "internal"
+	LocalStorageConsumerConfigMapName = "storageconsumer-internal"
 	// KMSConfigMapName is the name configmap which has KMS config details
 	KMSConfigMapName = "ocs-kms-connection-details"
 )

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -75,7 +75,12 @@ const (
 	StorageConsumerMirroringInfoAnnotation = "ocs.openshift.io/consumer-mirroring-info"
 	ForceDeletionAnnotationKey             = "ocs.openshift.io/force-deletion"
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
+	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
 )
+
+type BackwardCompatabilityInfo struct {
+	Pre4_19InternalConsumer string `json:"pre4_19InternalConsumer"`
+}
 
 var podNamespace = os.Getenv(PodNamespaceEnvVar)
 


### PR DESCRIPTION
The internal Client/consumer in provider mode needs to be handled differently.
We need to onboard the client to the internal consumer. Hence, from the upgrade controller, we are creating a consumer/configMap, updating the client status to point to this new consumer, and in the end, deleting the old storage consumer.

Fixes: https://issues.redhat.com/browse/DFBUGS-2290