### PR TITLE
cluster: update exporter and crashcollector resources

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -70,6 +70,26 @@ var (
 				"cpu":    resource.MustParse("50m"),
 			},
 		},
+		"crashcollector": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+			},
+		},
+		"exporter": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.05"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.05"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
 	}
 
 	LeanDaemonResources = map[string]corev1.ResourceRequirements{

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -535,9 +535,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 				"arbiter": getPlacement(sc, "arbiter"),
 			},
 			PriorityClassNames: rookCephv1.PriorityClassNamesSpec{
-				rookCephv1.KeyMgr: systemNodeCritical,
-				rookCephv1.KeyMon: systemNodeCritical,
-				rookCephv1.KeyOSD: systemNodeCritical,
+				rookCephv1.KeyMgr:            systemNodeCritical,
+				rookCephv1.KeyMon:            systemNodeCritical,
+				rookCephv1.KeyOSD:            systemNodeCritical,
+				rookCephv1.KeyCephExporter:   systemNodeCritical,
+				rookCephv1.KeyCrashCollector: systemNodeCritical,
 			},
 			Resources:    newCephDaemonResources(sc),
 			LogCollector: logCollector,
@@ -1097,8 +1099,10 @@ func isDeviceSetToBeEncrypted(sc *ocsv1.StorageCluster, ds ocsv1.StorageDeviceSe
 
 func newCephDaemonResources(sc *ocsv1.StorageCluster) map[string]corev1.ResourceRequirements {
 	resources := map[string]corev1.ResourceRequirements{
-		"mon": defaults.GetProfileDaemonResources("mon", sc),
-		"mgr": defaults.GetProfileDaemonResources("mgr", sc),
+		"mon":            defaults.GetProfileDaemonResources("mon", sc),
+		"mgr":            defaults.GetProfileDaemonResources("mgr", sc),
+		"crashcollector": defaults.GetDaemonResources("crashcollector", sc.Spec.Resources),
+		"exporter":       defaults.GetDaemonResources("exporter", sc.Spec.Resources),
 	}
 	custom := sc.Spec.Resources
 	for k := range custom {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -837,8 +837,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.BalancedDaemonResources["mgr"],
-				"mon": defaults.BalancedDaemonResources["mon"],
+				"mgr":            defaults.BalancedDaemonResources["mgr"],
+				"mon":            defaults.BalancedDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -850,8 +852,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.LeanDaemonResources["mgr"],
-				"mon": defaults.LeanDaemonResources["mon"],
+				"mgr":            defaults.LeanDaemonResources["mgr"],
+				"mon":            defaults.LeanDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -863,8 +867,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.BalancedDaemonResources["mgr"],
-				"mon": defaults.BalancedDaemonResources["mon"],
+				"mgr":            defaults.BalancedDaemonResources["mgr"],
+				"mon":            defaults.BalancedDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -876,8 +882,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.PerformanceDaemonResources["mgr"],
-				"mon": defaults.PerformanceDaemonResources["mon"],
+				"mgr":            defaults.PerformanceDaemonResources["mgr"],
+				"mon":            defaults.PerformanceDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -910,6 +918,8 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -942,7 +952,9 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
-				"mon": defaults.PerformanceDaemonResources["mon"],
+				"mon":            defaults.PerformanceDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -976,6 +988,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
+				"exporter": defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -1010,6 +1023,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
+				"exporter": defaults.DaemonResources["exporter"],
 			},
 		},
 	}

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
@@ -70,6 +70,26 @@ var (
 				"cpu":    resource.MustParse("50m"),
 			},
 		},
+		"crashcollector": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+			},
+		},
+		"exporter": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.05"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.05"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
 	}
 
 	LeanDaemonResources = map[string]corev1.ResourceRequirements{


### PR DESCRIPTION
update the exporter and crashcollector with limits and priority class, so it wont get evicted
during memeory pressure testing

Used the default limits as of `mon`