### PR TITLE
server: send the cephClient with opaque secret type

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1719,6 +1719,8 @@ func (s *OCSProviderServer) appendCephClientSecretKubeResources(
 
 		cephUserSecret.Name = cephClients[i]
 		cephUserSecret.Namespace = consumer.Status.Client.OperatorNamespace
+		// clearing the secretType to be empty/Opaque instead of type rook.
+		cephUserSecret.Type = ""
 
 		kubeResources = append(kubeResources, cephUserSecret)
 	}


### PR DESCRIPTION
we were sending the cephClient secrets with the type as rook, we should be sending them as type opaque

fixes: https://issues.redhat.com/browse/DFBUGS-2299