### PR TITLE
Prevent quota reduction via CEL validation in StorageConsumer CRD

### DIFF
--- a/api/v1alpha1/storageconsumer_types.go
+++ b/api/v1alpha1/storageconsumer_types.go
@@ -38,6 +38,7 @@ const (
 )
 
 // StorageConsumerSpec defines the desired state of StorageConsumer
+// +kubebuilder:validation:XValidation:rule="!(has(self.storageQuotaInGiB) && has(oldSelf.storageQuotaInGiB) && self.storageQuotaInGiB < oldSelf.storageQuotaInGiB && self.storageQuotaInGiB != 0)",message="storageQuotaInGiB cannot be decreased unless setting to 0"
 type StorageConsumerSpec struct {
 	// Enable flag ignores a reconcile if set to false
 	Enable bool `json:"enable,omitempty"`

--- a/config/crd/bases/ocs.openshift.io_storageconsumers.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageconsumers.yaml
@@ -98,6 +98,11 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-validations:
+            - message: storageQuotaInGiB cannot be decreased unless setting to 0
+              rule: '!(has(self.storageQuotaInGiB) && has(oldSelf.storageQuotaInGiB)
+                && self.storageQuotaInGiB < oldSelf.storageQuotaInGiB && self.storageQuotaInGiB
+                != 0)'
           status:
             description: StorageConsumerStatus defines the observed state of StorageConsumer
             properties:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageconsumers.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageconsumers.yaml
@@ -98,6 +98,11 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-validations:
+            - message: storageQuotaInGiB cannot be decreased unless setting to 0
+              rule: '!(has(self.storageQuotaInGiB) && has(oldSelf.storageQuotaInGiB)
+                && self.storageQuotaInGiB < oldSelf.storageQuotaInGiB && self.storageQuotaInGiB
+                != 0)'
           status:
             description: StorageConsumerStatus defines the observed state of StorageConsumer
             properties:

--- a/deploy/ocs-operator/manifests/storageconsumer.crd.yaml
+++ b/deploy/ocs-operator/manifests/storageconsumer.crd.yaml
@@ -98,6 +98,11 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-validations:
+            - message: storageQuotaInGiB cannot be decreased unless setting to 0
+              rule: '!(has(self.storageQuotaInGiB) && has(oldSelf.storageQuotaInGiB)
+                && self.storageQuotaInGiB < oldSelf.storageQuotaInGiB && self.storageQuotaInGiB
+                != 0)'
           status:
             description: StorageConsumerStatus defines the observed state of StorageConsumer
             properties:

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
@@ -38,6 +38,7 @@ const (
 )
 
 // StorageConsumerSpec defines the desired state of StorageConsumer
+// +kubebuilder:validation:XValidation:rule="!(has(self.storageQuotaInGiB) && has(oldSelf.storageQuotaInGiB) && self.storageQuotaInGiB < oldSelf.storageQuotaInGiB && self.storageQuotaInGiB != 0)",message="storageQuotaInGiB cannot be decreased unless setting to 0"
 type StorageConsumerSpec struct {
 	// Enable flag ignores a reconcile if set to false
 	Enable bool `json:"enable,omitempty"`

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1/storageconsumer_types.go
@@ -38,6 +38,7 @@ const (
 )
 
 // StorageConsumerSpec defines the desired state of StorageConsumer
+// +kubebuilder:validation:XValidation:rule="!(has(self.storageQuotaInGiB) && has(oldSelf.storageQuotaInGiB) && self.storageQuotaInGiB < oldSelf.storageQuotaInGiB && self.storageQuotaInGiB != 0)",message="storageQuotaInGiB cannot be decreased unless setting to 0"
 type StorageConsumerSpec struct {
 	// Enable flag ignores a reconcile if set to false
 	Enable bool `json:"enable,omitempty"`


### PR DESCRIPTION
Added CEL validation to ensure StorageQuotaInGiB cannot be decreased via CR updates.

Tested manually:
1.Delete the old CRD, apply the new CRD, and verify that the CRD was created.
```
$ oc delete crd storageconsumers.ocs.openshift.io
customresourcedefinition.apiextensions.k8s.io "storageconsumers.ocs.openshift.io" deleted
$ oc get crd storageconsumers.ocs.openshift.io
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "storageconsumers.ocs.openshift.io" not found
$ oc apply -f config/crd/bases/ocs.openshift.io_storageconsumers.yaml
customresourcedefinition.apiextensions.k8s.io/storageconsumers.ocs.openshift.io created
$ oc get crd storageconsumers.ocs.openshift.io
NAME                                CREATED AT
storageconsumers.ocs.openshift.io   2025-04-28T09:07:44Z
```

2.Create a StorageConsumer Custom Resource
```
$ oc apply -f - <<EOF
apiVersion: ocs.openshift.io/v1alpha1
kind: StorageConsumer
metadata:
  name: test-consumer
  namespace: default
spec:
  enable: true
  storageQuotaInGiB: 100
EOF
storageconsumer.ocs.openshift.io/test-consumer created
```
```
$ oc get storageconsumers.ocs.openshift.io -n default -o yaml
apiVersion: v1
items:
- apiVersion: ocs.openshift.io/v1alpha1
  kind: StorageConsumer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
    creationTimestamp: "2025-04-28T09:08:53Z"
    generation: 1
    name: test-consumer
    namespace: default
    resourceVersion: "3132911"
    uid: 025bdade-85eb-46f9-a9b8-2169f6649f27
  spec:
    enable: true
    storageQuotaInGiB: 100
kind: List
metadata:
  resourceVersion: ""
```  

3.Test: Decrease the storageQuotaInGiB from 100 → 50 (Expect Rejection)
```
$ oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 50}}'
The StorageConsumer "test-consumer" is invalid: spec: Invalid value: "object": storageQuotaInGiB cannot be decreased on update
```
```
$ oc get storageconsumers.ocs.openshift.io -n default -o yaml
apiVersion: v1
items:
- apiVersion: ocs.openshift.io/v1alpha1
  kind: StorageConsumer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
    creationTimestamp: "2025-04-28T09:08:53Z"
    generation: 1
    name: test-consumer
    namespace: default
    resourceVersion: "3132911"
    uid: 025bdade-85eb-46f9-a9b8-2169f6649f27
  spec:
    enable: true
    storageQuotaInGiB: 100
kind: List
metadata:
  resourceVersion: ""
  ```
4. Test: Increase the storageQuotaInGiB from 100 → 110 (Expect Success)
  ```
  $ oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 110}}'
storageconsumer.ocs.openshift.io/test-consumer patched
```
```
$ oc get storageconsumers.ocs.openshift.io -n default -o yaml
apiVersion: v1
items:
- apiVersion: ocs.openshift.io/v1alpha1
  kind: StorageConsumer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
    creationTimestamp: "2025-04-28T09:08:53Z"
    generation: 2
    name: test-consumer
    namespace: default
    resourceVersion: "3134674"
    uid: 025bdade-85eb-46f9-a9b8-2169f6649f27
  spec:
    enable: true
    storageQuotaInGiB: 110
kind: List
metadata:
  resourceVersion: ""
  ```

5.Test: Decrease the storageQuotaInGiB from 100 → 0 (Expect Success)
When `StorageQuotaInGiB=0`, a `ClusterResourceQuota` is not created because the function checks if `consumer.Spec.StorageQuotaInGiB > 0` before adding a quota resource.
https://github.com/red-hat-storage/ocs-operator/blob/91f2ec4af69fd5d7292487ee479e1b47893d3234/services/provider/server/server.go#L2060

```
$  oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 0}}'
storageconsumer.ocs.openshift.io/test-consumer patched
```
```
$ oc get storageconsumers.ocs.openshift.io -n default -o yaml
apiVersion: v1
items:
- apiVersion: ocs.openshift.io/v1alpha1
  kind: StorageConsumer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
    creationTimestamp: "2025-04-28T11:37:09Z"
    generation: 3
    name: test-consumer
    namespace: default
    resourceVersion: "3227178"
    uid: 7f2a32e1-6272-4840-83f8-fced2dcfa600
  spec:
    enable: true
    storageQuotaInGiB: 0
kind: List
metadata:
  resourceVersion: ""
```
  
  6.Test: Increase the storageQuotaInGiB from 0 → 34 (Expect Success)
  ```
  $  oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 34}}'
storageconsumer.ocs.openshift.io/test-consumer patched
```
```
oviner~/DEV_REPOS/ocs-operator(cel_validate_quota_reduction)$ oc get storageconsumers.ocs.openshift.io -n default -o yaml
apiVersion: v1
items:
- apiVersion: ocs.openshift.io/v1alpha1
  kind: StorageConsumer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
    creationTimestamp: "2025-04-28T11:37:09Z"
    generation: 4
    name: test-consumer
    namespace: default
    resourceVersion: "3227976"
    uid: 7f2a32e1-6272-4840-83f8-fced2dcfa600
  spec:
    enable: true
    storageQuotaInGiB: 34
kind: List
metadata:
  resourceVersion: ""
  ```

7.Delete line  `storageQuotaInGiB` with `oc edit`
```
$ oc edit storageconsumer test-consumer                               
storageconsumer.ocs.openshift.io/test-consumer edited

$  oc get storageconsumers.ocs.openshift.io -n default -o yaml
apiVersion: v1
items:
- apiVersion: ocs.openshift.io/v1alpha1
  kind: StorageConsumer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
    creationTimestamp: "2025-05-06T10:34:10Z"
    generation: 7
    name: test-consumer
    namespace: default
    resourceVersion: "1424351"
    uid: a33d2fbc-0c0b-4b52-9313-cff54c9b63dc
  spec:
    enable: true
kind: List
metadata:
  resourceVersion: ""
  
```

8. Test: Add the storageQuotaInGiB = 5 (Expect Success)
```
$ $ oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 5}}'
storageconsumer.ocs.openshift.io/test-consumer patched

$ oc get storageconsumers.ocs.openshift.io test-consumer -n default -o yaml
apiVersion: ocs.openshift.io/v1alpha1
kind: StorageConsumer
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"ocs.openshift.io/v1alpha1","kind":"StorageConsumer","metadata":{"annotations":{},"name":"test-consumer","namespace":"default"},"spec":{"enable":true,"storageQuotaInGiB":100}}
  creationTimestamp: "2025-05-06T10:34:10Z"
  generation: 8
  name: test-consumer
  namespace: default
  resourceVersion: "1425492"
  uid: a33d2fbc-0c0b-4b52-9313-cff54c9b63dc
spec:
  enable: true
  storageQuotaInGiB: 5
  
$ oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 2}}'
The StorageConsumer "test-consumer" is invalid: spec: Invalid value: "object": storageQuotaInGiB cannot be decreased unless setting to 0

$ oc patch storageconsumer test-consumer --type=merge -p '{"spec": {"storageQuotaInGiB": 6}}'
storageconsumer.ocs.openshift.io/test-consumer patched

```


