### PR TITLE
Always apply rbd-mirror debug logging ceph configs

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -42,6 +42,16 @@ bluestore_prefer_deferred_size_hdd = 0
 bluestore_slow_ops_warn_lifetime = 0
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.8
+[client.rbd-mirror.a]
+debug_ms = 1
+debug_rbd = 15
+debug_rbd_mirror = 30
+log_file = /var/log/ceph/\$cluster-\$name.log
+[client.rbd-mirror-peer]
+debug_ms = 1
+debug_rbd = 15
+debug_rbd_mirror = 30
+log_file = /var/log/ceph/\$cluster-\$name.log
 `
 )
 

--- a/controllers/storagecluster/cephrbdmirrors.go
+++ b/controllers/storagecluster/cephrbdmirrors.go
@@ -3,30 +3,21 @@ package storagecluster
 import (
 	"context"
 	"fmt"
-	"os"
-	"time"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type ocsCephRbdMirrors struct{}
-
-var (
-	rbdMirrorDebugLoggingEnabled = false
-)
 
 func (r *StorageClusterReconciler) fetchCephRbdMirrorInstance(cephRbdMirror *cephv1.CephRBDMirror) (cephv1.CephRBDMirror, error) {
 	existing := cephv1.CephRBDMirror{}
@@ -144,209 +135,4 @@ func (obj *ocsCephRbdMirrors) ensureDeleted(r *StorageClusterReconciler, sc *ocs
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, r.deleteCephRbdMirrorInstance(cephRbdMirrors)
-}
-
-func (r *StorageClusterReconciler) ensureRbdMirrorDebugLogging(sc *ocsv1.StorageCluster) (reconcile.Result, error) {
-	enableRbdMirrorDebugLoggingJobName := "enable-rbd-mirror-debug-logging"
-	disableRbdMirrorDebugLoggingJobName := "disable-rbd-mirror-debug-logging"
-	enableRbdMirrorDebugLoggingCommands :=
-		`echo "starting configuration of mirror logging"
-ceph config set client.rbd-mirror.a debug_ms 1
-ceph config set client.rbd-mirror.a debug_rbd 15
-ceph config set client.rbd-mirror.a debug_rbd_mirror 30
-ceph config set client.rbd-mirror.a log_file /var/log/ceph/\$cluster-\$name.log
-ceph config set client.rbd-mirror-peer debug_ms 1
-ceph config set client.rbd-mirror-peer debug_rbd 15
-ceph config set client.rbd-mirror-peer debug_rbd_mirror 30
-ceph config set client.rbd-mirror-peer log_file /var/log/ceph/\$cluster-\$name.log
-ceph config set mgr mgr/rbd_support/log_level debug
-		echo "completed"`
-	disableRbdMirrorDebugLoggingCommands :=
-		`echo "Removing configuration of mirror logging"
-ceph config rm client.rbd-mirror.a debug_ms
-ceph config rm client.rbd-mirror.a debug_rbd
-ceph config rm client.rbd-mirror.a debug_rbd_mirror
-ceph config rm client.rbd-mirror.a log_file
-ceph config rm client.rbd-mirror-peer debug_ms
-ceph config rm client.rbd-mirror-peer debug_rbd
-ceph config rm client.rbd-mirror-peer debug_rbd_mirror
-ceph config rm client.rbd-mirror-peer log_file
-ceph config rm mgr mgr/rbd_support/log_level
-		echo "completed"`
-
-	// Mirroring is enabled but the debug logging is disabled
-	if sc.Spec.Mirroring != nil && sc.Spec.Mirroring.Enabled && !rbdMirrorDebugLoggingEnabled {
-
-		err := r.Client.Create(r.ctx, getRbdMirrorDebugLoggingJob(sc, enableRbdMirrorDebugLoggingJobName, enableRbdMirrorDebugLoggingCommands))
-		if err != nil && !errors.IsAlreadyExists(err) {
-			return reconcile.Result{}, err
-		}
-		// Check if the job has succeeded
-		job := &batchv1.Job{}
-		err = r.Client.Get(r.ctx, types.NamespacedName{Name: enableRbdMirrorDebugLoggingJobName, Namespace: sc.Namespace}, job)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if job.Status.Succeeded == 0 {
-			// Job has not succeeded yet, so requeue a reconcile request after 10 sec to check again
-			r.Log.Info("Waiting for enable-rbd-mirror-debug-logging job to complete")
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
-
-		r.Log.Info("Successfully enabled rbd mirror debug logging")
-		rbdMirrorDebugLoggingEnabled = true
-	}
-	// Mirroring is disabled but the debug logging is enabled
-	if (sc.Spec.Mirroring == nil || !sc.Spec.Mirroring.Enabled) && rbdMirrorDebugLoggingEnabled {
-		err := r.Client.Create(r.ctx, getRbdMirrorDebugLoggingJob(sc, disableRbdMirrorDebugLoggingJobName, disableRbdMirrorDebugLoggingCommands))
-		if err != nil && !errors.IsAlreadyExists(err) {
-			return reconcile.Result{}, err
-		}
-		// Check if the job has succeeded
-		job := &batchv1.Job{}
-		err = r.Client.Get(r.ctx, types.NamespacedName{Name: disableRbdMirrorDebugLoggingJobName, Namespace: sc.Namespace}, job)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if job.Status.Succeeded == 0 {
-			// Job has not succeeded yet, so requeue a reconcile request after 10 sec to check again
-			r.Log.Info("Waiting for disable-rbd-mirror-debug-logging job to complete")
-			return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
-		}
-
-		// Delete both the enable & disable jobs
-		err = r.Client.Delete(r.ctx, &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      enableRbdMirrorDebugLoggingJobName,
-				Namespace: sc.Namespace,
-			}})
-		if err != nil && !errors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-		err = r.Client.Delete(r.ctx, &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      disableRbdMirrorDebugLoggingJobName,
-				Namespace: sc.Namespace,
-			}})
-		if err != nil && !errors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-
-		r.Log.Info("Successfully disabled rbd mirror debug logging")
-		rbdMirrorDebugLoggingEnabled = false
-	}
-	return reconcile.Result{}, nil
-}
-
-func getRbdMirrorDebugLoggingJob(sc *ocsv1.StorageCluster, jobName string, configCommands string) *batchv1.Job {
-	rookImage := os.Getenv("ROOK_CEPH_IMAGE")
-	debugJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      jobName,
-			Namespace: sc.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: sc.APIVersion,
-					Kind:       sc.Kind,
-					Name:       sc.Name,
-					UID:        sc.UID,
-				},
-			},
-		},
-		Spec: batchv1.JobSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name:            "config-init",
-							Image:           rookImage,
-							Command:         []string{"/usr/local/bin/toolbox.sh"},
-							Args:            []string{"--skip-watch"},
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "ROOK_CEPH_USERNAME",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon"},
-											Key:                  "ceph-username",
-										},
-									},
-								},
-								{
-									Name: "ROOK_CEPH_SECRET",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon"},
-											Key:                  "ceph-secret",
-										},
-									},
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "ceph-config", MountPath: "/etc/ceph"},
-								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{
-										"ALL",
-									},
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name:  "script",
-							Image: rookImage,
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "ceph-config", MountPath: "/etc/ceph", ReadOnly: true},
-							},
-							Command: []string{
-								"bash",
-								"-c",
-								configCommands,
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{
-										"ALL",
-									},
-								},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{Name: "ceph-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-						{Name: "mon-endpoint-volume", VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon-endpoints"},
-								Items:                []corev1.KeyToPath{{Key: "data", Path: "mon-endpoints"}},
-							},
-						},
-						},
-					},
-					RestartPolicy: corev1.RestartPolicyNever,
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: ptr.To(true),
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						},
-					},
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      defaults.NodeTolerationKey,
-							Operator: corev1.TolerationOpEqual,
-							Value:    "true",
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-					},
-				},
-			},
-		},
-	}
-	return debugJob
 }

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -648,16 +648,6 @@ func (r *StorageClusterReconciler) reconcilePhases(
 
 	}
 
-	// Ensure that verbose logging is enabled when RBD mirroring is enabled
-	// TODO: This is a temporary arrangement, this is to be removed when RDR goes to GA
-	if !instance.Spec.ExternalStorage.Enable {
-		result, err := r.ensureRbdMirrorDebugLogging(instance)
-		if !result.IsZero() || err != nil {
-			r.Log.Error(err, "Failed to ensure RBD mirror debug logging.")
-			return result, err
-		}
-	}
-
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Irrespective of whether rbd-mirror is deployed or not, the debug logging configs are always applied. This maakes the code simpler & clearr. As without rbd-mirror present, the debug logging configs are anyways not used so it is not a problem.

Ref-https://issues.redhat.com/browse/DFBUGS-2087