### PR TITLE
skip reconciling rns if blockpool is marked for deletion

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -448,6 +448,12 @@ func (r *StorageConsumerReconciler) reconcileCephRadosNamespace(
 			continue
 		}
 
+		// TODO (leelavg): this is a temporary fix till a decision is taken for when to proceed with deletion of rns cr
+		if !bp.DeletionTimestamp.IsZero() {
+			r.Log.Info("Skipping reconcile for radosnamespace as blockpool is marked for deletion", "CephBlockPool", bp.Name)
+			continue
+		}
+
 		rns := &rookCephv1.CephBlockPoolRadosNamespace{}
 		rns.Name = fmt.Sprintf("%s-%s", bp.Name, radosNamespaceName)
 		if radosNamespaceName == util.ImplicitRbdRadosNamespaceName {


### PR DESCRIPTION
we create a rns in each of the blockpool but don't delete it as blockpool deletion can't be taken as rns deletion, however this blocks a couple of usecases and this commit provides a temp fix to not reconcile rns cr if bp is marked for deletion.

this allows manual deletion of rns cr for allowing bp deletion if it is the only entity stopping bp deletion.