### PR TITLE
storageautoscaler: scale only when more than threshold minus 10% percent of cluster is used

### DIFF
--- a/controllers/storageautoscaler/scraper_test.go
+++ b/controllers/storageautoscaler/scraper_test.go
@@ -27,7 +27,11 @@ func TestFilterObjectsForScaling(t *testing.T) {
 	}
 
 	syncMap := &sync.Map{}
-	syncMap.Store("deviceClass", 0.60)
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   1.80,
+		TotalOsd:     3,
+		HighestUsage: 0.60,
+	})
 
 	log := logr.Logger{}
 	objectList := filterObjectsForScaling(&scalerList, syncMap, log)
@@ -35,7 +39,11 @@ func TestFilterObjectsForScaling(t *testing.T) {
 	assert.Equal(t, 1, len(objectList))
 	assert.Equal(t, "ssdscaler", objectList[0].Name)
 
-	syncMap.Store("deviceClass", 0.40)
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   0.60,
+		TotalOsd:     3,
+		HighestUsage: 0.40,
+	})
 
 	objectList = filterObjectsForScaling(&scalerList, syncMap, log)
 
@@ -59,7 +67,7 @@ func TestUpdateSyncMap(t *testing.T) {
 
 		// check if the sync map is updated
 		usage, _ := syncMap.Load("ssd")
-		assert.Equal(t, 0.70, usage)
+		assert.Equal(t, 0.70, usage.(OsdUsage).HighestUsage)
 
 		// during the second update
 		syncMap = &sync.Map{}
@@ -76,7 +84,7 @@ func TestUpdateSyncMap(t *testing.T) {
 
 		// check if the sync map is updated
 		usage, _ = syncMap.Load("ssd")
-		assert.Equal(t, 0.50, usage)
+		assert.Equal(t, 0.50, usage.(OsdUsage).HighestUsage)
 	})
 	t.Run("test syncmap update with multiple device class", func(t *testing.T) {
 		syncMap := &sync.Map{}
@@ -99,9 +107,9 @@ func TestUpdateSyncMap(t *testing.T) {
 
 		// check if the sync map is updated
 		nvmeUsage, _ := syncMap.Load("nvme")
-		assert.Equal(t, 0.50, nvmeUsage)
+		assert.Equal(t, 0.50, nvmeUsage.(OsdUsage).HighestUsage)
 		ssdUsage, _ := syncMap.Load("ssd")
-		assert.Equal(t, 0.70, ssdUsage)
+		assert.Equal(t, 0.70, ssdUsage.(OsdUsage).HighestUsage)
 	})
 	t.Run("test syncmap update with no device class", func(t *testing.T) {
 		syncMap := &sync.Map{}
@@ -119,7 +127,7 @@ func TestUpdateSyncMap(t *testing.T) {
 
 		// check if the sync map is updated
 		usage, _ := syncMap.Load("ssd")
-		assert.Equal(t, 0.70, usage)
+		assert.Equal(t, 0.70, usage.(OsdUsage).HighestUsage)
 
 		// during the second update
 		syncMap = &sync.Map{}
@@ -156,6 +164,108 @@ func TestUpdateSyncMap(t *testing.T) {
 
 		// check if the sync map is updated
 		usage, _ := syncMap.Load("ssd")
-		assert.Equal(t, 0.70, usage)
+		assert.Equal(t, 0.70, usage.(OsdUsage).HighestUsage)
 	})
+}
+
+func TestTotalUsageGreaterThanAdjustedThreshold(t *testing.T) {
+	t.Run("test total usage greater than threshold minus 10 percent", func(t *testing.T) {
+		deviceClassUsage := OsdUsage{
+			TotalUsage:   1.80,
+			TotalOsd:     3,
+			HighestUsage: 0.60,
+		}
+		result := totalUsageGreaterThanAdjustedThreshold(deviceClassUsage, 50, logr.Logger{}, "deviceClass")
+		assert.True(t, result)
+	})
+	t.Run("test total usage equal to threshold minus 10 percent", func(t *testing.T) {
+		deviceClassUsage := OsdUsage{
+			TotalUsage:   1.21,
+			TotalOsd:     3,
+			HighestUsage: 0.40,
+		}
+		result := totalUsageGreaterThanAdjustedThreshold(deviceClassUsage, 50, logr.Logger{}, "deviceClass")
+		assert.True(t, result)
+	})
+	t.Run("after resize test total usage less than threshold minus 10 percent", func(t *testing.T) {
+		// clusterUsage := 1.90/6 // 0.31
+		// Threshold = 50, threshold-10 = 40
+		// 0.31 < 0.40
+		// so it should return false
+		deviceClassUsage := OsdUsage{
+			TotalUsage:   1.90,
+			TotalOsd:     6,
+			HighestUsage: 0.55,
+		}
+		result := totalUsageGreaterThanAdjustedThreshold(deviceClassUsage, 50, logr.Logger{}, "deviceClass")
+		assert.False(t, result)
+	})
+}
+
+func TestIsScalingRequired(t *testing.T) {
+	syncMap := &sync.Map{}
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   1.21,
+		TotalOsd:     3,
+		HighestUsage: 0.60,
+	})
+
+	log := logr.Logger{}
+	result := isScalingRequired(syncMap, 50, log, "deviceClass")
+	assert.True(t, result)
+
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   0.60,
+		TotalOsd:     3,
+		HighestUsage: 0.40,
+	})
+
+	result = isScalingRequired(syncMap, 50, log, "deviceClass")
+	assert.False(t, result)
+
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   1.0,
+		TotalOsd:     3,
+		HighestUsage: 0.60,
+	})
+
+	result = isScalingRequired(syncMap, 50, log, "deviceClass")
+	assert.False(t, result)
+
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   1.20,
+		TotalOsd:     0,
+		HighestUsage: 0.60,
+	})
+
+	result = isScalingRequired(syncMap, 50, log, "deviceClass")
+	assert.False(t, result)
+
+	syncMap.Store("deviceClass", OsdUsage{
+		TotalUsage:   1.20,
+		TotalOsd:     3,
+		HighestUsage: 0.60,
+	})
+
+	result = isScalingRequired(syncMap, 0, log, "deviceClass")
+	assert.True(t, result)
+}
+
+func TestAverageOsdUsage(t *testing.T) {
+	deviceClassUsage := OsdUsage{
+		TotalUsage:   1.20,
+		TotalOsd:     3,
+		HighestUsage: 0.60,
+	}
+	log := logr.Logger{}
+	result := averageOsdUsage(deviceClassUsage, log, "deviceClass")
+	assert.Equal(t, float64(40), result)
+
+	deviceClassUsage = OsdUsage{
+		TotalUsage:   1.20,
+		TotalOsd:     0,
+		HighestUsage: 0.60,
+	}
+	result = averageOsdUsage(deviceClassUsage, log, "deviceClass")
+	assert.Equal(t, float64(0), result)
 }

--- a/controllers/storageautoscaler/storageautoscaler_controller_test.go
+++ b/controllers/storageautoscaler/storageautoscaler_controller_test.go
@@ -14,26 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestCheckIfScalingNotRequired(t *testing.T) {
-	usage := 0.055
-	threshold := 6
-
-	required := checkIfScalingRequired(usage, threshold)
-	assert.False(t, required)
-
-	usage = 0.05
-	threshold = 5
-
-	required = checkIfScalingRequired(usage, threshold)
-	assert.True(t, required)
-
-	usage = 0.05
-	threshold = 4
-
-	required = checkIfScalingRequired(usage, threshold)
-	assert.True(t, required)
-}
-
 func TestCalculateExpectedOsdSizeAndCount(t *testing.T) {
 	// vertical scaling
 	t.Run("vertical scaling", func(t *testing.T) {
@@ -118,26 +98,6 @@ func TestCalculateExpectedOsdSizeAndCount(t *testing.T) {
 		testStartStorageCapacity := resource.MustParse("9Ti")
 		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Quantities are equal")
 	})
-}
-
-func TestCheckIfScalingRequired(t *testing.T) {
-	usage := 0.055
-	threshold := 6
-
-	required := checkIfScalingRequired(usage, threshold)
-	assert.False(t, required)
-
-	usage = 0.05
-	threshold = 5
-
-	required = checkIfScalingRequired(usage, threshold)
-	assert.True(t, required)
-
-	usage = 0.05
-	threshold = 4
-
-	required = checkIfScalingRequired(usage, threshold)
-	assert.True(t, required)
 }
 
 func TestDetectInvalidState(t *testing.T) {


### PR DESCRIPTION
add a another check for scaling to scale only when more than threshold minus 10% of cluster is full

in some cases ceph takes time to balance the osd,
so its important to calculate the total cluster size for a device class

