### PR TITLE
Set mon_max_pg_per_osd to 1000 to avoid too many PGs warning

### DIFF
--- a/controllers/storagecluster/cephconfig.go
+++ b/controllers/storagecluster/cephconfig.go
@@ -34,7 +34,6 @@ bdev_flock_retry = 20
 mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8
 mon_osd_nearfull_ratio = .75
-mon_max_pg_per_osd = 600
 mon_pg_warn_max_object_skew = 0
 mon_data_avail_warn = 15
 mon_warn_on_pool_no_redundancy = false


### PR DESCRIPTION
Ref-https://issues.redhat.com/browse/DFBUGS-2372
After mon_target_pg_per_osd is set to 400, sometimes we see a ceph health warning about too many PGs per OSD as the osd count reaches 600-700 sometimes. Setting the mon_max_pg_per_osd to 1000 will help avoid this warning.