### PR TITLE
Fix NFS snapshot class name used in internal consumer distribution

### DIFF
--- a/controllers/storagecluster/storageconsumer.go
+++ b/controllers/storagecluster/storageconsumer.go
@@ -168,7 +168,7 @@ func getLocalVolumeSnapshotClassNames(ctx context.Context, kubeClient client.Cli
 	volumeSnapshotClassNames[util.GenerateNameForSnapshotClass(storageCluster.Name, util.CephfsSnapshotter)] = true
 
 	if storageCluster.Spec.NFS != nil && storageCluster.Spec.NFS.Enable {
-		volumeSnapshotClassNames[util.GenerateNameForCephNetworkFilesystemStorageClass(storageCluster)] = true
+		volumeSnapshotClassNames[util.GenerateNameForSnapshotClass(storageCluster.Name, util.NfsSnapshotter)] = true
 	}
 
 	// for day2 volumesnapshotclasses


### PR DESCRIPTION
Replaces incorrect use of NFS StorageClass name with the correct NFS VolumeSnapshotClass name in `getLocalVolumeSnapshotClassNames()`.
