### PR TITLE
Add target size ratio value to custom cephBlockPool during creation

### DIFF
--- a/services/ux-backend/handlers/expandstorage/handler.go
+++ b/services/ux-backend/handlers/expandstorage/handler.go
@@ -163,6 +163,7 @@ func createCephBlockPool(w http.ResponseWriter, r *http.Request, client client.C
 					Size:                     uint(dataProtectionPolicy),
 					RequireSafeReplicaSize:   true,
 					ReplicasPerFailureDomain: uint(replicasPerFailureDomain),
+					TargetSizeRatio:          0.49,
 				},
 				Parameters: map[string]string{
 					"compression_mode": compression,


### PR DESCRIPTION
Custom cephBlockPool are not reconciled by ocs-operator, so if the user does not set the target size ratio value, it will be not set. This would affect the scaling of the pool.

So we need to add the target size ratio default value to the custom cephBlockPool during creation.

Part Of https://github.com/red-hat-storage/odf-console/pull/2067

https://issues.redhat.com/browse/DFBUGS-2059