### PR TITLE
do not mark virt SC as default for kubevirt workloads

### DIFF
--- a/controllers/util/storageclasses.go
+++ b/controllers/util/storageclasses.go
@@ -132,8 +132,13 @@ func NewDefaultVirtRbdStorageClass(
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"description": "Provides RWO and RWX Block volumes suitable for Virtual Machine disks",
-				"reclaimspace.csiaddons.openshift.io/schedule":   "@weekly",
-				"storageclass.kubevirt.io/is-default-virt-class": "true",
+				"reclaimspace.csiaddons.openshift.io/schedule": "@weekly",
+
+				// this is an interim fix to unblock CNV, we were partially allowing reconcile of this StorageClass
+				// in pre4.19 which was wrong and always reconciling this now is disallowing CNV to remove this
+				// annotation. we anyways allow addition of metadata and user can place this annotation if required.
+
+				// "storageclass.kubevirt.io/is-default-virt-class": "true",
 			},
 			Labels: map[string]string{},
 		},

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageclasses.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageclasses.go
@@ -132,8 +132,13 @@ func NewDefaultVirtRbdStorageClass(
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"description": "Provides RWO and RWX Block volumes suitable for Virtual Machine disks",
-				"reclaimspace.csiaddons.openshift.io/schedule":   "@weekly",
-				"storageclass.kubevirt.io/is-default-virt-class": "true",
+				"reclaimspace.csiaddons.openshift.io/schedule": "@weekly",
+
+				// this is an interim fix to unblock CNV, we were partially allowing reconcile of this StorageClass
+				// in pre4.19 which was wrong and always reconciling this now is disallowing CNV to remove this
+				// annotation. we anyways allow addition of metadata and user can place this annotation if required.
+
+				// "storageclass.kubevirt.io/is-default-virt-class": "true",
 			},
 			Labels: map[string]string{},
 		},


### PR DESCRIPTION
we were partially reconciling virt storageclass after it's creation and this allowed external entities to remove the annotation which shouldn't have been allowed.

with updated design ocs-operator holds full control over the storageclass and this is disallowing user not to remove the annotation. since we allow the addition of annotations we create the SC w/o the annotation and user can mark it as default.

we are considering this as an interim fix to unblock CNV.

revert of #2213