### PR TITLE
improved logs in the provider server for debugging

### DIFF
--- a/services/provider/main.go
+++ b/services/provider/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/services/provider/server"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
@@ -22,11 +24,13 @@ func main() {
 	klog.Info("Starting Provider API server")
 
 	namespace := util.GetPodNamespace()
-
+	loggerOpts := zap.Options{}
+	logger := zap.New(zap.UseFlagOptions(&loggerOpts))
+	ctrl.SetLogger(logger)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	providerServer, err := server.NewOCSProviderServer(ctx, namespace)
+	providerServer, err := server.NewOCSProviderServer(ctx, namespace, logger)
 	if err != nil {
 		klog.Errorf("failed to start provider server. %v", err)
 		return


### PR DESCRIPTION
This PR improves the logs in the ocs-provider-server pod.

The earlier logs were not fully explainable, partial information was provided and hence it was confusing to debug based on log events.

I have made changes with respect to  ocs-provider-server pod, since a bug was raised for  log issues.
