### PR TITLE
Make mon_target_pg_per_osd = 400 always both for new & upgraded clusters

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -1563,7 +1563,8 @@ func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string)
 func getCephClusterCephConfig(sc *ocsv1.StorageCluster) map[string]map[string]string {
 	cephConfig := map[string]map[string]string{
 		"global": {
-			"mon_max_pg_per_osd": "1000",
+			"mon_target_pg_per_osd": "400",
+			"mon_max_pg_per_osd":    "1000",
 		},
 	}
 	if sc.Spec.ManagedResources.CephCluster.CephConfig != nil {

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -309,8 +309,6 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 			} else {
 				r.Log.Info("Creating CephCluster.", "CephCluster", klog.KRef(cephCluster.Namespace, cephCluster.Name))
 			}
-			// set mon_target_pg_per_osd to 400 only during new cluster creation as setting it on existing cluster can cause data movement.
-			setMonTargetPgPerOsd(&cephCluster.Spec.CephConfig)
 			if err := r.Client.Create(context.TODO(), cephCluster); err != nil {
 				r.Log.Error(err, "Unable to create CephCluster.", "CephCluster", klog.KRef(cephCluster.Namespace, cephCluster.Name))
 				return reconcile.Result{}, err
@@ -388,8 +386,6 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 			sc.Status.Phase = statusutil.PhaseNotReady
 		}
 	}
-
-	preserveMonTargetPgPerOsd(found.Spec.CephConfig, &cephCluster.Spec.CephConfig)
 
 	// Update the CephCluster if it is not in the desired state
 	if !reflect.DeepEqual(cephCluster.Spec, found.Spec) {
@@ -1562,37 +1558,6 @@ func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string)
 	}
 
 	return crs
-}
-
-// setMonTargetPgPerOsd sets the mon_target_pg_per_osd value to 400 if not already set
-func setMonTargetPgPerOsd(cephConfig *map[string]map[string]string) {
-	if *cephConfig == nil {
-		*cephConfig = make(map[string]map[string]string)
-	}
-	if global, exists := (*cephConfig)["global"]; exists {
-		if _, exists := global["mon_target_pg_per_osd"]; !exists {
-			global["mon_target_pg_per_osd"] = "400"
-		}
-	} else {
-		(*cephConfig)["global"] = map[string]string{
-			"mon_target_pg_per_osd": "400",
-		}
-	}
-}
-
-// preserveMonTargetPgPerOsd preserves the mon_target_pg_per_osd value if its present in the existing cephconfig but is missing in the updated cephconfig
-func preserveMonTargetPgPerOsd(existingCephConfig map[string]map[string]string, updatedCephConfig *map[string]map[string]string) {
-	if global, exists := existingCephConfig["global"]; exists {
-		if value, exists := global["mon_target_pg_per_osd"]; exists {
-			if *updatedCephConfig == nil {
-				*updatedCephConfig = make(map[string]map[string]string)
-			}
-			if _, exists := (*updatedCephConfig)["global"]; !exists {
-				(*updatedCephConfig)["global"] = make(map[string]string)
-			}
-			(*updatedCephConfig)["global"]["mon_target_pg_per_osd"] = value
-		}
-	}
 }
 
 func getCephClusterCephConfig(sc *ocsv1.StorageCluster) map[string]map[string]string {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -9,16 +9,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/imdario/mergo"
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-	api "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/platform"
 	ocsutil "github.com/red-hat-storage/ocs-operator/v4/controllers/util"
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -93,7 +90,6 @@ func TestEnsureCephCluster(t *testing.T) {
 		reconciler := createFakeStorageClusterReconciler(t, networkConfig)
 
 		expected := newCephCluster(mockStorageCluster.DeepCopy(), "", nil, log)
-		setMonTargetPgPerOsd(&expected.Spec.CephConfig)
 		expected.Status.State = c.cephClusterState
 
 		if !c.shouldCreate {
@@ -1775,120 +1771,4 @@ func TestIsEncrptionSettingUpdated(t *testing.T) {
 	// encryption setting has not changed
 	actualResult = isEncrptionSettingUpdated(false, newStorageClassDeviceSet)
 	assert.Equal(t, false, actualResult)
-}
-
-func TestMonTargetPgPerOsdBehaviour(t *testing.T) {
-	var cases = []struct {
-		description            string
-		existing               *cephv1.CephCluster
-		storageClusterSpec     *api.StorageClusterSpec
-		expectedTargetPGPerOsd string
-	}{
-		{
-			description:            "case 1: New cluster creation - TargetPGPerOsd should be set to 400",
-			expectedTargetPGPerOsd: "400",
-		},
-		{
-			description: "case 2: New pool creation, TargetPGPerOsd is specified on CR- should respect CR setting",
-			storageClusterSpec: &api.StorageClusterSpec{
-				ManagedResources: api.ManagedResourcesSpec{
-					CephCluster: api.ManageCephCluster{
-						CephConfig: map[string]map[string]string{
-							"global": {
-								"mon_target_pg_per_osd": "500",
-							},
-						},
-					},
-				},
-			},
-			expectedTargetPGPerOsd: "500",
-		},
-		{
-			description: "case 3: Existing cluster with target pg value - should preserve value",
-			existing: &cephv1.CephCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cephcluster",
-				},
-				Spec: cephv1.ClusterSpec{
-					CephConfig: map[string]map[string]string{
-						"global": {
-							"mon_target_pg_per_osd": "400",
-						},
-					},
-				},
-			},
-			expectedTargetPGPerOsd: "400",
-		},
-		{
-			description: "case 4: Existing cluster without target pg value - should not set flag",
-			existing: &cephv1.CephCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cephcluster",
-				},
-				Spec: cephv1.ClusterSpec{},
-			},
-			expectedTargetPGPerOsd: "",
-		},
-		{
-			description: "case 5: Existing cluster without target pg value - CR specifies target pg value - should respect CR setting",
-			existing: &cephv1.CephCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cephcluster",
-				},
-				Spec: cephv1.ClusterSpec{},
-			},
-			storageClusterSpec: &api.StorageClusterSpec{
-				ManagedResources: api.ManagedResourcesSpec{
-					CephCluster: api.ManageCephCluster{
-						CephConfig: map[string]map[string]string{
-							"global": {
-								"mon_target_pg_per_osd": "200",
-							},
-						},
-					},
-				},
-			},
-			expectedTargetPGPerOsd: "200",
-		},
-	}
-
-	for _, c := range cases {
-		t.Logf("Running %s", c.description)
-		sc := &ocsv1.StorageCluster{}
-		mockStorageCluster.DeepCopyInto(sc)
-		sc.Status.Images.Ceph = &ocsv1.ComponentImageStatus{}
-		reconciler := createFakeStorageClusterReconciler(t, networkConfig)
-		expected := newCephCluster(mockStorageCluster.DeepCopy(), "", nil, log)
-		if c.storageClusterSpec != nil {
-			_ = mergo.Merge(&sc.Spec, c.storageClusterSpec)
-		}
-		err := reconciler.Client.Create(context.TODO(), sc)
-		assert.NilError(t, err)
-
-		if c.existing != nil {
-			c.existing.ObjectMeta.Name = expected.Name
-			c.existing.ObjectMeta.Namespace = expected.Namespace
-			err := reconciler.Client.Create(context.TODO(), c.existing)
-			assert.NilError(t, err)
-		}
-
-		obj := &ocsCephCluster{}
-		_, err = obj.ensureCreated(&reconciler, sc)
-		assert.NilError(t, err)
-
-		actual := &cephv1.CephCluster{}
-		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
-		assert.NilError(t, err)
-		assert.Equal(t, expected.ObjectMeta.Name, actual.ObjectMeta.Name)
-		assert.Equal(t, expected.ObjectMeta.Namespace, actual.ObjectMeta.Namespace)
-
-		targetPg, exists := actual.Spec.CephConfig["global"]["mon_target_pg_per_osd"]
-		if c.expectedTargetPGPerOsd == "" {
-			assert.Equal(t, false, exists, "mon_target_pg_per_osd should not exist")
-
-		} else {
-			assert.Equal(t, true, exists, "mon_target_pg_per_osd should exist")
-			assert.Equal(t, c.expectedTargetPGPerOsd, targetPg, "mon_target_pg_per_osd value mismatch")
-		}
-	}
 }


### PR DESCRIPTION
Following discussion on https://issues.redhat.com/browse/DFBUGS-2391 & ODF Weekly call it was decided to make mon_target_pg_per_osd = 400 always, both for new & upgraded clusters. This was decided based on factors like
1. New & Upgraded clusters should not diverge in terms of behavior
2. Old customers are able to utilize the performance gain from this

This will trigger a data movement upon upgrade from 4.18 to 4.19. We have to add upgrade notes, release notes notifying customers of the data movement & the health warning that would appear upon upgrade.