### PR TITLE
allow virtualization storageclass to be marked as default for kubevirt

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -243,6 +243,8 @@ type ManageCephBlockPools struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	VirtualizationStorageClassName string `json:"virtualizationStorageClassName,omitempty"`
+	// if set to true, the virtualization storageClass will be annotated as the default for kubevirt workloads
+	DefaultVirtualizationStorageClass bool `json:"defaultVirtualizationStorageClass,omitempty"`
 	// PoolSpec specifies the pool specification for the default cephBlockPool
 	PoolSpec *rookCephv1.PoolSpec `json:"poolSpec,omitempty"`
 }

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -716,6 +716,10 @@ spec:
                           cephBlockPools will be annotated as the default for the
                           whole cluster
                         type: boolean
+                      defaultVirtualizationStorageClass:
+                        description: if set to true, the virtualization storageClass
+                          will be annotated as the default for kubevirt workloads
+                        type: boolean
                       disableSnapshotClass:
                         type: boolean
                       disableStorageClass:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -716,6 +716,10 @@ spec:
                           cephBlockPools will be annotated as the default for the
                           whole cluster
                         type: boolean
+                      defaultVirtualizationStorageClass:
+                        description: if set to true, the virtualization storageClass
+                          will be annotated as the default for kubevirt workloads
+                        type: boolean
                       disableSnapshotClass:
                         type: boolean
                       disableStorageClass:

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -718,6 +718,10 @@ spec:
                           cephBlockPools will be annotated as the default for the
                           whole cluster
                         type: boolean
+                      defaultVirtualizationStorageClass:
+                        description: if set to true, the virtualization storageClass
+                          will be annotated as the default for kubevirt workloads
+                        type: boolean
                       disableSnapshotClass:
                         type: boolean
                       disableStorageClass:

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -243,6 +243,8 @@ type ManageCephBlockPools struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	VirtualizationStorageClassName string `json:"virtualizationStorageClassName,omitempty"`
+	// if set to true, the virtualization storageClass will be annotated as the default for kubevirt workloads
+	DefaultVirtualizationStorageClass bool `json:"defaultVirtualizationStorageClass,omitempty"`
 	// PoolSpec specifies the pool specification for the default cephBlockPool
 	PoolSpec *rookCephv1.PoolSpec `json:"poolSpec,omitempty"`
 }

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1372,6 +1372,7 @@ func (s *OCSProviderServer) appendStorageClassKubeResources(
 				consumerConfig.GetCsiRbdNodeCephUserName(),
 				consumer.Status.Client.OperatorNamespace,
 				rbdStorageId,
+				storageCluster.Spec.ManagedResources.CephBlockPools.DefaultVirtualizationStorageClass,
 			)
 		}
 		if kmsConfig, err := util.GetKMSConfigMap(defaults.KMSConfigMapName, storageCluster, s.client); err == nil && kmsConfig != nil {

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -243,6 +243,8 @@ type ManageCephBlockPools struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	VirtualizationStorageClassName string `json:"virtualizationStorageClassName,omitempty"`
+	// if set to true, the virtualization storageClass will be annotated as the default for kubevirt workloads
+	DefaultVirtualizationStorageClass bool `json:"defaultVirtualizationStorageClass,omitempty"`
 	// PoolSpec specifies the pool specification for the default cephBlockPool
 	PoolSpec *rookCephv1.PoolSpec `json:"poolSpec,omitempty"`
 }


### PR DESCRIPTION
from 4.19 operator created storageclasses are fully managed, however similar to how we allow a certain SC to be marked as default we also need to allow virtualization SC to be marked as per used needs.