### PR TITLE
controllers: add finalizers for internal client/consumer

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -80,13 +80,17 @@ const (
 	StorageClientCrdName = "storageclients.ocs.openshift.io"
 
 	VolumeGroupSnapshotClassCrdName = "volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io"
+
+	internalComponentFinalizer = "ocs.openshift.io/internal-component"
+
+	labelZoneRegionWithoutBeta = "failure-domain.kubernetes.io/region"
+
+	labelZoneFailureDomainWithoutBeta = "failure-domain.kubernetes.io/zone"
+
+	labelRookPrefix = "topology.rook.io"
 )
 
 var storageClusterFinalizer = "storagecluster.ocs.openshift.io"
-
-const labelZoneRegionWithoutBeta = "failure-domain.kubernetes.io/region"
-const labelZoneFailureDomainWithoutBeta = "failure-domain.kubernetes.io/zone"
-const labelRookPrefix = "topology.rook.io"
 
 var validTopologyLabelKeys = []string{
 	// This is the most preferred key as kubernetes recommends zone and region


### PR DESCRIPTION
Deletion of internal client/consumer shouldn't be allowed, and they should be removed only when storageCluster is deleted.
To ensure the same, finalizers would be added to storageConsumer and storageClient in such a way that they can only be deleted when the storageCluster is deleted. 

Resolves: [DFBUGS-2333](https://issues.redhat.com/browse/DFBUGS-2333)
