### PR TITLE
external: add external mode label to storageclasses

### DIFF
--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -400,7 +400,6 @@ func assertReconciliationOfExternalResource(t *testing.T, reconciler StorageClus
 	sc := &api.StorageCluster{}
 	err = reconciler.Client.Get(ctx, request.NamespacedName, sc)
 	assert.NoError(t, err)
-	firstExtSecretChecksum := sc.Status.ExternalSecretHash
 
 	extRsrcs, err := reconciler.retrieveExternalSecretData(sc)
 	assert.NoError(t, err)
@@ -431,23 +430,12 @@ func assertReconciliationOfExternalResource(t *testing.T, reconciler StorageClus
 	sc = &api.StorageCluster{}
 	err = reconciler.Client.Get(ctx, request.NamespacedName, sc)
 	assert.NoError(t, err)
-	secondExtSecretChecksum := sc.Status.ExternalSecretHash
-	// as there are changes, first and second checksums should not match
-	assert.NotEqual(t, firstExtSecretChecksum, secondExtSecretChecksum)
 
 	// third reconcile on same 'reconciler', without any change in the resources
 	result, err = reconciler.Reconcile(ctx, request)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
 	assertExpectedExternalResources(t, reconciler)
-
-	// get the updated storagecluster object after third reconciliation
-	sc = &api.StorageCluster{}
-	err = reconciler.Client.Get(ctx, request.NamespacedName, sc)
-	assert.NoError(t, err)
-	thirdExtSecretChecksum := sc.Status.ExternalSecretHash
-	// as there are no changes, second and third checksums should match
-	assert.Equal(t, secondExtSecretChecksum, thirdExtSecretChecksum)
 
 }
 

--- a/controllers/storagecluster/storageconsumer.go
+++ b/controllers/storagecluster/storageconsumer.go
@@ -17,6 +17,8 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -109,6 +111,19 @@ func (s *storageConsumer) ensureDeleted(_ *StorageClusterReconciler, _ *ocsv1.St
 	return ctrl.Result{}, nil
 }
 
+func getExternalClassesBlaclistSelector() labels.Selector {
+	blackListRequirement, err := labels.NewRequirement(
+		util.ExternalClassLabelKey,
+		selection.NotEquals,
+		[]string{"true"},
+	)
+	if err != nil {
+		panic(fmt.Sprintf("Error in external class label selector definition: %v", err))
+	}
+
+	return labels.NewSelector().Add(*blackListRequirement)
+}
+
 func getLocalStorageClassNames(ctx context.Context, kubeClient client.Client, storageCluster *ocsv1.StorageCluster) (
 	[]ocsv1a1.StorageClassSpec, error) {
 
@@ -140,11 +155,13 @@ func getLocalStorageClassNames(ctx context.Context, kubeClient client.Client, st
 
 	// for day2 storageclasses
 	storageClassesInCluster := &storagev1.StorageClassList{}
-	if err := kubeClient.List(ctx, storageClassesInCluster); err != nil {
+	if err := kubeClient.List(ctx, storageClassesInCluster, &client.MatchingLabelsSelector{
+		// not select storageclass with external labels
+		Selector: getExternalClassesBlaclistSelector(),
+	}); err != nil {
 		return nil, err
 	}
 	for idx := range storageClassesInCluster.Items {
-		// TODO: skip storageclasses that are from external mode if both internal & external mode is enabled
 		sc := &storageClassesInCluster.Items[idx]
 		if slices.Contains(supportedCsiDrivers, sc.Provisioner) {
 			storageClassNames[sc.Name] = true
@@ -173,7 +190,10 @@ func getLocalVolumeSnapshotClassNames(ctx context.Context, kubeClient client.Cli
 
 	// for day2 volumesnapshotclasses
 	volumeSnapshotClassesInCluster := &snapapi.VolumeSnapshotClassList{}
-	if err := kubeClient.List(ctx, volumeSnapshotClassesInCluster); err != nil {
+	if err := kubeClient.List(ctx, volumeSnapshotClassesInCluster, &client.MatchingLabelsSelector{
+		// not select snapshotclasses with external labels
+		Selector: getExternalClassesBlaclistSelector(),
+	}); err != nil {
 		return nil, err
 	}
 	for idx := range volumeSnapshotClassesInCluster.Items {
@@ -207,7 +227,10 @@ func getLocalVolumeGroupSnapshotClassNames(ctx context.Context, kubeClient clien
 	if crd.UID != "" {
 		// for day2 volumegroupsnapshotclasses
 		volumeGroupSnapshotClassesInCluster := &groupsnapapi.VolumeGroupSnapshotClassList{}
-		if err := kubeClient.List(ctx, volumeGroupSnapshotClassesInCluster); err != nil {
+		if err := kubeClient.List(ctx, volumeGroupSnapshotClassesInCluster, &client.MatchingLabelsSelector{
+			// not select groupsnapshotclasses with external labels
+			Selector: getExternalClassesBlaclistSelector(),
+		}); err != nil {
 			return nil, err
 		}
 		for idx := range volumeGroupSnapshotClassesInCluster.Items {

--- a/controllers/storagecluster/volumegroupsnapshotterclasses.go
+++ b/controllers/storagecluster/volumegroupsnapshotterclasses.go
@@ -3,6 +3,7 @@ package storagecluster
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
@@ -89,6 +90,7 @@ func (obj *ocsGroupSnapshotClass) ensureCreated(r *StorageClusterReconciler, ins
 		reconcileStrategy: ReconcileStrategy(instance.Spec.ManagedResources.CephBlockPools.ReconcileStrategy),
 	}
 	rbdGroupSnapshotClass.groupSnapshotClass.Name = util.GenerateNameForGroupSnapshotClass(instance, util.RbdGroupSnapshotter)
+	util.AddLabel(rbdGroupSnapshotClass.groupSnapshotClass, util.ExternalClassLabelKey, strconv.FormatBool(true))
 
 	cephfsClusterID, cephfsProvisionerSecret, err := r.getClusterIDAndSecretName(instance, util.CephfsSnapshotter)
 	if err != nil {
@@ -105,12 +107,12 @@ func (obj *ocsGroupSnapshotClass) ensureCreated(r *StorageClusterReconciler, ins
 		reconcileStrategy: ReconcileStrategy(instance.Spec.ManagedResources.CephFilesystems.ReconcileStrategy),
 	}
 	cephFsGroupSnapshotClass.groupSnapshotClass.Name = util.GenerateNameForGroupSnapshotClass(instance, util.CephfsGroupSnapshotter)
+	util.AddLabel(cephFsGroupSnapshotClass.groupSnapshotClass, util.ExternalClassLabelKey, strconv.FormatBool(true))
 
 	volumeGroupSnapshotClasses := []GroupSnapshotClassConfiguration{
 		rbdGroupSnapshotClass,
 		cephFsGroupSnapshotClass,
 	}
-
 	err = r.createGroupSnapshotClasses(volumeGroupSnapshotClasses)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/controllers/storagecluster/volumesnapshotterclasses.go
+++ b/controllers/storagecluster/volumesnapshotterclasses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
@@ -131,6 +132,7 @@ func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance
 		reconcileStrategy: ReconcileStrategy(instance.Spec.ManagedResources.CephBlockPools.ReconcileStrategy),
 	}
 	rbdSnapClass.snapshotClass.Name = util.GenerateNameForSnapshotClass(instance.Name, util.RbdSnapshotter)
+	util.AddLabel(rbdSnapClass.snapshotClass, util.ExternalClassLabelKey, strconv.FormatBool(true))
 
 	cephfsClusterID, cephfsProvisionerSecret, err := r.getClusterIDAndSecretName(instance, util.CephfsSnapshotter)
 	if err != nil {
@@ -141,8 +143,9 @@ func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance
 		reconcileStrategy: ReconcileStrategy(instance.Spec.ManagedResources.CephFilesystems.ReconcileStrategy),
 	}
 	cephFsSnapClass.snapshotClass.Name = util.GenerateNameForSnapshotClass(instance.Name, util.CephfsSnapshotter)
-	volumeSnapshotClasses := []SnapshotClassConfiguration{rbdSnapClass, cephFsSnapClass}
+	util.AddLabel(cephFsSnapClass.snapshotClass, util.ExternalClassLabelKey, strconv.FormatBool(true))
 
+	volumeSnapshotClasses := []SnapshotClassConfiguration{rbdSnapClass, cephFsSnapClass}
 	err = r.createSnapshotClasses(volumeSnapshotClasses)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -71,6 +71,7 @@ const (
 	CephRBDMirrorName                    = "cephrbdmirror"
 	OcsClientTimeout                     = 10 * time.Second
 	StorageClientMappingConfigName       = "storage-client-mapping"
+	ExternalClassLabelKey                = "storageclass.ocs.openshift.io/is-external"
 )
 
 var podNamespace = os.Getenv(PodNamespaceEnvVar)

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -71,6 +71,7 @@ const (
 	CephRBDMirrorName                    = "cephrbdmirror"
 	OcsClientTimeout                     = 10 * time.Second
 	StorageClientMappingConfigName       = "storage-client-mapping"
+	ExternalClassLabelKey                = "storageclass.ocs.openshift.io/is-external"
 )
 
 var podNamespace = os.Getenv(PodNamespaceEnvVar)

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1452,6 +1452,8 @@ func (s *OCSProviderServer) appendStorageClassKubeResources(
 			klog.Warningf("Encountered unsupported provisioner in storage class %s", storageClassName)
 		} else if storageClass == nil {
 			klog.Warningf("The name %s does not points to a builtin or an existing storage class, skipping", storageClassName)
+		} else if storageClass.Labels[util.ExternalClassLabelKey] == "true" {
+			klog.Warningf("The storage class %s is an external storage class, skipping", storageClassName)
 		} else {
 			kubeResources = append(kubeResources, storageClass)
 		}
@@ -1524,6 +1526,8 @@ func (s *OCSProviderServer) appendVolumeSnapshotClassKubeResources(
 			klog.Warningf("Encountered unsupported driver in volume snapshot class %s", snapshotClassName)
 		} else if snapshotClass == nil {
 			klog.Warningf("The name %s does not points to a builtin or an existing volumesnapshot class, skipping", snapshotClassName)
+		} else if snapshotClass.Labels[util.ExternalClassLabelKey] == "true" {
+			klog.Warningf("The snapshot class %s is an external storage class, skipping", snapshotClassName)
 		} else {
 			kubeResources = append(kubeResources, snapshotClass)
 		}
@@ -1589,6 +1593,8 @@ func (s *OCSProviderServer) appendVolumeGroupSnapshotClassKubeResources(
 			klog.Warningf("Encountered unsupported driver in volume group snapshot class %s", groupSnapshotClassName)
 		} else if groupSnapshotClass == nil {
 			klog.Warningf("The name %s does not points to a builtin or an existing volume group snapshot class, skipping", groupSnapshotClassName)
+		} else if groupSnapshotClass.Labels[util.ExternalClassLabelKey] == "true" {
+			klog.Warningf("The groupSnapshot class %s is an external storage class, skipping", groupSnapshotClassName)
 		} else {
 			kubeResources = append(kubeResources, groupSnapshotClass)
 		}


### PR DESCRIPTION
1) Adding labels to external storageclass and external volume snapshot and volume group snapshot storageclaaes, so distinguish between internal and external storageclass

2) Add a filter to deafult storageconsumer to not use the external classes 

3) Adding filter in provider reconcile to not distribute external storageclasses to the clients