### PR TITLE
Send OCS sub channel only if the current CSV of the sub has succeeded

### DIFF
--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -52,6 +52,7 @@ rules:
       - operators.coreos.com
     resources:
       - subscriptions
+      - clusterserviceversions
     verbs:
       - get
       - list

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -52,6 +52,7 @@ rules:
       - operators.coreos.com
     resources:
       - subscriptions
+      - clusterserviceversions
     verbs:
       - get
       - list


### PR DESCRIPTION
When the channel of the ocs-operator subscription is changed (e.g., from stable-4.18 to stable-4.19), this update is immediately propagated to the client, triggering its upgrade. However, if the client upgrades before the provider has completed its own CSV upgrade, the provider may detect that the client is ahead and mark itself as NotUpgradeable, blocking the upgrade process.

This commit ensures that the updated channel information is only sent to the client after the provider's CSV has reached the Succeeded phase. This prevents premature client upgrades and avoids upgrade deadlocks caused by version skew between provider and client.

Ref- https://issues.redhat.com/browse/DFBUGS-2502