### PR TITLE
controllers: prevent deletion of storageclusterpeer

### DIFF
--- a/controllers/storageclusterpeer/storageclusterpeer_controller.go
+++ b/controllers/storageclusterpeer/storageclusterpeer_controller.go
@@ -75,7 +75,7 @@ func (r *StorageClusterPeerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 func (r *StorageClusterPeerReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	var err error
 	r.ctx = ctx
-	r.log = log.FromContext(ctx, "StorageClient", request)
+	r.log = log.FromContext(ctx, "StorageClusterPeer", request)
 	r.log.Info("Reconciling StorageClusterPeer.")
 
 	// Fetch the StorageClusterPeer instance


### PR DESCRIPTION
add a finalizer to stop deletion of storageclusterpeer if storageclientmapping configmap is created. This will ensure that if storageclusterpeer is marked for deletion before configmap the dr uninstall will not get stuck

Fixes: https://issues.redhat.com/browse/DFBUGS-2407