### PR TITLE
DFBUGS-2555: cluster: update exporter and crashcollector resources

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -64,6 +64,32 @@ var (
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},
+		"ocs-metrics-exporter": {
+			Requests: corev1.ResourceList{
+				"memory": resource.MustParse("50Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+		},
+		"crashcollector": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
+				corev1.ResourceMemory: resource.MustParse("60Mi"),
+			},
+		},
+		"exporter": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.05"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.05"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
 	}
 
 	LeanDaemonResources = map[string]corev1.ResourceRequirements{

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -498,9 +498,11 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 				"arbiter": getPlacement(sc, "arbiter"),
 			},
 			PriorityClassNames: rookCephv1.PriorityClassNamesSpec{
-				rookCephv1.KeyMgr: systemNodeCritical,
-				rookCephv1.KeyMon: systemNodeCritical,
-				rookCephv1.KeyOSD: systemNodeCritical,
+				rookCephv1.KeyMgr:            systemNodeCritical,
+				rookCephv1.KeyMon:            systemNodeCritical,
+				rookCephv1.KeyOSD:            systemNodeCritical,
+				rookCephv1.KeyCephExporter:   systemNodeCritical,
+				rookCephv1.KeyCrashCollector: systemNodeCritical,
 			},
 			Resources:    newCephDaemonResources(sc),
 			LogCollector: logCollector,
@@ -1025,8 +1027,10 @@ func countAndReplicaOf(ds *ocsv1.StorageDeviceSet) (int, int) {
 
 func newCephDaemonResources(sc *ocsv1.StorageCluster) map[string]corev1.ResourceRequirements {
 	resources := map[string]corev1.ResourceRequirements{
-		"mon": defaults.GetProfileDaemonResources("mon", sc),
-		"mgr": defaults.GetProfileDaemonResources("mgr", sc),
+		"mon":            defaults.GetProfileDaemonResources("mon", sc),
+		"mgr":            defaults.GetProfileDaemonResources("mgr", sc),
+		"crashcollector": defaults.GetDaemonResources("crashcollector", sc.Spec.Resources),
+		"exporter":       defaults.GetDaemonResources("exporter", sc.Spec.Resources),
 	}
 	custom := sc.Spec.Resources
 	for k := range custom {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -836,8 +836,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.BalancedDaemonResources["mgr"],
-				"mon": defaults.BalancedDaemonResources["mon"],
+				"mgr":            defaults.BalancedDaemonResources["mgr"],
+				"mon":            defaults.BalancedDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -849,8 +851,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.LeanDaemonResources["mgr"],
-				"mon": defaults.LeanDaemonResources["mon"],
+				"mgr":            defaults.LeanDaemonResources["mgr"],
+				"mon":            defaults.LeanDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -862,8 +866,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.BalancedDaemonResources["mgr"],
-				"mon": defaults.BalancedDaemonResources["mon"],
+				"mgr":            defaults.BalancedDaemonResources["mgr"],
+				"mon":            defaults.BalancedDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -875,8 +881,10 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 			expected: map[string]corev1.ResourceRequirements{
-				"mgr": defaults.PerformanceDaemonResources["mgr"],
-				"mon": defaults.PerformanceDaemonResources["mon"],
+				"mgr":            defaults.PerformanceDaemonResources["mgr"],
+				"mon":            defaults.PerformanceDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -909,6 +917,8 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -941,7 +951,9 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
-				"mon": defaults.PerformanceDaemonResources["mon"],
+				"mon":            defaults.PerformanceDaemonResources["mon"],
+				"crashcollector": defaults.DaemonResources["crashcollector"],
+				"exporter":       defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -975,6 +987,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
+				"exporter": defaults.DaemonResources["exporter"],
 			},
 		},
 		{
@@ -1009,6 +1022,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("16Gi"),
 					},
 				},
+				"exporter": defaults.DaemonResources["exporter"],
 			},
 		},
 	}


### PR DESCRIPTION
update the exporter and crashcollector with limits and priority class, so it wont get evicted
during memeory pressure testing


(cherry picked from commit 621faf9021840770ab6a90a568b59cbfc0ab2536)