### PR TITLE
Follow the replicate size of the default CephBlockPool for the .mgr pool

### DIFF
--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -117,6 +117,13 @@ func (o *ocsCephBlockPools) reconcileMgrCephBlockPool(r *StorageClusterReconcile
 
 	_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
 		cephBlockPool.Spec.Name = ".mgr"
+
+		// Pass the Replicated Size Spec for the default CephBlockPool from the storageCluster CR
+		manageCBPSpec := &storageCluster.Spec.ManagedResources.CephBlockPools
+		if manageCBPSpec.PoolSpec != nil && manageCBPSpec.PoolSpec.Replicated.Size != 0 {
+			cephBlockPool.Spec.Replicated.Size = manageCBPSpec.PoolSpec.Replicated.Size
+		}
+
 		setDefaultMetadataPoolSpec(&cephBlockPool.Spec.PoolSpec, storageCluster)
 		util.AddLabel(cephBlockPool, util.ForbidMirroringLabel, "true")
 


### PR DESCRIPTION
In a cluster if customer has specified the replication size for the default CephBlockPool for example 2, then the .mgr pool should also have the same replication size. This will majorly help in prototyping ODF for 2 node cluster as for all other pools we have ways to specify the replication size but not for the .mgr pool.

Ref-https://issues.redhat.com/browse/DFBUGS-2568
