### PR TITLE
add nil check for client in metrics exporter

### DIFF
--- a/metrics/internal/collectors/storageconsumer.go
+++ b/metrics/internal/collectors/storageconsumer.go
@@ -141,14 +141,16 @@ func (c *StorageConsumerCollector) collectStorageConsumersMetadata(storageConsum
 			prometheus.GaugeValue, float64(storageConsumer.Status.LastHeartbeat.Time.Unix()),
 			storageConsumer.Name)
 
-		ch <- prometheus.MustNewConstMetric(c.ClientOperatorVersion,
-			prometheus.GaugeValue,
-			float64(encodeVersion(storageConsumer.Status.Client.OperatorVersion)),
-			storageConsumer.Name)
+		if storageConsumer.Status.Client != nil {
+			ch <- prometheus.MustNewConstMetric(c.ClientOperatorVersion,
+				prometheus.GaugeValue,
+				float64(encodeVersion(storageConsumer.Status.Client.OperatorVersion)),
+				storageConsumer.Name)
 
-		ch <- prometheus.MustNewConstMetric(c.StorageQuotaUtilizationRatio,
-			prometheus.GaugeValue, storageConsumer.Status.Client.StorageQuotaUtilizationRatio,
-			storageConsumer.Status.Client.Name, storageConsumer.Status.Client.ClusterName)
+			ch <- prometheus.MustNewConstMetric(c.StorageQuotaUtilizationRatio,
+				prometheus.GaugeValue, storageConsumer.Status.Client.StorageQuotaUtilizationRatio,
+				storageConsumer.Status.Client.Name, storageConsumer.Status.Client.ClusterName)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR introduces a nil check for the `Client` object under `StorageConsumer` in `metrics-exporter` since it has been changed to use pointer semantics.

- **Currently**: When a `StorageConsumer` resource lacks a valid `Client`, the `ocs-metrics-exporter` pod encounters a nil pointer dereference, causing it to enter a `CrashLoopBackOff` state and finally an
```
NAME                                   READY    STATUS            RESTARTS      AGE
ocs-metrics-exporter-b84c6797d-w5d9t   2/3      CrashLoopBackOff  5 (48s ago)   24m
```

- **With the fix**: `ocs-metrics-exporter` continues to run without an error even without a valid `Client`. 

Fixes: [DFBUGS-2509](https://issues.redhat.com/browse/DFBUGS-2509)