### PR TITLE
Set mon_target_pg_per_osd based on the resource profile

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -1563,10 +1563,19 @@ func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string)
 func getCephClusterCephConfig(sc *ocsv1.StorageCluster) map[string]map[string]string {
 	cephConfig := map[string]map[string]string{
 		"global": {
-			"mon_target_pg_per_osd": "400",
 			"mon_max_pg_per_osd":    "1000",
+			"mon_target_pg_per_osd": "200",
 		},
 	}
+
+	// Set the mon_target_pg_per_osd based on the resource profile
+	switch sc.Spec.ResourceProfile {
+	case "lean":
+		cephConfig["global"]["mon_target_pg_per_osd"] = "100"
+	case "performance":
+		cephConfig["global"]["mon_target_pg_per_osd"] = "400"
+	}
+
 	if sc.Spec.ManagedResources.CephCluster.CephConfig != nil {
 		// Merge the existing ceph config with the new one
 		for section, config := range sc.Spec.ManagedResources.CephCluster.CephConfig {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -1785,7 +1785,7 @@ func TestGetCephClusterCephConfig(t *testing.T) {
 			storageCluster: &ocsv1.StorageCluster{},
 			expectedConfig: map[string]map[string]string{
 				"global": {
-					"mon_target_pg_per_osd": "400",
+					"mon_target_pg_per_osd": "200",
 					"mon_max_pg_per_osd":    "1000",
 				},
 			},
@@ -1830,7 +1830,7 @@ func TestGetCephClusterCephConfig(t *testing.T) {
 			},
 			expectedConfig: map[string]map[string]string{
 				"global": {
-					"mon_target_pg_per_osd": "400",
+					"mon_target_pg_per_osd": "200",
 					"mon_max_pg_per_osd":    "1000",
 				},
 				"osd": {


### PR DESCRIPTION
There were concerns of additional memory load on the OSDs with the increased mon_target_pg_per_osd value of 400. To mitigate this, we are setting the mon_target_pg_per_osd value based on the resource profile. By default for the balanced profile, the value is set to 200. For the lean profile, the value is set to 100. For the performance profile the value is set to 400.

https://issues.redhat.com/browse/DFBUGS-2569