### PR TITLE
Add disable key rotation annotation only for the internal client

### DIFF
--- a/controllers/storagecluster/storageconsumer.go
+++ b/controllers/storagecluster/storageconsumer.go
@@ -72,6 +72,10 @@ func (s *storageConsumer) ensureCreated(r *StorageClusterReconciler, storageClus
 
 		controllerutil.AddFinalizer(storageConsumer, internalComponentFinalizer)
 
+		if val, ok := storageCluster.GetAnnotations()[defaults.KeyRotationEnableAnnotation]; ok {
+			util.AddAnnotation(storageConsumer, defaults.KeyRotationEnableAnnotation, val)
+		}
+
 		return nil
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create/update storageconsumer %s: %v", storageConsumer.Name, err)

--- a/controllers/util/storageclasses.go
+++ b/controllers/util/storageclasses.go
@@ -175,7 +175,7 @@ func NewDefaultEncryptedRbdStorageClass(
 	nodeSecret,
 	namespace,
 	encryptionServiceName string,
-	disableKeyRotation bool,
+	KeyRotationAnnotationValue string,
 ) *storagev1.StorageClass {
 
 	sc := &storagev1.StorageClass{
@@ -206,8 +206,8 @@ func NewDefaultEncryptedRbdStorageClass(
 			"csi.storage.k8s.io/controller-expand-secret-namespace": namespace,
 		},
 	}
-	if disableKeyRotation {
-		AddAnnotation(sc, defaults.KeyRotationEnableAnnotation, "false")
+	if KeyRotationAnnotationValue != "" {
+		AddAnnotation(sc, defaults.KeyRotationEnableAnnotation, KeyRotationAnnotationValue)
 	}
 	return sc
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageclasses.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageclasses.go
@@ -175,7 +175,7 @@ func NewDefaultEncryptedRbdStorageClass(
 	nodeSecret,
 	namespace,
 	encryptionServiceName string,
-	disableKeyRotation bool,
+	KeyRotationAnnotationValue string,
 ) *storagev1.StorageClass {
 
 	sc := &storagev1.StorageClass{
@@ -206,8 +206,8 @@ func NewDefaultEncryptedRbdStorageClass(
 			"csi.storage.k8s.io/controller-expand-secret-namespace": namespace,
 		},
 	}
-	if disableKeyRotation {
-		AddAnnotation(sc, defaults.KeyRotationEnableAnnotation, "false")
+	if KeyRotationAnnotationValue != "" {
+		AddAnnotation(sc, defaults.KeyRotationEnableAnnotation, KeyRotationAnnotationValue)
 	}
 	return sc
 }

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1421,7 +1421,7 @@ func (s *OCSProviderServer) appendStorageClassKubeResources(
 					consumerConfig.GetCsiRbdNodeCephUserName(),
 					consumer.Status.Client.OperatorNamespace,
 					kmsServiceName,
-					storageCluster.GetAnnotations()[defaults.KeyRotationEnableAnnotation] == "false",
+					consumer.GetAnnotations()[defaults.KeyRotationEnableAnnotation],
 				)
 			}
 		}


### PR DESCRIPTION
We are adding the disable key rotation annotation from the storageCluster to the internal storage consumer. And based on that annotation, we will add the key rotation annotation to the storageClass.

Ref-https://issues.redhat.com/browse/DFBUGS-2288