### PR TITLE
Enable ReadAffinity with default CrushLocationLabels in CephConnection

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -389,7 +389,7 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 			return nil, err
 		}
 
-		cephConnection, err := s.getDesiredCephConnection(ctx, consumer)
+		cephConnection, err := s.getDesiredCephConnection(ctx, consumer, storageCluster)
 		if err != nil {
 			klog.Error(err)
 			return nil, status.Errorf(codes.Internal, "failed to produce client state hash")
@@ -656,7 +656,7 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 		return nil, status.Errorf(codes.Internal, "Failed to get mirroring status for consumer.")
 	}
 
-	cephConnection, err := s.getDesiredCephConnection(ctx, storageConsumer)
+	cephConnection, err := s.getDesiredCephConnection(ctx, storageConsumer, storageCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, status.Errorf(codes.Internal, "failed to produce client state hash")
@@ -1036,7 +1036,7 @@ func (s *OCSProviderServer) getKubeResources(ctx context.Context, consumer *ocsv
 	}
 
 	kubeResources := []client.Object{}
-	if cephConnection, err := s.getDesiredCephConnection(ctx, consumer); err == nil {
+	if cephConnection, err := s.getDesiredCephConnection(ctx, consumer, storageCluster); err == nil {
 		kubeResources = append(kubeResources, cephConnection)
 	} else {
 		return nil, err
@@ -1148,6 +1148,7 @@ func (s *OCSProviderServer) getKubeResources(ctx context.Context, consumer *ocsv
 func (s *OCSProviderServer) getDesiredCephConnection(
 	ctx context.Context,
 	consumer *ocsv1alpha1.StorageConsumer,
+	storageCluster *ocsv1.StorageCluster,
 ) (*csiopv1a1.CephConnection, error) {
 
 	configmap := &v1.ConfigMap{}
@@ -1166,13 +1167,39 @@ func (s *OCSProviderServer) getDesiredCephConnection(
 		return nil, fmt.Errorf("failed to extract monitor IPs from configmap %s: %v", monConfigMap, err)
 	}
 
+	readAffinityOptions := util.GetReadAffinityOptions(storageCluster)
+	readAffinityDisabledAnnotation, _ := strconv.ParseBool(consumer.Annotations["ocs.openshift.io/disable-read-affinity"])
+
+	var readAffinity *csiopv1a1.ReadAffinitySpec = nil
+	if readAffinityOptions.Enabled && !readAffinityDisabledAnnotation {
+		labels := readAffinityOptions.CrushLocationLabels
+		if len(labels) == 0 {
+			labels = []string{
+				"kubernetes.io/hostname",
+				"topology.kubernetes.io/region",
+				"topology.kubernetes.io/zone",
+				"topology.rook.io/datacenter",
+				"topology.rook.io/room",
+				"topology.rook.io/pod",
+				"topology.rook.io/pdu",
+				"topology.rook.io/row",
+				"topology.rook.io/rack",
+				"topology.rook.io/chassis",
+			}
+		}
+		readAffinity = &csiopv1a1.ReadAffinitySpec{
+			CrushLocationLabels: labels,
+		}
+	}
+
 	return &csiopv1a1.CephConnection{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      consumer.Status.Client.Name,
 			Namespace: consumer.Status.Client.OperatorNamespace,
 		},
 		Spec: csiopv1a1.CephConnectionSpec{
-			Monitors: monIps,
+			Monitors:     monIps,
+			ReadAffinity: readAffinity,
 		},
 	}, nil
 }


### PR DESCRIPTION
This PR addresses the bug where read affinity was not configured in the CephConnection resource.

Adds ReadAffinity section with default CrushLocationLabels:
```
"topology.rook.io/chassis", "topology.rook.io/rack", "topology.rook.io/row", "topology.rook.io/pdu", "topology.rook.io/pod", "topology.rook.io/room", "topology.rook.io/datacenter", "topology.kubernetes.io/region", "topology.kubernetes.io/zone", "kubernetes.io/hostname"
```
This change ensures that CSI read affinity is enabled by default.