### PR TITLE
Do not block provider upgrade if client is having a greater version

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -950,8 +950,7 @@ func getUnsupportedClientsCount(r *StorageClusterReconciler, namespace string) (
 		if scList.Items[idx].Status.Client != nil {
 			clientVersion, err := semver.Make(scList.Items[idx].Status.Client.OperatorVersion)
 			if err == nil {
-				// provider operator and client operator should be on same version for full compatibility
-				if providerVersion.Major != clientVersion.Major || providerVersion.Minor != clientVersion.Minor {
+				if providerVersion.Major != clientVersion.Major || providerVersion.Minor <= clientVersion.Minor {
 					count++
 				}
 			} else {


### PR DESCRIPTION
The client version might be updated on the client side by manual action. If that happens the hub would be blocked from upgrading the provider. To avoid that, we should not block the provider upgrade if the client version is greater than the provider version.