### PR TITLE
Filter packageManifests with the catalogSource Name & Namespace

### DIFF
--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -72,6 +72,7 @@ rules:
       - packagemanifests
     verbs:
       - get
+      - list
   - apiGroups:
       - ocs.openshift.io
     resources:

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -72,6 +72,7 @@ rules:
       - packagemanifests
     verbs:
       - get
+      - list
   - apiGroups:
       - ocs.openshift.io
     resources:


### PR DESCRIPTION
We just discovered there can be multiple catalogSources with the same name & namespace. So we need to filter the list with the catSrc Name & Namespace of the subscription to get the correct packageManifest.