### PR TITLE
controllers: update the consumer configmap default values

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -555,6 +555,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, kmsConfigMap *co
 				CephFS: rookCephv1.CSICephFSSpec{
 					KernelMountOptions: util.GetCephFSKernelMountOptions(sc),
 				},
+				SkipUserCreation: true,
 			},
 			SkipUpgradeChecks:            sc.Spec.ManagedResources.CephCluster.SkipUpgradeChecks,
 			UpgradeOSDRequiresHealthyPGs: sc.Spec.ManagedResources.CephCluster.UpgradeOSDRequiresHealthyPGs,

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
@@ -25,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )

--- a/controllers/util/storageconsumer.go
+++ b/controllers/util/storageconsumer.go
@@ -290,20 +290,20 @@ func GetStorageConsumerDefaultResourceNames(
 	if availableServices.Rbd {
 		resourceNamesMap.SetRbdRadosNamespaceName(storageConsumerName)
 		resourceNamesMap.SetRbdClientProfileName(storageConsumerUid)
-		resourceNamesMap.SetCsiRbdNodeCephUserName(fmt.Sprintf("rbd-node-%s", storageConsumerUid))
-		resourceNamesMap.SetCsiRbdProvisionerCephUserName(fmt.Sprintf("rbd-provisioner-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiRbdNodeCephUserName(fmt.Sprintf("csi-rbd-node-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiRbdProvisionerCephUserName(fmt.Sprintf("csi-rbd-provisioner-%s", storageConsumerUid))
 	}
 	if availableServices.CephFs {
 		resourceNamesMap.SetSubVolumeGroupName(storageConsumerName)
 		resourceNamesMap.SetSubVolumeGroupRadosNamespaceName(storageConsumerName)
 		resourceNamesMap.SetCephFsClientProfileName(storageConsumerUid)
-		resourceNamesMap.SetCsiCephFsNodeCephUserName(fmt.Sprintf("cephfs-node-%s", storageConsumerUid))
-		resourceNamesMap.SetCsiCephFsProvisionerCephUserName(fmt.Sprintf("cephfs-provisioner-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiCephFsNodeCephUserName(fmt.Sprintf("csi-cephfs-node-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiCephFsProvisionerCephUserName(fmt.Sprintf("csi-cephfs-provisioner-%s", storageConsumerUid))
 	}
 	if availableServices.Nfs {
 		resourceNamesMap.SetNfsClientProfileName(storageConsumerUid)
-		resourceNamesMap.SetCsiNfsNodeCephUserName(fmt.Sprintf("nfs-node-%s", storageConsumerUid))
-		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("nfs-provisioner-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiNfsNodeCephUserName(fmt.Sprintf("csi-nfs-node-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("csi-nfs-provisioner-%s", storageConsumerUid))
 	}
 	return defaults
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
@@ -290,20 +290,20 @@ func GetStorageConsumerDefaultResourceNames(
 	if availableServices.Rbd {
 		resourceNamesMap.SetRbdRadosNamespaceName(storageConsumerName)
 		resourceNamesMap.SetRbdClientProfileName(storageConsumerUid)
-		resourceNamesMap.SetCsiRbdNodeCephUserName(fmt.Sprintf("rbd-node-%s", storageConsumerUid))
-		resourceNamesMap.SetCsiRbdProvisionerCephUserName(fmt.Sprintf("rbd-provisioner-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiRbdNodeCephUserName(fmt.Sprintf("csi-rbd-node-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiRbdProvisionerCephUserName(fmt.Sprintf("csi-rbd-provisioner-%s", storageConsumerUid))
 	}
 	if availableServices.CephFs {
 		resourceNamesMap.SetSubVolumeGroupName(storageConsumerName)
 		resourceNamesMap.SetSubVolumeGroupRadosNamespaceName(storageConsumerName)
 		resourceNamesMap.SetCephFsClientProfileName(storageConsumerUid)
-		resourceNamesMap.SetCsiCephFsNodeCephUserName(fmt.Sprintf("cephfs-node-%s", storageConsumerUid))
-		resourceNamesMap.SetCsiCephFsProvisionerCephUserName(fmt.Sprintf("cephfs-provisioner-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiCephFsNodeCephUserName(fmt.Sprintf("csi-cephfs-node-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiCephFsProvisionerCephUserName(fmt.Sprintf("csi-cephfs-provisioner-%s", storageConsumerUid))
 	}
 	if availableServices.Nfs {
 		resourceNamesMap.SetNfsClientProfileName(storageConsumerUid)
-		resourceNamesMap.SetCsiNfsNodeCephUserName(fmt.Sprintf("nfs-node-%s", storageConsumerUid))
-		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("nfs-provisioner-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiNfsNodeCephUserName(fmt.Sprintf("csi-nfs-node-%s", storageConsumerUid))
+		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("csi-nfs-provisioner-%s", storageConsumerUid))
 	}
 	return defaults
 }


### PR DESCRIPTION
The PR does the following:
1. Skip default csi user creation by rook
2. Fill the internal and fresh deployment configmap with the correct values for the csi secret names