### PR TITLE
consumer: update the naming convention for the ceph clients

### DIFF
--- a/controllers/storageconsumer/consumer_test.go
+++ b/controllers/storageconsumer/consumer_test.go
@@ -65,6 +65,7 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 //TODO: add more unit-tests related to consumer reconcile
 
 func TestNoobaaAccount(t *testing.T) {
+	t.Skip("Skipping as we are disabling Noobaa with clients")
 	var r StorageConsumerReconciler
 	ctx := context.TODO()
 	scheme := createFakeScheme(t)

--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -63,6 +63,7 @@ const (
 	StorageConsumerNameLabel      = "ocs.openshift.io/storageconsumer-name"
 	storageConsumerFinalizer      = "ocs.openshift.io/storageconsumer-protection"
 	primaryConsumerUIDAnnotation  = "ocs.openshift.io/primary-consumer-uid"
+	csiCephUserCurrGen            = 1
 )
 
 // StorageConsumerReconciler reconciles a StorageConsumer object
@@ -222,16 +223,18 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientRBDProvisioner(
-					consumerResources.GetCsiRbdProvisionerCephUserName(),
+					util.GenerateCsiRbdProvisionerCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
 					consumerResources.GetRbdRadosNamespaceName(),
 					consumerConfigMap,
+					csiCephUserCurrGen,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientRBDNode(
-					consumerResources.GetCsiRbdNodeCephUserName(),
+					util.GenerateCsiRbdNodeCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
 					consumerResources.GetRbdRadosNamespaceName(),
 					consumerConfigMap,
+					csiCephUserCurrGen,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
@@ -246,17 +249,19 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientCephFSProvisioner(
-					consumerResources.GetCsiCephFsProvisionerCephUserName(),
+					util.GenerateCsiCephFsProvisionerCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserCurrGen,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
 
 				if err := r.reconcileCephClientCephFSNode(
-					consumerResources.GetCsiCephFsNodeCephUserName(),
+					util.GenerateCsiCephFsNodeCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserCurrGen,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
@@ -264,16 +269,18 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 
 			if availableServices.Nfs {
 				if err := r.reconcileCephClientNfsProvisioner(
-					consumerResources.GetCsiNfsProvisionerCephUserName(),
+					util.GenerateCsiNfsProvisionerCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserCurrGen,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientNfsNode(
-					consumerResources.GetCsiNfsNodeCephUserName(),
+					util.GenerateCsiNfsNodeCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserCurrGen,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
@@ -596,6 +603,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDProvisioner(
 	cephClientName string,
 	radosNamespaceName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -607,15 +615,15 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDProvisioner(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
 		if radosNamespaceName == util.ImplicitRbdRadosNamespaceName {
 			radosNamespaceName = "''"
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "profile rbd, allow command 'osd blocklist'",
-				"mgr": "allow rw",
-				"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
-			},
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "profile rbd, allow command 'osd blocklist'",
+			"mgr": "allow rw",
+			"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
 		}
 		return nil
 	}); err != nil {
@@ -628,6 +636,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDNode(
 	cephClientName string,
 	radosNamespaceName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -639,15 +648,15 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDNode(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
 		if radosNamespaceName == util.ImplicitRbdRadosNamespaceName {
 			radosNamespaceName = "''"
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "profile rbd",
-				"mgr": "allow rw",
-				"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
-			},
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "profile rbd",
+			"mgr": "allow rw",
+			"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
 		}
 		return nil
 	}); err != nil {
@@ -660,6 +669,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -671,13 +681,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r, allow command 'osd blocklist'",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs metadata=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r, allow command 'osd blocklist'",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs metadata=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {
@@ -690,6 +700,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSNode(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -701,13 +712,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSNode(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs *=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs *=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {
@@ -720,6 +731,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsProvisioner(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -731,13 +743,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsProvisioner(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r, allow command 'osd blocklist'",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs metadata=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r, allow command 'osd blocklist'",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs metadata=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {
@@ -750,6 +762,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsNode(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -761,13 +774,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsNode(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs *=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs *=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -76,6 +76,7 @@ const (
 	ForceDeletionAnnotationKey             = "ocs.openshift.io/force-deletion"
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
 	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
+	CsiCephUserGenerationLabelKey          = "ocs.openshift.io/csi-ceph-user-generation"
 )
 
 type BackwardCompatabilityInfo struct {

--- a/controllers/util/storageconsumer.go
+++ b/controllers/util/storageconsumer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -306,6 +307,30 @@ func GetStorageConsumerDefaultResourceNames(
 		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("nfs-provisioner-%s", storageConsumerUid))
 	}
 	return defaults
+}
+
+func GenerateCsiRbdProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiRbdNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsNodeCephUserKey, generation, uid)
 }
 
 // These methods are for backward compatibility for provider mode upgraded cluster

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -80,7 +80,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2025-06-30T18:04:40Z"
+    createdAt: "2025-07-01T11:59:29Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.30.0

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2025-06-30T18:04:40Z"
+    createdAt: "2025-07-01T11:59:29Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -639,7 +639,7 @@ spec:
                 - name: OCS_METRICS_EXPORTER_IMAGE
                   value: quay.io/ocs-dev/ocs-metrics-exporter:latest
                 - name: ROOK_CEPH_IMAGE
-                  value: quay.io/ocs-dev/rook-ceph:vmaster-5d3a5a849
+                  value: quay.io/ocs-dev/rook-ceph:vmaster-068aaaedb
                 - name: CEPH_IMAGE
                   value: quay.io/ceph/ceph:v19.2.1
                 - name: NOOBAA_CORE_IMAGE
@@ -803,7 +803,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/ocs-dev/rook-ceph:vmaster-5d3a5a849
+  - image: quay.io/ocs-dev/rook-ceph:vmaster-068aaaedb
     name: rook-container
   - image: quay.io/ceph/ceph:v19.2.1
     name: ceph-container

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -49,7 +49,7 @@ OCS_CSV="$OUTDIR_TEMPLATES/ocs-operator.csv.yaml.in"
 # We are using rook dowsntream image now, i.e, red-hat-storage/rook code
 # and we should continue to use dowsntream image only due to few
 # downstream only changes present in rook downstream fork.
-LATEST_ROOK_IMAGE="quay.io/ocs-dev/rook-ceph:vmaster-5d3a5a849"
+LATEST_ROOK_IMAGE="quay.io/ocs-dev/rook-ceph:vmaster-068aaaedb"
 LATEST_NOOBAA_CORE_IMAGE="quay.io/noobaa/noobaa-core:master-20250326"
 LATEST_NOOBAA_DB_IMAGE="quay.io/sclorg/postgresql-15-c9s"
 LATEST_CEPH_IMAGE="quay.io/ceph/ceph:v19.2.1"
@@ -92,7 +92,7 @@ CSI_ADDONS_BUNDLE_FULL_IMAGE_NAME="quay.io/csiaddons/k8s-bundle:v0.11.0"
 CEPH_CSI_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/cephcsi-operator-bundle:main-0ac7669"
 OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/ocs-client-operator-bundle:72027"
 NOOBAA_BUNDLE_FULL_IMAGE_NAME="quay.io/noobaa/noobaa-operator-bundle:master-20250326"
-ROOK_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/rook-ceph-operator-bundle:master-5d3a5a849"
+ROOK_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/rook-ceph-operator-bundle:master-068aaaedb"
 KUBE_RBAC_PROXY_FULL_IMAGE_NAME="gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1"
 
 OCS_OPERATOR_INSTALL="${OCS_OPERATOR_INSTALL:-false}"

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -76,6 +76,7 @@ const (
 	ForceDeletionAnnotationKey             = "ocs.openshift.io/force-deletion"
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
 	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
+	CsiCephUserGenerationLabelKey          = "ocs.openshift.io/csi-ceph-user-generation"
 )
 
 type BackwardCompatabilityInfo struct {

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -306,6 +307,30 @@ func GetStorageConsumerDefaultResourceNames(
 		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("nfs-provisioner-%s", storageConsumerUid))
 	}
 	return defaults
+}
+
+func GenerateCsiRbdProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiRbdNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsNodeCephUserKey, generation, uid)
 }
 
 // These methods are for backward compatibility for provider mode upgraded cluster


### PR DESCRIPTION
This PR does the following:
1. Create the cephClients with the desired name based on the generation and consumer UID

Review only the last commit