### PR TITLE
get the cephclient based on generation during desiredstate rpc

### DIFF
--- a/controllers/storageconsumer/consumer_test.go
+++ b/controllers/storageconsumer/consumer_test.go
@@ -65,6 +65,7 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 //TODO: add more unit-tests related to consumer reconcile
 
 func TestNoobaaAccount(t *testing.T) {
+	t.Skip("Skipping as we are disabling Noobaa with clients")
 	var r StorageConsumerReconciler
 	ctx := context.TODO()
 	scheme := createFakeScheme(t)

--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -174,6 +174,11 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 		return reconcile.Result{}, err
 	}
 
+	csiCephUserGeneration, err := util.GetCsiCephUserCurrGeneration()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get csi ceph user generation: %v", err)
+	}
+
 	if r.storageConsumer.GetDeletionTimestamp().IsZero() {
 		if controllerutil.AddFinalizer(r.storageConsumer, storageConsumerFinalizer) {
 			r.Log.Info("Finalizer not found for StorageConsumer. Adding finalizer.")
@@ -222,16 +227,18 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientRBDProvisioner(
-					consumerResources.GetCsiRbdProvisionerCephUserName(),
+					util.GenerateCsiRbdProvisionerCephClientName(csiCephUserGeneration, r.storageConsumer.UID),
 					consumerResources.GetRbdRadosNamespaceName(),
 					consumerConfigMap,
+					csiCephUserGeneration,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientRBDNode(
-					consumerResources.GetCsiRbdNodeCephUserName(),
+					util.GenerateCsiRbdNodeCephClientName(csiCephUserGeneration, r.storageConsumer.UID),
 					consumerResources.GetRbdRadosNamespaceName(),
 					consumerConfigMap,
+					csiCephUserGeneration,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
@@ -246,17 +253,19 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientCephFSProvisioner(
-					consumerResources.GetCsiCephFsProvisionerCephUserName(),
+					util.GenerateCsiCephFsProvisionerCephClientName(csiCephUserGeneration, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserGeneration,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
 
 				if err := r.reconcileCephClientCephFSNode(
-					consumerResources.GetCsiCephFsNodeCephUserName(),
+					util.GenerateCsiCephFsNodeCephClientName(csiCephUserGeneration, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserGeneration,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
@@ -264,16 +273,18 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 
 			if availableServices.Nfs {
 				if err := r.reconcileCephClientNfsProvisioner(
-					consumerResources.GetCsiNfsProvisionerCephUserName(),
+					util.GenerateCsiNfsProvisionerCephClientName(csiCephUserGeneration, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserGeneration,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
 				if err := r.reconcileCephClientNfsNode(
-					consumerResources.GetCsiNfsNodeCephUserName(),
+					util.GenerateCsiNfsNodeCephClientName(csiCephUserGeneration, r.storageConsumer.UID),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
+					csiCephUserGeneration,
 				); err != nil {
 					return reconcile.Result{}, err
 				}
@@ -596,6 +607,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDProvisioner(
 	cephClientName string,
 	radosNamespaceName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -607,15 +619,15 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDProvisioner(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
 		if radosNamespaceName == util.ImplicitRbdRadosNamespaceName {
 			radosNamespaceName = "''"
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "profile rbd, allow command 'osd blocklist'",
-				"mgr": "allow rw",
-				"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
-			},
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "profile rbd, allow command 'osd blocklist'",
+			"mgr": "allow rw",
+			"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
 		}
 		return nil
 	}); err != nil {
@@ -628,6 +640,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDNode(
 	cephClientName string,
 	radosNamespaceName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -639,15 +652,15 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDNode(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
 		if radosNamespaceName == util.ImplicitRbdRadosNamespaceName {
 			radosNamespaceName = "''"
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "profile rbd",
-				"mgr": "allow rw",
-				"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
-			},
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "profile rbd",
+			"mgr": "allow rw",
+			"osd": fmt.Sprintf("profile rbd namespace=%s", radosNamespaceName),
 		}
 		return nil
 	}); err != nil {
@@ -660,6 +673,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -671,13 +685,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r, allow command 'osd blocklist'",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs metadata=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r, allow command 'osd blocklist'",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs metadata=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {
@@ -690,6 +704,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSNode(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -701,13 +716,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSNode(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs *=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs *=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {
@@ -720,6 +735,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsProvisioner(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -731,13 +747,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsProvisioner(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r, allow command 'osd blocklist'",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs metadata=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r, allow command 'osd blocklist'",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs metadata=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {
@@ -750,6 +766,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsNode(
 	cephClientName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
+	csiCephUserGeneration int64,
 ) error {
 	cephClient := &rookCephv1.CephClient{}
 	cephClient.Name = cephClientName
@@ -761,13 +778,13 @@ func (r *StorageConsumerReconciler) reconcileCephClientNfsNode(
 		if err := controllerutil.SetOwnerReference(additionalOwner, cephClient, r.Scheme); err != nil {
 			return err
 		}
-		cephClient.Spec = rookCephv1.ClientSpec{
-			Caps: map[string]string{
-				"mon": "allow r",
-				"mgr": "allow rw",
-				"osd": "allow rw tag cephfs *=*",
-				"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
-			},
+		util.AddLabel(cephClient, util.CsiCephUserGenerationLabelKey, strconv.FormatInt(csiCephUserGeneration, 10))
+		cephClient.Spec.SecretName = cephClientName
+		cephClient.Spec.Caps = map[string]string{
+			"mon": "allow r",
+			"mgr": "allow rw",
+			"osd": "allow rw tag cephfs *=*",
+			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
 	}); err != nil {

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,6 +77,8 @@ const (
 	ForceDeletionAnnotationKey             = "ocs.openshift.io/force-deletion"
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
 	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
+	CsiCephUserGenerationLabelKey          = "ocs.openshift.io/csi-ceph-user-generation"
+	CsiCephUserCurrGenEnvVarName           = "CSI_CEPH_USER_CURR_GEN"
 )
 
 type BackwardCompatabilityInfo struct {
@@ -90,6 +93,15 @@ func GetPodNamespace() string {
 		panic(fmt.Errorf("%s must be set", PodNamespaceEnvVar))
 	}
 	return podNamespace
+}
+
+// GetCsiCephUserCurrGeneration returns the current generation number for csi ceph user
+func GetCsiCephUserCurrGeneration() (int64, error) {
+	csiCephUserCurrGenerationAsString := os.Getenv(CsiCephUserCurrGenEnvVarName)
+	if csiCephUserCurrGenerationAsString == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(csiCephUserCurrGenerationAsString, 10, 64)
 }
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes

--- a/controllers/util/storageconsumer.go
+++ b/controllers/util/storageconsumer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -306,6 +307,30 @@ func GetStorageConsumerDefaultResourceNames(
 		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("nfs-provisioner-%s", storageConsumerUid))
 	}
 	return defaults
+}
+
+func GenerateCsiRbdProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiRbdNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsNodeCephUserKey, generation, uid)
 }
 
 // These methods are for backward compatibility for provider mode upgraded cluster

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,6 +77,8 @@ const (
 	ForceDeletionAnnotationKey             = "ocs.openshift.io/force-deletion"
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
 	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
+	CsiCephUserGenerationLabelKey          = "ocs.openshift.io/csi-ceph-user-generation"
+	CsiCephUserCurrGenEnvVarName           = "CSI_CEPH_USER_CURR_GEN"
 )
 
 type BackwardCompatabilityInfo struct {
@@ -90,6 +93,15 @@ func GetPodNamespace() string {
 		panic(fmt.Errorf("%s must be set", PodNamespaceEnvVar))
 	}
 	return podNamespace
+}
+
+// GetCsiCephUserCurrGeneration returns the current generation number for csi ceph user
+func GetCsiCephUserCurrGeneration() (int64, error) {
+	csiCephUserCurrGenerationAsString := os.Getenv(CsiCephUserCurrGenEnvVarName)
+	if csiCephUserCurrGenerationAsString == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(csiCephUserCurrGenerationAsString, 10, 64)
 }
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageconsumer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -306,6 +307,30 @@ func GetStorageConsumerDefaultResourceNames(
 		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("nfs-provisioner-%s", storageConsumerUid))
 	}
 	return defaults
+}
+
+func GenerateCsiRbdProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiRbdNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiRbdNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiCephFsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiCephFsNodeCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsProvisionerCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsProvisionerCephUserKey, generation, uid)
+}
+
+func GenerateCsiNfsNodeCephClientName(generation int64, uid types.UID) string {
+	return fmt.Sprintf("%s-g%d-%v", csiNfsNodeCephUserKey, generation, uid)
 }
 
 // These methods are for backward compatibility for provider mode upgraded cluster


### PR DESCRIPTION
consumer configmap now stores name of the secret that needs to be sent
to client rather than the name of cephclient.