### PR TITLE
Add default requests and limits for ocs-operator pods

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -800,6 +800,16 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration, nod
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
 						},
 					},
 					Tolerations: tolerations,

--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -66,18 +66,32 @@ var (
 		},
 		"ocs-metrics-exporter": {
 			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("50Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("512Mi"),
+				"cpu":    resource.MustParse("250m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("1.5Gi"),
+				"cpu":    resource.MustParse("1"),
 			},
 		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("0.1"),
-				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("0.1"),
-				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+		"logcollector": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("250Mi"),
 			},
 		},
 		"exporter": {

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -650,7 +650,13 @@ spec:
                     port: 8081
                   initialDelaySeconds: 5
                   periodSeconds: 10
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 250m
+                    memory: 512Mi
+                  requests:
+                    cpu: 50m
+                    memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:
@@ -709,7 +715,13 @@ spec:
                 name: ux-backend-server
                 ports:
                 - containerPort: 8080
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 250m
+                    memory: 512Mi
+                  requests:
+                    cpu: 50m
+                    memory: 128Mi
                 securityContext:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -800,6 +800,16 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration, nod
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
 						},
 					},
 					Tolerations: tolerations,

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
@@ -66,18 +66,32 @@ var (
 		},
 		"ocs-metrics-exporter": {
 			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("50Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("512Mi"),
+				"cpu":    resource.MustParse("250m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("1.5Gi"),
+				"cpu":    resource.MustParse("1"),
 			},
 		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("0.1"),
-				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("0.1"),
-				corev1.ResourceMemory: resource.MustParse("60Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+		"logcollector": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("250Mi"),
 			},
 		},
 		"exporter": {

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -259,6 +260,18 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
 	ocsCSV.Annotations["operators.operatorframework.io/internal-objects"] = ""
 
 	templateStrategySpec := &ocsCSV.Spec.InstallStrategy.StrategySpec
+
+	// set default mem/cpu requests/limits value in csv
+	templateStrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
 
 	// whitelisting APIs
 	for index, definition := range ocsCSV.Spec.CustomResourceDefinitions.Owned {
@@ -692,6 +705,17 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 								},
 							},
 						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("250m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+
 						SecurityContext: &corev1.SecurityContext{
 							RunAsNonRoot:           ptr.To(true),
 							ReadOnlyRootFilesystem: ptr.To(true),

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -800,6 +800,16 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration, nod
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
 						},
 					},
 					Tolerations: tolerations,


### PR DESCRIPTION
This PR adds the default requests and limits for the ocs-operator pods.
The default metrics are set for the following pods
- ocs-operator
- ocs-metircs-exporter
- ux-backend
- crash-collector
- log-collector