### PR TITLE
add a label of df version when storageconsumer gets created

### DIFF
--- a/controllers/storageconsumer/storageconsumer_upgrade_controller.go
+++ b/controllers/storageconsumer/storageconsumer_upgrade_controller.go
@@ -335,6 +335,7 @@ func (r *StorageConsumerUpgradeReconciler) reconcileStorageConsumer(
 	consumerConfigMapName string,
 ) error {
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, storageConsumer, func() error {
+		util.AddLabel(storageConsumer, util.CreatedAtDfVersionLabelKey, "4.18")
 		spec := &storageConsumer.Spec
 		spec.ResourceNameMappingConfigMap.Name = consumerConfigMapName
 

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -77,6 +77,7 @@ const (
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
 	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
 	CsiCephUserGenerationLabelKey          = "ocs.openshift.io/csi-ceph-user-generation"
+	CreatedAtDfVersionLabelKey             = "ocs.openshift.io/created-at-df-version"
 )
 
 type BackwardCompatabilityInfo struct {

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -77,6 +77,7 @@ const (
 	RookForceDeletionAnnotationKey         = "rook.io/force-deletion"
 	BackwardCompatabilityInfoAnnotationKey = "ocs.openshift.io/backward-compatability-info"
 	CsiCephUserGenerationLabelKey          = "ocs.openshift.io/csi-ceph-user-generation"
+	CreatedAtDfVersionLabelKey             = "ocs.openshift.io/created-at-df-version"
 )
 
 type BackwardCompatabilityInfo struct {

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/version/version.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/version/version.go
@@ -1,6 +1,21 @@
 package version
 
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
 var (
 	// Version of the operator
 	Version = "4.20.0"
 )
+
+// Returns Major and Minor Version joined by dot (.)
+func GetMajorAndMinorVersion() (string, error) {
+	semverVersion, err := semver.Parse(Version)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d.%d", semverVersion.Major, semverVersion.Minor), nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,21 @@
 package version
 
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
 var (
 	// Version of the operator
 	Version = "4.20.0"
 )
+
+// Returns Major and Minor Version joined by dot (.)
+func GetMajorAndMinorVersion() (string, error) {
+	semverVersion, err := semver.Parse(Version)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d.%d", semverVersion.Major, semverVersion.Minor), nil
+}


### PR DESCRIPTION
helps to distinguish when the StorageConsumer is created which dictates what all resources and it's specifics got reconciled or started.