### PR TITLE
fix cephClients ownership and panic in consumer watches

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -877,6 +877,9 @@ func (r *StorageConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 			oldClient := objOld.Status.Client
 			newClient := objNew.Status.Client
+			if oldClient == nil && newClient == nil {
+				return false
+			}
 			return oldClient == nil && newClient != nil || oldClient != nil && newClient == nil || oldClient.ID != newClient.ID
 		},
 	}


### PR DESCRIPTION
watches:
due to the change in offboard the status.Client in consumer can change to nil and until consumer is enabled the same field is nil, we should account that in watches

cephclients:
to know the name of cephclient we need the consumer uid but when internal consumer from provider mode is morphed as internal consumer in 4.19 older consumer will be deleted and cephclient should have new consumer as the owner