### PR TITLE
Ignore only the 'cache' folder in the root of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ tags
 # End of https://www.gitignore.io/api/go,vim,visualstudiocode
 _output
 _cache
-cache
+./cache
 bin
 
 tools/csv-merger/csv-merger


### PR DESCRIPTION
Ignoring all folders named 'cache' is wrong as there are other 'cache' folders in the repository that are not meant to be ignored, such as those in the metrics directory.