### PR TITLE
Don't set replication spec on pools if erasure coded spec are present

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -1505,14 +1505,17 @@ func setDefaultMetadataPoolSpec(poolSpec *rookCephv1.PoolSpec, sc *ocsv1.Storage
 	if poolSpec.FailureDomain == "" {
 		poolSpec.FailureDomain = getFailureDomain(sc)
 	}
-	// Set default replication settings if necessary
-	// Always set the default Size & ReplicasPerFailureDomain in arbiter mode
-	defaultReplicatedSpec := generateCephReplicatedSpec(sc, poolTypeMetadata)
-	if poolSpec.Replicated.Size == 0 || arbiterEnabled(sc) {
-		poolSpec.Replicated.Size = defaultReplicatedSpec.Size
-	}
-	if poolSpec.Replicated.ReplicasPerFailureDomain == 0 || arbiterEnabled(sc) {
-		poolSpec.Replicated.ReplicasPerFailureDomain = defaultReplicatedSpec.ReplicasPerFailureDomain
+	// Set replication spec only if the pool is not erasure coded
+	if reflect.DeepEqual(poolSpec.ErasureCoded, rookCephv1.ErasureCodedSpec{}) {
+		// Set default replication settings if necessary
+		// Always set the default Size & ReplicasPerFailureDomain in arbiter mode
+		defaultReplicatedSpec := generateCephReplicatedSpec(sc, poolTypeMetadata)
+		if poolSpec.Replicated.Size == 0 || arbiterEnabled(sc) {
+			poolSpec.Replicated.Size = defaultReplicatedSpec.Size
+		}
+		if poolSpec.Replicated.ReplicasPerFailureDomain == 0 || arbiterEnabled(sc) {
+			poolSpec.Replicated.ReplicasPerFailureDomain = defaultReplicatedSpec.ReplicasPerFailureDomain
+		}
 	}
 }
 
@@ -1525,17 +1528,20 @@ func setDefaultDataPoolSpec(poolSpec *rookCephv1.PoolSpec, sc *ocsv1.StorageClus
 	if poolSpec.FailureDomain == "" {
 		poolSpec.FailureDomain = getFailureDomain(sc)
 	}
-	// Set default replication settings if necessary
-	// Always set the default Size & ReplicasPerFailureDomain in arbiter mode
-	defaultReplicatedSpec := generateCephReplicatedSpec(sc, poolTypeData)
-	if poolSpec.Replicated.Size == 0 || arbiterEnabled(sc) {
-		poolSpec.Replicated.Size = defaultReplicatedSpec.Size
-	}
-	if poolSpec.Replicated.ReplicasPerFailureDomain == 0 || arbiterEnabled(sc) {
-		poolSpec.Replicated.ReplicasPerFailureDomain = defaultReplicatedSpec.ReplicasPerFailureDomain
-	}
-	if poolSpec.Replicated.TargetSizeRatio == 0.0 {
-		poolSpec.Replicated.TargetSizeRatio = defaultReplicatedSpec.TargetSizeRatio
+	// Set replication spec only if the pool is not erasure coded
+	if reflect.DeepEqual(poolSpec.ErasureCoded, rookCephv1.ErasureCodedSpec{}) {
+		// Set default replication settings if necessary
+		// Always set the default Size & ReplicasPerFailureDomain in arbiter mode
+		defaultReplicatedSpec := generateCephReplicatedSpec(sc, poolTypeData)
+		if poolSpec.Replicated.Size == 0 || arbiterEnabled(sc) {
+			poolSpec.Replicated.Size = defaultReplicatedSpec.Size
+		}
+		if poolSpec.Replicated.ReplicasPerFailureDomain == 0 || arbiterEnabled(sc) {
+			poolSpec.Replicated.ReplicasPerFailureDomain = defaultReplicatedSpec.ReplicasPerFailureDomain
+		}
+		if poolSpec.Replicated.TargetSizeRatio == 0.0 {
+			poolSpec.Replicated.TargetSizeRatio = defaultReplicatedSpec.TargetSizeRatio
+		}
 	}
 }
 


### PR DESCRIPTION
Previously ocs-operator enforced all pools to have a replication spec, which was preventing erasure coded pools from being created. Now if erasure coded spec is present, it will not set the replication spec.