### PR TITLE
metrics: add tini to prevent zombie processes in metrics-exporter

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -457,7 +457,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 							"--namespaces", instance.Namespace,
 							"--ceph-auth-namespace", r.OperatorNamespace,
 						},
-						Command: []string{"/usr/local/bin/metrics-exporter"},
+						Command: []string{"/usr/bin/tini", "--", "/usr/local/bin/metrics-exporter"},
 						Image:   r.images.OCSMetricsExporter,
 						Name:    metricsExporterName,
 						LivenessProbe: &corev1.Probe{

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -14,10 +14,15 @@ RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o metrics-exporter main.g
 
 FROM quay.io/ceph/ceph:v18
 
+# Install tini to reap zombie processes created by ceph/rbd commands
+USER root
+RUN dnf install -y tini && \
+    dnf clean all
+
 COPY --from=builder workspace/metrics-exporter /usr/local/bin/metrics-exporter
 
 RUN chmod +x /usr/local/bin/metrics-exporter
 
 USER 2024
 
-ENTRYPOINT ["/usr/local/bin/metrics-exporter"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/metrics-exporter"]

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -110,6 +110,8 @@ spec:
         image: quay.io/ocs-dev/ocs-operator
         name: ocs-metrics-exporter
         command:
+        - /usr/bin/tini
+        - --
         - /usr/local/bin/metrics-exporter
         args:
           - '--namespaces'


### PR DESCRIPTION
The ocs-metrics-exporter creates zombie processes when executing `ceph` and `rbd` commands to collect metrics. While we use `CombinedOutput()` which should wait for process completion, zombies are still accumulating in some customer environments. Adding tini as a minimal init system (via the ENTRYPOINT) ensures all zombie processes are properly reaped regardless of how they're created.

https://issues.redhat.com/browse/DFBUGS-2875