### PR TITLE
Adding new 'HighRBDChildrenCount' alert.

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -461,3 +461,17 @@ spec:
       for: 30s
       labels:
         severity: warning
+  - name: ceph-rbd-children.rules
+    rules:
+    - alert: HighRBDChildrenCount
+      annotations:
+        description: RBD children count has exceeded 200 count for image {{ $labels.image }} under namespace {{ $labels.namespace }}.
+          Please monitor the apps and make sure their behaviour is correct.
+        message: RBD children count has exceeded the threshold limit.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/HighRBDChildrenCount.md
+        severity_level: warning
+      expr: |
+        ocs_rbd_children_count > 200
+      for: 30m
+      labels:
+        severity: warning


### PR DESCRIPTION
When PV clones/snapshots count cross a particular limit, this alert will be triggered.
Currently the limit is set to 200, just before hitting the system-wide softlimit of 240.

Story: https://issues.redhat.com/browse/RHSTOR-7403