### PR TITLE
DFBUGS-3690:[release-4.16]: provider: do not send mon secret to client

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -322,51 +322,6 @@ func (s *OCSProviderServer) getExternalResources(ctx context.Context, consumerRe
 			"MonitoringPort":     strconv.Itoa(int(port)),
 		})})
 
-	healthCheckerSecretName := ""
-	healthCheckerName := ""
-	for _, cephRes := range consumerResource.Status.CephResources {
-		if cephRes.Kind == "CephClient" {
-			clientSecretName, cephUserType, err := s.getCephClientInformation(ctx, cephRes.Name)
-			if err != nil {
-				return nil, err
-			} else if cephUserType == "healthchecker" {
-				healthCheckerSecretName = clientSecretName
-				healthCheckerName = cephRes.Name
-				break
-			}
-		}
-	}
-
-	if healthCheckerSecretName == "" {
-		return nil, fmt.Errorf("no healthchecker secret found")
-	}
-
-	cephUserSecret := &v1.Secret{}
-	err = s.client.Get(ctx, types.NamespacedName{Name: healthCheckerSecretName, Namespace: s.namespace}, cephUserSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get %s secret. %v", healthCheckerSecretName, err)
-	}
-
-	extR = append(extR, &pb.ExternalResource{
-		Name: healthCheckerSecretName,
-		Kind: "Secret",
-		Data: mustMarshal(map[string]string{
-			"userID":  healthCheckerName,
-			"userKey": string(cephUserSecret.Data[healthCheckerName]),
-		}),
-	})
-
-	extR = append(extR, &pb.ExternalResource{
-		Name: monSecret,
-		Kind: "Secret",
-		Data: mustMarshal(map[string]string{
-			"fsid":          fsid,
-			"mon-secret":    "mon-secret",
-			"ceph-username": fmt.Sprintf("client.%s", healthCheckerName),
-			"ceph-secret":   string(cephUserSecret.Data[healthCheckerName]),
-		}),
-	})
-
 	return extR, nil
 }
 

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -38,30 +38,12 @@ var mockExtR = map[string]*externalResource{
 			"mapping":  "{}",
 		},
 	},
-	"rook-ceph-mon": {
-		Name: "rook-ceph-mon",
-		Kind: "Secret",
-		Data: map[string]string{
-			"ceph-username": "client.995e66248ad3e8642de868f461cdd827",
-			"fsid":          "b88c2d78-9de9-4227-9313-a63f62f78743",
-			"mon-secret":    "mon-secret",
-			"ceph-secret":   "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
-		},
-	},
 	"monitoring-endpoint": {
 		Name: "monitoring-endpoint",
 		Kind: "CephCluster",
 		Data: map[string]string{
 			"MonitoringEndpoint": "10.105.164.231",
 			"MonitoringPort":     "9283",
-		},
-	},
-	"rook-ceph-client-995e66248ad3e8642de868f461cdd827": {
-		Name: "rook-ceph-client-995e66248ad3e8642de868f461cdd827",
-		Kind: "Secret",
-		Data: map[string]string{
-			"userID":  "995e66248ad3e8642de868f461cdd827",
-			"userKey": "AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ==",
 		},
 	},
 }
@@ -74,13 +56,8 @@ var (
 			Namespace: serverNamespace,
 		},
 		Status: ocsv1alpha1.StorageConsumerStatus{
-			CephResources: []*ocsv1alpha1.CephResourcesSpec{
-				{
-					Name: "995e66248ad3e8642de868f461cdd827",
-					Kind: "CephClient",
-				},
-			},
-			State: ocsv1alpha1.StorageConsumerStateReady,
+			CephResources: []*ocsv1alpha1.CephResourcesSpec{},
+			State:         ocsv1alpha1.StorageConsumerStateReady,
 		},
 	}
 
@@ -178,33 +155,6 @@ func TestGetExternalResources(t *testing.T) {
 		consumerManager: consumerManager,
 	}
 
-	cephClient := &rookCephv1.CephClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "995e66248ad3e8642de868f461cdd827",
-			Namespace: server.namespace,
-			Annotations: map[string]string{
-				controllers.StorageCephUserTypeAnnotation: "healthchecker",
-				controllers.StorageRequestAnnotation:      "global",
-				controllers.StorageConsumerAnnotation:     "consumer",
-			},
-		},
-		Status: &rookCephv1.CephClientStatus{
-			Info: map[string]string{
-				"secretName": "rook-ceph-client-995e66248ad3e8642de868f461cdd827",
-			},
-		},
-	}
-
-	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "rook-ceph-client-995e66248ad3e8642de868f461cdd827", Namespace: server.namespace},
-		Data: map[string][]byte{
-			"995e66248ad3e8642de868f461cdd827": []byte("AQADw/hhqBOcORAAJY3fKIvte++L/zYhASjYPQ=="),
-		},
-	}
-
-	assert.NoError(t, client.Create(ctx, cephClient))
-	assert.NoError(t, client.Create(ctx, secret))
-
 	monCm, monSc := createMonConfigMapAndSecret(server)
 	assert.NoError(t, client.Create(ctx, monCm))
 	assert.NoError(t, client.Create(ctx, monSc))
@@ -229,11 +179,8 @@ func TestGetExternalResources(t *testing.T) {
 		assert.Equal(t, extResource.Name, mockResoruce.Name)
 	}
 
-	// When ocsv1alpha1.StorageConsumerStateReady but ceph resources is empty
 	req.StorageConsumerUUID = string(consumerResource5.UID)
 	storageConRes, err = server.GetStorageConfig(ctx, &req)
-	assert.Error(t, err)
-	assert.Nil(t, storageConRes)
 
 	// When ocsv1alpha1.StorageConsumerStateReady but secret is not ready
 	for _, i := range consumerResource.Status.CephResources {


### PR DESCRIPTION
there is no requirement to send mon-secret to client and due to the change in content client.admin keyring is being overwritten at client end when both rook-op and client-op runs in same namespace.