### PR TITLE
indicate connected client about server ability to serve requests

### DIFF
--- a/controllers/storagecluster/storageclient.go
+++ b/controllers/storagecluster/storageclient.go
@@ -25,6 +25,7 @@ const (
 	ocsClientConfigMapName             = "ocs-client-operator-config"
 	manageNoobaaSubKey                 = "manageNoobaaSubscription"
 	useHostNetworkForCsiControllersKey = "useHostNetworkForCsiControllers"
+	disableVersionChecksKey            = "disableVersionChecks"
 	// cephNetworkAnnotationKey is the annotation key used to store network details used by ceph
 	cniNetworksAnnotationKey = "k8s.v1.cni.cncf.io/networks"
 )
@@ -130,6 +131,7 @@ func (s *storageClient) updateClientConfigMap(r *StorageClusterReconciler, names
 	}
 	clientConfig.Data[manageNoobaaSubKey] = strconv.FormatBool(false)
 	clientConfig.Data[useHostNetworkForCsiControllersKey] = strconv.FormatBool(useHostNetworkForCsiControllers)
+	clientConfig.Data[disableVersionChecksKey] = strconv.FormatBool(true)
 
 	if !maps.Equal(clientConfig.Data, existingData) {
 		if err := r.Client.Update(r.ctx, clientConfig); err != nil {

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -344,6 +344,9 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 	}
 
 	klog.Infof("Found StorageConsumer for GetDesiredClientState")
+	if !checkClientPreConditions(consumer, ocsVersion.Version) {
+		return nil, status.Error(codes.FailedPrecondition, "client operator does not meet version requirements")
+	}
 
 	// Verify Status
 	switch consumer.Status.State {
@@ -427,6 +430,7 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 			inMaintenanceMode,
 			isConsumerMirrorEnabled,
 			topologyKey,
+			ocsVersion.Version,
 		)
 		response.DesiredStateHash = desiredClientConfigHash
 
@@ -697,6 +701,7 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 		inMaintenanceMode,
 		isConsumerMirrorEnabled,
 		topologyKey,
+		ocsVersion.Version,
 	)
 
 	return &pb.ReportStatusResponse{
@@ -2075,4 +2080,25 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 		}
 	}
 	return kubeResources
+}
+
+func checkClientPreConditions(consumer *ocsv1alpha1.StorageConsumer, ocsOpVersion string) bool {
+	if consumer == nil || consumer.Status.Client == nil {
+		klog.Errorf("failed precondition: client status is not available")
+		return false
+	}
+
+	clientOpVersion := consumer.Status.Client.OperatorVersion
+	if clientOpVersion == notAvailable {
+		klog.Errorf("failed precondition: client version in client status is not available")
+		return false
+	}
+
+	ocsOpSemver := semver.MustParse(ocsOpVersion)
+	clientOpSemver := semver.MustParse(clientOpVersion)
+	if ocsOpSemver.Major < clientOpSemver.Major || ocsOpSemver.Minor < clientOpSemver.Minor {
+		klog.Errorf("failed precondition: client version is ahead of server version")
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
1. explicitly sets a key on client-op configmap for client to take decisions on co-location with hub
2. explicity send a failed precondition when server not able to serve the connected client