### PR TITLE
Halve the CPU requests of daemons for IBM Z platform

### DIFF
--- a/controllers/defaults/utils.go
+++ b/controllers/defaults/utils.go
@@ -1,10 +1,18 @@
 package defaults
 
 import (
+	"runtime"
+	"strconv"
 	"strings"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	IbmZCpuArch         = "s390x"
+	IbmZCpuAdjustFactor = 0.5
 )
 
 // GetDaemonResources returns a custom ResourceRequirements for the passed
@@ -14,7 +22,18 @@ func GetDaemonResources(name string, custom map[string]corev1.ResourceRequiremen
 	if res, ok := custom[name]; ok {
 		return res
 	}
-	return DaemonResources[name]
+	resourceRequirements := DaemonResources[name]
+	if runtime.GOARCH == IbmZCpuArch {
+		// Adjust CPU requests for IBM Z platform
+		resourceRequirementsCopy := resourceRequirements.DeepCopy()
+		if resourceRequirementsCopy.Requests != nil {
+			if cpuRequest, exists := resourceRequirementsCopy.Requests[corev1.ResourceCPU]; exists {
+				resourceRequirementsCopy.Requests[corev1.ResourceCPU] = adjustCpuResource(cpuRequest, IbmZCpuAdjustFactor)
+			}
+		}
+		return *resourceRequirementsCopy
+	}
+	return resourceRequirements
 }
 
 func GetProfileDaemonResources(name string, sc *ocsv1.StorageCluster) corev1.ResourceRequirements {
@@ -24,14 +43,31 @@ func GetProfileDaemonResources(name string, sc *ocsv1.StorageCluster) corev1.Res
 	}
 	resourceProfile := sc.Spec.ResourceProfile
 	resourceProfile = strings.ToLower(resourceProfile)
+	var resourceRequirements corev1.ResourceRequirements
 	switch resourceProfile {
 	case "lean":
-		return LeanDaemonResources[name]
+		resourceRequirements = LeanDaemonResources[name]
 	case "balanced":
-		return BalancedDaemonResources[name]
+		resourceRequirements = BalancedDaemonResources[name]
 	case "performance":
-		return PerformanceDaemonResources[name]
+		resourceRequirements = PerformanceDaemonResources[name]
 	default:
-		return BalancedDaemonResources[name]
+		resourceRequirements = BalancedDaemonResources[name]
 	}
+	if runtime.GOARCH == IbmZCpuArch {
+		// Adjust CPU requests for IBM Z platform
+		resourceRequirementsCopy := resourceRequirements.DeepCopy()
+		if resourceRequirementsCopy.Requests != nil {
+			if cpuRequest, exists := resourceRequirementsCopy.Requests[corev1.ResourceCPU]; exists {
+				resourceRequirementsCopy.Requests[corev1.ResourceCPU] = adjustCpuResource(cpuRequest, IbmZCpuAdjustFactor)
+			}
+		}
+		return *resourceRequirementsCopy
+	}
+	return resourceRequirements
+}
+
+func adjustCpuResource(cpuQty resource.Quantity, adjustFactor float64) resource.Quantity {
+	str := strconv.FormatInt(int64(float64(cpuQty.MilliValue())*adjustFactor), 10) + "m"
+	return resource.MustParse(str)
 }

--- a/controllers/defaults/utils_test.go
+++ b/controllers/defaults/utils_test.go
@@ -1,0 +1,74 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestHalveCpuResource(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        resource.Quantity
+		adjustFactor float64
+		expected     resource.Quantity
+	}{
+		{
+			name:     "50% of 1 CPU",
+			input:    resource.MustParse("1"),
+			adjustFactor: 0.5,
+			expected: resource.MustParse("0.5"),
+		},
+		{
+			name:     "50% of 1.5 CPU",
+			input:    resource.MustParse("1.5"),
+			adjustFactor: 0.5,
+			expected: resource.MustParse("0.75"),
+		},
+		{
+			name:     "75% of 1.5 CPU",
+			input:    resource.MustParse("1.5"),
+			adjustFactor: 0.75,
+			expected: resource.MustParse("1.125"),
+		},
+		{
+			name:     "66.67% of 2 CPU",
+			input:    resource.MustParse("2"),
+			adjustFactor: 0.6667,
+			expected: resource.MustParse("1.333"),
+		},
+		{
+			name:     "50% of 999m",
+			input:    resource.MustParse("999m"),
+			adjustFactor: 0.5,
+			expected: resource.MustParse("499m"),
+		},
+		{
+			name:     "33.33% of 100m",
+			input:    resource.MustParse("100m"),
+			adjustFactor: 0.3333,
+			expected: resource.MustParse("33m"),
+		},
+		{
+			name:     "50% of 1m",
+			input:    resource.MustParse("1m"),
+			adjustFactor: 0.5,
+			expected: resource.MustParse("0m"),
+		},
+		{
+			name:     "300% of 0",
+			input:    resource.MustParse("0"),
+			adjustFactor: 3,
+			expected: resource.MustParse("0"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := adjustCpuResource(tc.input, tc.adjustFactor)
+			assert.Equal(t, tc.expected.MilliValue(), result.MilliValue(),
+				"Expected %s, got %s", tc.expected.String(), result.String())
+		})
+	}
+}

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/utils.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/utils.go
@@ -1,10 +1,18 @@
 package defaults
 
 import (
+	"runtime"
+	"strconv"
 	"strings"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	IbmZCpuArch         = "s390x"
+	IbmZCpuAdjustFactor = 0.5
 )
 
 // GetDaemonResources returns a custom ResourceRequirements for the passed
@@ -14,7 +22,18 @@ func GetDaemonResources(name string, custom map[string]corev1.ResourceRequiremen
 	if res, ok := custom[name]; ok {
 		return res
 	}
-	return DaemonResources[name]
+	resourceRequirements := DaemonResources[name]
+	if runtime.GOARCH == IbmZCpuArch {
+		// Adjust CPU requests for IBM Z platform
+		resourceRequirementsCopy := resourceRequirements.DeepCopy()
+		if resourceRequirementsCopy.Requests != nil {
+			if cpuRequest, exists := resourceRequirementsCopy.Requests[corev1.ResourceCPU]; exists {
+				resourceRequirementsCopy.Requests[corev1.ResourceCPU] = adjustCpuResource(cpuRequest, IbmZCpuAdjustFactor)
+			}
+		}
+		return *resourceRequirementsCopy
+	}
+	return resourceRequirements
 }
 
 func GetProfileDaemonResources(name string, sc *ocsv1.StorageCluster) corev1.ResourceRequirements {
@@ -24,14 +43,31 @@ func GetProfileDaemonResources(name string, sc *ocsv1.StorageCluster) corev1.Res
 	}
 	resourceProfile := sc.Spec.ResourceProfile
 	resourceProfile = strings.ToLower(resourceProfile)
+	var resourceRequirements corev1.ResourceRequirements
 	switch resourceProfile {
 	case "lean":
-		return LeanDaemonResources[name]
+		resourceRequirements = LeanDaemonResources[name]
 	case "balanced":
-		return BalancedDaemonResources[name]
+		resourceRequirements = BalancedDaemonResources[name]
 	case "performance":
-		return PerformanceDaemonResources[name]
+		resourceRequirements = PerformanceDaemonResources[name]
 	default:
-		return BalancedDaemonResources[name]
+		resourceRequirements = BalancedDaemonResources[name]
 	}
+	if runtime.GOARCH == IbmZCpuArch {
+		// Adjust CPU requests for IBM Z platform
+		resourceRequirementsCopy := resourceRequirements.DeepCopy()
+		if resourceRequirementsCopy.Requests != nil {
+			if cpuRequest, exists := resourceRequirementsCopy.Requests[corev1.ResourceCPU]; exists {
+				resourceRequirementsCopy.Requests[corev1.ResourceCPU] = adjustCpuResource(cpuRequest, IbmZCpuAdjustFactor)
+			}
+		}
+		return *resourceRequirementsCopy
+	}
+	return resourceRequirements
+}
+
+func adjustCpuResource(cpuQty resource.Quantity, adjustFactor float64) resource.Quantity {
+	str := strconv.FormatInt(int64(float64(cpuQty.MilliValue())*adjustFactor), 10) + "m"
+	return resource.MustParse(str)
 }


### PR DESCRIPTION
On IBM Z platform the individual CPU cores are much more powerful than other architectures. Hence, we halve the CPU requests of daemons to optimize resource usage.

Ref-https://issues.redhat.com/browse/RHSTOR-7611