### PR TITLE
Add malayparida2000 to approvers and reviewers in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ approvers:
   - agarwal-mudit
   - nb-ohad
   - iamniting
+  - malayparida2000
   - BlaineEXE
   - travisn
 # review == this code is good /lgtm
@@ -12,5 +13,6 @@ reviewers:
   - agarwal-mudit
   - nb-ohad
   - iamniting
+  - malayparida2000
   - BlaineEXE
   - travisn


### PR DESCRIPTION
I already do review & approve PRs in the repo via the admin access by manually adding the labels. This change will allow me to automatically approve and review PRs without needing to add labels manually.