### PR TITLE
controllers: add blockpool label to rns

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -61,6 +61,7 @@ const (
 	StorageConsumerNameLabel      = "ocs.openshift.io/storageconsumer-name"
 	storageConsumerFinalizer      = "ocs.openshift.io/storageconsumer-protection"
 	primaryConsumerUIDAnnotation  = "ocs.openshift.io/primary-consumer-uid"
+	blockPoolNameLabel            = "ocs.openshift.io/cephblockpool-name"
 	csiCephUserCurrGen            = 1
 )
 
@@ -562,6 +563,7 @@ func (r *StorageConsumerReconciler) reconcileCephRadosNamespace(
 				if err := controllerutil.SetOwnerReference(additionalOwner, rns, r.Scheme); err != nil {
 					return err
 				}
+				util.AddLabel(rns, blockPoolNameLabel, bp.Name)
 				rns.Spec.Name = radosNamespaceName
 				rns.Spec.BlockPoolName = bp.Name
 				return nil


### PR DESCRIPTION
UI requires us to add the blockpool name label to the rns to display mirroring information on the blockpools page

This was initially added to rns created by the storagerequest controller, but it was missed while creating the RNS in the storageconsumer controller

Original PR: https://github.com/red-hat-storage/ocs-operator/pull/2883

Fixes: https://issues.redhat.com/browse/DFBUGS-2832