### PR TITLE
Always collect ocs must-gather irrespective of test result

### DIFF
--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -37,14 +37,12 @@ func AfterTestSuiteCleanup() {
 	debug("\n------------------------------\n")
 
 	// collect debug log before deleting namespace & cluster
-	if SuiteFailed {
-		debug("AfterTestSuite: collecting debug information\n")
-		err := RunMustGather()
-		gomega.Expect(err).To(gomega.BeNil())
-	}
+	debug("AfterTestSuite: collecting debug information\n")
+	err := RunMustGather()
+	gomega.Expect(err).To(gomega.BeNil())
 
 	debug("AfterTestSuite: deleting Namespace %s\n", TestNamespace)
-	err := DeployManager.DeleteNamespaceAndWait(TestNamespace)
+	err = DeployManager.DeleteNamespaceAndWait(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	if ocsClusterUninstall {


### PR DESCRIPTION
After some discussion & thoughts, we decided to always collect the ocs must-gather irrespective of test result. This would help a lot in verifying the results of any fix whether or not that fix actually results in a test failure. We acknowledge that this would result in sight increase in the time taken to run the tests. But this would help a lot in looking at the impact of any PR readily.