### PR TITLE
ocs-metrics-exporter and toolbox needs to run on host network for data replication separation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -350,6 +350,14 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
+  - hostnetwork-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
   - privileged
   resources:
   - securitycontextconstraints

--- a/controllers/storagecluster/cephtoolbox.go
+++ b/controllers/storagecluster/cephtoolbox.go
@@ -71,6 +71,9 @@ func (r *StorageClusterReconciler) ensureToolsDeployment(sc *ocsv1.StorageCluste
 				toolsDeployment.Spec.Template.Spec.HostNetwork = false
 			}
 		}
+		if shouldUseHostNetworking(sc) {
+			toolsDeployment.Spec.Template.Spec.HostNetwork = true
+		}
 
 		if !isFound {
 			return r.Client.Create(context.TODO(), toolsDeployment)

--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -377,6 +377,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: ptr.To(true),
 				},
+				HostNetwork: shouldUseHostNetworking(instance),
 				Containers: []corev1.Container{
 					{
 						Resources: defaults.MonitoringResources["kube-rbac-proxy"],

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -114,6 +114,7 @@ var storageClusterFinalizer = "storagecluster.ocs.openshift.io"
 // +kubebuilder:rbac:groups=objectbucket.io,resources=objectbuckets;objectbucketclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=hostnetwork-v2,verbs=use
 
 // Reconcile reads that state of the cluster for a StorageCluster object and makes changes based on the state read
 // and what is in the StorageCluster.Spec

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2025-09-03T08:16:46Z"
+    createdAt: "2025-09-04T15:06:16Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
@@ -504,6 +504,14 @@ spec:
           - create
           - get
           - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostnetwork-v2
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         - apiGroups:
           - security.openshift.io
           resourceNames:

--- a/deploy/ocs-operator/manifests/ocs-metrics-exporter-hostnetwork-role-binding.yaml
+++ b/deploy/ocs-operator/manifests/ocs-metrics-exporter-hostnetwork-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocs-metrics-exporter-hostnetwork
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:hostnetwork-v2
+subjects:
+- kind: ServiceAccount
+  name: ocs-metrics-exporter
+  namespace: openshift-storage

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2025-09-03T08:16:46Z"
+    createdAt: "2025-09-04T15:06:16Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -523,6 +523,14 @@ spec:
           - create
           - get
           - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostnetwork-v2
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         - apiGroups:
           - security.openshift.io
           resourceNames:

--- a/rbac/ocs-metrics-exporter-hostnetwork-role-binding.yaml
+++ b/rbac/ocs-metrics-exporter-hostnetwork-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocs-metrics-exporter-hostnetwork
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:hostnetwork-v2
+subjects:
+- kind: ServiceAccount
+  name: ocs-metrics-exporter
+  namespace: openshift-storage


### PR DESCRIPTION
ocs-metrics-exporter and toolbox needs to run on host network for data replication separation as pod network will not have access to secondary host network and will not be able to execute ceph commands
