### PR TITLE
sever: move to a cached client for provider server

### DIFF
--- a/config/rbac/provider_server_cr.yaml
+++ b/config/rbac/provider_server_cr.yaml
@@ -11,6 +11,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -18,13 +19,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - groupsnapshot.storage.k8s.io
+  - groupsnapshot.storage.openshift.io
   resources:
   - volumegroupsnapshotclasses
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
     - csiaddons.openshift.io
   resources:
@@ -32,3 +36,4 @@ rules:
   verbs:
     - get
     - list
+    - watch

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -60,6 +60,7 @@ const (
 	// This is the name for the FieldIndex
 	OwnerUIDIndexName   = "ownerUID"
 	AnnotationIndexName = "annotation"
+	ObjectUidIndexName  = "objectUID"
 
 	OdfInfoNamespacedNameClaimName      = "odfinfo.odf.openshift.io"
 	ExitCodeThatShouldRestartTheProcess = 42
@@ -196,6 +197,10 @@ func OwnersIndexFieldFunc(obj client.Object) []string {
 
 func AnnotationIndexFieldFunc(obj client.Object) []string {
 	return maps.Keys(obj.GetAnnotations())
+}
+
+func ObjectUidIndexFieldFunc(obj client.Object) []string {
+	return []string{string(obj.GetUID())}
 }
 
 func GetTopologyConstrainedPools(storageCluster *ocsv1.StorageCluster) string {

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2025-10-14T04:23:46Z"
+    createdAt: "2025-10-15T03:44:20Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
@@ -550,6 +550,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - snapshot.storage.k8s.io
           resources:
@@ -557,13 +558,16 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - groupsnapshot.storage.k8s.io
+          - groupsnapshot.storage.openshift.io
           resources:
           - volumegroupsnapshotclasses
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - csiaddons.openshift.io
           resources:
@@ -571,6 +575,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         serviceAccountName: ocs-provider-server
       - rules:
         - apiGroups:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2025-10-14T04:23:46Z"
+    createdAt: "2025-10-15T03:44:20Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -569,6 +569,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - snapshot.storage.k8s.io
           resources:
@@ -576,13 +577,16 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - groupsnapshot.storage.k8s.io
+          - groupsnapshot.storage.openshift.io
           resources:
           - volumegroupsnapshotclasses
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - csiaddons.openshift.io
           resources:
@@ -590,6 +594,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         serviceAccountName: ocs-provider-server
       - rules:
         - apiGroups:

--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -11,6 +11,8 @@ rules:
       - services
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ceph.rook.io
     resources:
@@ -24,6 +26,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ocs.openshift.io
     resources:
@@ -32,6 +35,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
       - create
       - delete
       - update
@@ -53,6 +57,8 @@ rules:
       - cephclients
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -60,6 +66,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - operators.coreos.com
     resources:
@@ -68,6 +75,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - packages.operators.coreos.com
     resources:
@@ -75,6 +83,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ocs.openshift.io
     resources:
@@ -82,6 +91,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -89,6 +99,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ocs.openshift.io
     resources:
@@ -96,6 +107,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -103,6 +115,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - noobaa.io
     resources:
@@ -110,3 +123,4 @@ rules:
     verbs:
       - get
       - list
+      - watch

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -60,6 +60,7 @@ const (
 	// This is the name for the FieldIndex
 	OwnerUIDIndexName   = "ownerUID"
 	AnnotationIndexName = "annotation"
+	ObjectUidIndexName  = "objectUID"
 
 	OdfInfoNamespacedNameClaimName      = "odfinfo.odf.openshift.io"
 	ExitCodeThatShouldRestartTheProcess = 42
@@ -196,6 +197,10 @@ func OwnersIndexFieldFunc(obj client.Object) []string {
 
 func AnnotationIndexFieldFunc(obj client.Object) []string {
 	return maps.Keys(obj.GetAnnotations())
+}
+
+func ObjectUidIndexFieldFunc(obj client.Object) []string {
+	return []string{string(obj.GetUID())}
 }
 
 func GetTopologyConstrainedPools(storageCluster *ocsv1.StorageCluster) string {

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -11,6 +11,8 @@ rules:
       - services
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ceph.rook.io
     resources:
@@ -24,6 +26,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ocs.openshift.io
     resources:
@@ -32,6 +35,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
       - create
       - delete
       - update
@@ -53,6 +57,8 @@ rules:
       - cephclients
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -60,6 +66,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - operators.coreos.com
     resources:
@@ -68,6 +75,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - packages.operators.coreos.com
     resources:
@@ -75,6 +83,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ocs.openshift.io
     resources:
@@ -82,6 +91,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -89,6 +99,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ocs.openshift.io
     resources:
@@ -96,6 +107,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -103,6 +115,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - noobaa.io
     resources:
@@ -110,3 +123,4 @@ rules:
     verbs:
       - get
       - list
+      - watch

--- a/services/provider/server/consumer.go
+++ b/services/provider/server/consumer.go
@@ -3,85 +3,37 @@ package server
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	ifaces "github.com/red-hat-storage/ocs-operator/services/provider/api/v4/interfaces"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	clientgocache "k8s.io/client-go/tools/cache"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type ocsConsumerManager struct {
 	client    client.Client
 	namespace string
-	nameByUID map[types.UID]string
-	mutex     sync.RWMutex
 }
 
-func newConsumerManager(ctx context.Context, cl client.Client, namespace string) (*ocsConsumerManager, error) {
+func newConsumerManager(ctx context.Context, cl client.Client, cache ctrlcache.Cache, namespace string) (*ocsConsumerManager, error) {
 
-	consumerManager := &ocsConsumerManager{
+	if err := cache.IndexField(
+		ctx,
+		&ocsv1alpha1.StorageConsumer{},
+		util.ObjectUidIndexName,
+		util.ObjectUidIndexFieldFunc,
+	); err != nil {
+		return nil, fmt.Errorf("failed to set up FieldIndexer on StorageConsumer for uid: %v", err)
+	}
+
+	return &ocsConsumerManager{
 		client:    cl,
 		namespace: namespace,
-		nameByUID: map[types.UID]string{},
-	}
-
-	cache, err := newStorageConsumerCache(namespace)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cache: %w", err)
-	}
-
-	consumer := &metav1.PartialObjectMetadata{}
-	consumer.SetGroupVersionKind(ocsv1alpha1.GroupVersion.WithKind("StorageConsumer"))
-
-	informer, err := cache.GetInformer(ctx, consumer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get informer %w", err)
-	}
-
-	if _, err = informer.AddEventHandler(clientgocache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			consumer, ok := obj.(*metav1.PartialObjectMetadata)
-			if !ok {
-				return
-			}
-			consumerManager.mutex.RLock()
-			consumerManager.nameByUID[consumer.GetUID()] = consumer.Name
-			consumerManager.mutex.RUnlock()
-		},
-
-		DeleteFunc: func(obj any) {
-			consumer, ok := obj.(*metav1.PartialObjectMetadata)
-			if !ok {
-				return
-			}
-			consumerManager.mutex.RLock()
-			delete(consumerManager.nameByUID, consumer.GetUID())
-			consumerManager.mutex.RUnlock()
-		},
-	}); err != nil {
-		return nil, fmt.Errorf("failed to create informer: %w", err)
-	}
-
-	go func() {
-		if err := cache.Start(ctx); err != nil {
-			panic(fmt.Errorf("cache failed to start: %w", err))
-		}
-	}()
-
-	if !cache.WaitForCacheSync(ctx) {
-		panic("cache did not sync")
-	}
-
-	return consumerManager, nil
+	}, nil
 }
 
 // EnableStorageConsumer enables storageConsumer resource
@@ -120,29 +72,23 @@ func (c *ocsConsumerManager) GetByName(ctx context.Context, name string) (*ocsv1
 
 // Get returns a storageConsumer resource using the UID
 func (c *ocsConsumerManager) Get(ctx context.Context, id string) (*ocsv1alpha1.StorageConsumer, error) {
-	uid := types.UID(id)
 
-	c.mutex.RLock()
-	consumerName, ok := c.nameByUID[uid]
-	if !ok {
-		c.mutex.RUnlock()
+	storageConsumers := &ocsv1alpha1.StorageConsumerList{}
+	if err := c.client.List(
+		ctx,
+		storageConsumers,
+		client.MatchingFields{util.ObjectUidIndexName: id},
+		client.InNamespace(c.namespace),
+		client.Limit(1),
+	); err != nil {
+		return nil, err
+	}
+
+	if len(storageConsumers.Items) == 0 {
 		return nil, fmt.Errorf("no storageConsumer found with the UID %q", id)
 	}
-	c.mutex.RUnlock()
 
-	consumerObj := &ocsv1alpha1.StorageConsumer{}
-	if err := c.client.Get(ctx, types.NamespacedName{Name: consumerName, Namespace: c.namespace}, consumerObj); err != nil {
-		if kerrors.IsNotFound(err) {
-			return nil, fmt.Errorf("storageConsumer resource %q not found. %v", consumerName, err)
-		}
-		return nil, fmt.Errorf("failed to get storageConsumer resource with name %q. %v", consumerName, err)
-	}
-
-	if consumerObj.UID != uid {
-		return nil, fmt.Errorf("storageConsumer resource with name %q does not match UID %q", consumerName, uid)
-	}
-
-	return consumerObj, nil
+	return &storageConsumers.Items[0], nil
 }
 
 func (c *ocsConsumerManager) UpdateConsumerStatus(ctx context.Context, id string, status ifaces.StorageClientStatus) error {
@@ -225,40 +171,6 @@ func (c *ocsConsumerManager) ClearClientInformation(ctx context.Context, consume
 	}
 
 	return nil
-}
-
-func newStorageConsumerCache(namespace string) (ctrlcache.Cache, error) {
-
-	cacheScheme := runtime.NewScheme()
-	if err := ocsv1alpha1.AddToScheme(cacheScheme); err != nil {
-		return nil, fmt.Errorf("failed to add ocsv1alpha1 to scheme. %v", err)
-	}
-
-	config, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	cache, err := ctrlcache.New(
-		config,
-		ctrlcache.Options{
-			Scheme: cacheScheme,
-			DefaultNamespaces: map[string]ctrlcache.Config{
-				namespace: {},
-			},
-			ByObject: map[client.Object]ctrlcache.ByObject{
-				&metav1.PartialObjectMetadata{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: ocsv1alpha1.GroupVersion.String(),
-						Kind:       "StorageConsumer",
-					},
-				}: {},
-			},
-		})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create new cache %w", err)
-	}
-	return cache, nil
 }
 
 func fillStorageClientInfo(consumerStatus *ocsv1alpha1.StorageConsumerStatus, clientInfo ifaces.StorageClientInfo) {

--- a/services/provider/server/storageclusterpeer.go
+++ b/services/provider/server/storageclusterpeer.go
@@ -3,10 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
+
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type storageClusterPeerManager struct {
@@ -14,11 +15,11 @@ type storageClusterPeerManager struct {
 	namespace string
 }
 
-func newStorageClusterPeerManager(cl client.Client, namespace string) (*storageClusterPeerManager, error) {
+func newStorageClusterPeerManager(cl client.Client, namespace string) *storageClusterPeerManager {
 	return &storageClusterPeerManager{
 		client:    cl,
 		namespace: namespace,
-	}, nil
+	}
 }
 
 func (s *storageClusterPeerManager) GetByPeerStorageClusterUID(ctx context.Context, storageClusterUID types.UID) (*ocsv1.StorageClusterPeer, error) {

--- a/services/provider/server/storageclusterpeer_test.go
+++ b/services/provider/server/storageclusterpeer_test.go
@@ -13,22 +13,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestNewStorageClusterPeerManager(t *testing.T) {
-	t.Run("successful manager creation", func(t *testing.T) {
-		scheme, err := newScheme()
-		assert.NoError(t, err)
-
-		client := fake.NewClientBuilder().
-			WithScheme(scheme).
-			Build()
-
-		manager, err := newStorageClusterPeerManager(client, testNamespace)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, manager)
-		assert.Equal(t, testNamespace, manager.namespace)
-		assert.NotNil(t, manager.client)
-	})
+func createTestStorageClusterPeerManager(client client.Client) *storageClusterPeerManager {
+	return &storageClusterPeerManager{
+		client:    client,
+		namespace: testNamespace,
+	}
 }
 
 func TestGetByPeerStorageClusterUID(t *testing.T) {
@@ -119,8 +108,7 @@ func TestGetByPeerStorageClusterUID(t *testing.T) {
 			assert.NoError(t, err)
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingObjs...).Build()
-			scpManager, err := newStorageClusterPeerManager(fakeClient, testNamespace)
-			assert.NoError(t, err)
+			scpManager := createTestStorageClusterPeerManager(fakeClient)
 
 			result, err := scpManager.GetByPeerStorageClusterUID(context.TODO(), types.UID(tt.storageClusterUID))
 


### PR DESCRIPTION
Move from an uncached client in the provider server to a cached client

This fix is a part of [DFBUGS-2341](https://issues.redhat.com/browse/DFBUGS-2341). More PRs will follow.