### PR TITLE
Fix no fallback_scrape_protocol specified for target with nfs metrics

### DIFF
--- a/controllers/storagecluster/cephnfs.go
+++ b/controllers/storagecluster/cephnfs.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -221,6 +222,7 @@ func (r *StorageClusterReconciler) newNFSMetricsServiceMonitors(initData *ocsv1.
 						"app": "rook-ceph-nfs",
 					},
 				},
+				FallbackScrapeProtocol: ptr.To(monitoringv1.PrometheusText1_0_0),
 			},
 		},
 	}


### PR DESCRIPTION
msg="Failed to determine correct type of scrape target." component=
 "scrape manager" scrape_pool=serviceMonitor/openshift-storage/
 ocs-storagecluster-cephnfs-servicemonitor/0 target=
 http://10.131.4.20:9587/metrics content_type="" fallback_media_type=
 "" err="non-compliant scrape target sending blank Content-Type and no
 fallback_scrape_protocol specified for target"
Prometheus v3 is more strict concerning the Content-Type header received when scraping. If a scrape target is not providing the correct Content-Type header the fallback protocol can be specified using the fallback_scrape_protocol parameter.
Fix-https://issues.redhat.com/browse/DFBUGS-3883