### PR TITLE
make onboarding from same client resistant against expired ticket

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -175,6 +175,11 @@ func (s *OCSProviderServer) OnboardConsumer(ctx context.Context, req *pb.Onboard
 		return nil, status.Errorf(codes.InvalidArgument, "refusing to onboard onto storageconsumer with supplied token")
 	}
 
+	if err := checkTicketExpiration(onboardingTicket); err != nil {
+		klog.Errorf("onboarding ticket expired for consumer %q. %v", req.ConsumerName, err)
+		return nil, status.Errorf(codes.InvalidArgument, "onboarding ticket is expired. %v", err)
+	}
+
 	onboardingSecret := &corev1.Secret{}
 	onboardingSecret.Name = fmt.Sprintf("onboarding-token-%s", storageConsumer.UID)
 	onboardingSecret.Namespace = s.namespace
@@ -603,13 +608,16 @@ func decodeAndValidateTicket(ticket string, pubKey *rsa.PublicKey) (*services.On
 		return nil, fmt.Errorf("failed to verify onboarding ticket signature. %v", err)
 	}
 
-	if ticketData.ExpirationDate < time.Now().Unix() {
-		return nil, fmt.Errorf("onboarding ticket %s is expired", ticketData.ID)
-	}
-
 	klog.Infof("onboarding ticket %s has been verified successfully", ticketData.ID)
-
 	return &ticketData, nil
+}
+
+func checkTicketExpiration(ticketData *services.OnboardingTicket) error {
+	if ticketData.ExpirationDate < time.Now().Unix() {
+		return fmt.Errorf("onboarding ticket %s is expired", ticketData.ID)
+	}
+	klog.Infof("onboarding ticket for %s is valid", ticketData.ID)
+	return nil
 }
 
 // FulfillStorageClaim RPC call to create the StorageClaim CR on
@@ -902,8 +910,13 @@ func (s *OCSProviderServer) PeerStorageCluster(ctx context.Context, req *pb.Peer
 
 	onboardingToken, err := decodeAndValidateTicket(req.OnboardingToken, pubKey)
 	if err != nil {
-		klog.Errorf("Invalid onboarding token. %v", err)
-		return nil, status.Errorf(codes.InvalidArgument, "invalid onboarding ticket")
+		klog.Errorf("failed to validate onboarding ticket signature for %q. %v", req.StorageClusterUID, err)
+		return nil, status.Errorf(codes.InvalidArgument, "onboarding ticket signature is not valid. %v", err)
+	}
+
+	if err := checkTicketExpiration(onboardingToken); err != nil {
+		klog.Errorf("onboarding ticket expired for %q. %v", req.StorageClusterUID, err)
+		return nil, status.Errorf(codes.InvalidArgument, "onboarding ticket is expired. %v", err)
 	}
 
 	if onboardingToken.SubjectRole != services.PeerRole {


### PR DESCRIPTION
if the onboarding is already done and being retried by the same client we only need to validate the ticket signature for it's data and skip the timestamp thereby completing the onboard.