### PR TITLE
mds: enable the mds livenessProbe

### DIFF
--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -44,9 +44,6 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 				// set PriorityClassName for the MDS pods
 				PriorityClassName: systemClusterCritical,
 				Labels:            cephv1.Labels{defaults.ODFResourceProfileKey: initStorageCluster.Spec.ResourceProfile},
-				LivenessProbe: &cephv1.ProbeSpec{
-					Disabled: true,
-				},
 			},
 		},
 	}


### PR DESCRIPTION
enable the mds livenessProbe
As the jq support was added back in the ceph image 

```
Ceph has added jq back in ceph image from 19.2.1-244.el9cp
https://bugzilla.redhat.com/show_bug.cgi?id=2354764#c11
```

This reverts commit 3d8bba4fc8f184f6634610a9ddc37b9dae6650b3.