### PR TITLE
DFBUGS-4097:[release-4.19] fix block-only storagecluster deployment

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -2022,7 +2022,9 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 				klog.Warningf("%s with name %s doesn't exist in the cluster", classDisplayName, srcName)
 			} else if errors.Is(err, util.UnsupportedProvisioner) {
 				klog.Warningf("Encountered unsupported provisioner in %s: %s", classDisplayName, srcName)
-			} else if srcKubeObj == nil {
+			} else if errors.Is(err, util.UnsupportedDriver) {
+				klog.Warningf("Encountered unsupported driver in %s: %s", classDisplayName, srcName)
+			} else if reflect.ValueOf(srcKubeObj).IsNil() {
 				klog.Warningf("The name %s does not points to a builtin or an existing %s, skipping", classDisplayName, srcName)
 			} else if srcKubeObj.GetLabels()[util.ExternalClassLabelKey] == "true" {
 				klog.Warningf("The %s is an external %s, skipping", srcName, classDisplayName)
@@ -2030,7 +2032,7 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 				srcClassCache[srcName] = srcKubeObj
 			}
 		}
-		if srcKubeObj != nil {
+		if _, exist := srcClassCache[srcName]; exist {
 			distKubeObj := srcKubeObj.DeepCopyObject().(client.Object)
 			distKubeObj.SetName(destName)
 			kubeResources = append(kubeResources, distKubeObj)


### PR DESCRIPTION
storageclasses for rbd and cephfs are added by default to the storageconsumer which ideally is not a problem since if we don't find the spec we don't distribute it.

however, there is an unhandled panic when a nil interface is compared with interface of a type of nil value and the checks pass where it should fail.