### PR TITLE
Skip adding default node affinity for NooBaa standalone or external mode

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -179,19 +179,9 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	placement := getPlacement(sc, component)
 
 	nb.Spec.Tolerations = placement.Tolerations
-
-	if !r.IsNoobaaStandalone || ok {
-		// Add affinity if not in noobaa-standalone mode or if placement is specified
-		nb.Spec.Affinity = &nbv1.AffinitySpec{NodeAffinity: placement.NodeAffinity}
-		topologyMap := sc.Status.NodeTopologies
-		if topologyMap != nil {
-			topologyKey := getFailureDomain(sc)
-			topologyKey, _ = topologyMap.GetKeyValues(topologyKey)
-			nb.Spec.Affinity.TopologyKey = topologyKey
-		}
-	} else if nb.Spec.Affinity != nil {
-		// Clear the affinity if it was set previously to handle upgrades
-		nb.Spec.Affinity = nil
+	nb.Spec.Affinity = &nbv1.AffinitySpec{
+		NodeAffinity: placement.NodeAffinity,
+		TopologyKey:  sc.Status.FailureDomainKey,
 	}
 
 	nb.Spec.Image = &r.images.NooBaaCore

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -25,6 +25,14 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placeme
 	if component == "osd" || component == "prepareosd" {
 		specified = false
 	}
+
+	// In noobaa-standalone mode or external mode the default ocs labels are not added to the nodes
+	// so we should not add the default ocs node affinity for these modes
+	if (sc.Spec.MultiCloudGateway != nil && ReconcileStrategy(sc.Spec.MultiCloudGateway.ReconcileStrategy) == ReconcileStrategyStandalone) ||
+		sc.Spec.ExternalStorage.Enable {
+		defaultPlacement.NodeAffinity = nil
+	}
+
 	// If some placement is specified, merge it with the default placement
 	if specified {
 		placement = mergePlacements(defaultPlacement, specifiedPlacement)


### PR DESCRIPTION
In noobaa-standalone mode or external mode the default ocs labels are not added to the nodes. So we should not add the default ocs node affinity for these modes.