### PR TITLE
use lower resource requests for ocs-metrics-exporter

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -66,8 +66,8 @@ var (
 		},
 		"ocs-metrics-exporter": {
 			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("512Mi"),
-				"cpu":    resource.MustParse("250m"),
+				"memory": resource.MustParse("250Mi"),
+				"cpu":    resource.MustParse("100m"),
 			},
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("1.5Gi"),

--- a/controllers/storagecluster/resources_test.go
+++ b/controllers/storagecluster/resources_test.go
@@ -309,7 +309,7 @@ func TestGetDaemonResources(t *testing.T) {
 			},
 			expectedResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("250m"), // from daemon resources
+					corev1.ResourceCPU:    resource.MustParse("100m"), // from daemon resources
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 				},
 				Limits: corev1.ResourceList{

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
@@ -66,8 +66,8 @@ var (
 		},
 		"ocs-metrics-exporter": {
 			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("512Mi"),
-				"cpu":    resource.MustParse("250m"),
+				"memory": resource.MustParse("250Mi"),
+				"cpu":    resource.MustParse("100m"),
 			},
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("1.5Gi"),


### PR DESCRIPTION
We can assign lower resource requests for ocs-metrics-exporter pod as we have higher limits to allow burst scope for the pod.

Ref: https://issues.redhat.com/browse/DFBUGS-4052