### PR TITLE
add default resource requests/limits for ocs-provider-server and other sidecars

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -777,16 +777,6 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration, nod
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-							},
 						},
 					},
 					Tolerations: tolerations,

--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -124,6 +124,36 @@ var (
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 		},
+		"ocs-provider-server": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+		"mgr-sidecar": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("75Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		"rook-ceph-tools": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
 	}
 
 	LeanDaemonResources = map[string]corev1.ResourceRequirements{

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -921,6 +921,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -937,6 +938,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -953,6 +955,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -969,6 +972,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -1004,6 +1008,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -1040,6 +1045,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -1075,6 +1081,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 				"logcollector": defaults.DaemonResources["logcollector"],
 				"exporter":     defaults.DaemonResources["exporter"],
+				"mgr-sidecar":  defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -1111,6 +1118,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 				"logcollector": defaults.DaemonResources["logcollector"],
 				"exporter":     defaults.DaemonResources["exporter"],
+				"mgr-sidecar":  defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -1191,6 +1199,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 		{
@@ -1234,6 +1243,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 				"crashcollector": defaults.DaemonResources["crashcollector"],
 				"logcollector":   defaults.DaemonResources["logcollector"],
 				"exporter":       defaults.DaemonResources["exporter"],
+				"mgr-sidecar":    defaults.DaemonResources["mgr-sidecar"],
 			},
 		},
 	}

--- a/controllers/storagecluster/cephtoolbox.go
+++ b/controllers/storagecluster/cephtoolbox.go
@@ -48,6 +48,9 @@ func (r *StorageClusterReconciler) ensureToolsDeployment(sc *ocsv1.StorageCluste
 		return err
 	}
 
+	// Add default resource requirements, or respect custom resource definitions under storagecluster spec.
+	toolsDeployment.Spec.Template.Spec.Containers[0].Resources = getDaemonResources("rook-ceph-tools", sc)
+
 	if sc.Spec.EnableCephTools {
 		// Create or Update if ceph tools is enabled.
 

--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -303,6 +303,7 @@ func GetProviderAPIServerDeployment(instance *ocsv1.StorageCluster) *appsv1.Depl
 									ReadOnly:  true,
 								},
 							},
+							Resources: getDaemonResources(ocsProviderServerName, instance),
 						},
 					},
 					Volumes: []corev1.Volume{

--- a/controllers/storagecluster/provider_server_test.go
+++ b/controllers/storagecluster/provider_server_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -328,6 +329,16 @@ func GetProviderAPIServerDeploymentForTest(instance *ocsv1.StorageCluster) *apps
 									Name:      "cert-secret",
 									MountPath: server.ProviderCertsMountPoint,
 									ReadOnly:  true,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 							},
 						},

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2025-09-10T07:44:14Z"
+    createdAt: "2025-09-29T12:19:27Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.30.0

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2025-09-10T07:44:14Z"
+    createdAt: "2025-09-29T12:19:27Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -744,7 +744,13 @@ spec:
                 name: oauth-proxy
                 ports:
                 - containerPort: 8888
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 25m
+                    memory: 256Mi
+                  requests:
+                    cpu: 5m
+                    memory: 50Mi
                 securityContext:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -777,16 +777,6 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration, nod
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-							},
 						},
 					},
 					Tolerations: tolerations,

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
@@ -124,6 +124,36 @@ var (
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 		},
+		"ocs-provider-server": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+		"mgr-sidecar": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("75Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		"rook-ceph-tools": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
 	}
 
 	LeanDaemonResources = map[string]corev1.ResourceRequirements{

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -752,6 +752,16 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 							RunAsNonRoot:           ptr.To(true),
 							ReadOnlyRootFilesystem: ptr.To(true),
 						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("25m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
 					},
 				},
 				Volumes: []corev1.Volume{

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -777,16 +777,6 @@ func (r *StorageCluster) NewToolsDeployment(tolerations []corev1.Toleration, nod
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
 							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-							},
 						},
 					},
 					Tolerations: tolerations,


### PR DESCRIPTION
add default resource requests/limits for ocs-provider-server, mgr-sidecar, oauth-proxy.
And, also add capability to modify toolbox's resource requirements.