### PR TITLE
Only create but do not update the rook-ceph-mon-endpoints configMap

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	externalClusterDetailsSecret                = "rook-ceph-external-cluster-details"
+	monEndpointConfigMapName                    = "rook-ceph-mon-endpoints"
 	externalClusterDetailsKey                   = "external_cluster_details"
 	cephFsStorageClassName                      = "cephfs"
 	cephRbdStorageClassName                     = "ceph-rbd"
@@ -609,7 +610,7 @@ func (r *StorageClusterReconciler) createExternalStorageClusterConfigMap(cm *cor
 	}
 	// update the found ConfigMap's Data with the latest changes,
 	// if they don't match
-	if !reflect.DeepEqual(found.Data, cm.Data) {
+	if cm.ObjectMeta.Name != monEndpointConfigMapName && !reflect.DeepEqual(found.Data, cm.Data) {
 		found.Data = cm.DeepCopy().Data
 		if err = r.Client.Update(context.TODO(), found); err != nil {
 			return err


### PR DESCRIPTION
Right now both ocs-operator and rook are in race updating the configMap. This is not required as rook will update the configMap with the latest mon endpoints which it's capable of discovering. So ocs-operator should only create the configMap if it doesn't exist, then do not update it.