### PR TITLE
add @leelavg to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - malayparida2000
   - BlaineEXE
   - travisn
+  - leelavg
 # review == this code is good /lgtm
 reviewers:
   - obnoxxx
@@ -16,3 +17,4 @@ reviewers:
   - malayparida2000
   - BlaineEXE
   - travisn
+  - leelavg


### PR DESCRIPTION
already part of GH OCS org but not in OWNERS file forcing to add labels manually during PR merges.