### PR TITLE
zero the nonhashable fields during calculating of desired client state

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -46,10 +46,10 @@ BUNDLE_FULL_IMAGE_NAME="${BUNDLE_FULL_IMAGE_NAME:=${IMAGE_REGISTRY}/${REGISTRY_N
 # Bundle images of Dependencies of OCS Operator
 NOOBAA_BUNDLE_FULL_IMAGE_NAME="quay.io/noobaa/noobaa-operator-bundle:master-20250730"
 ROOK_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/rook-ceph-operator-bundle:master-76dd3bdbe"
-OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/ocs-client-operator-bundle:main-7c764ee"
+OCS_CLIENT_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/ocs-client-operator-bundle:main-0560f3b"
 # Below bundles are dependencies of ocs-client-operator, Ref- https://github.com/red-hat-storage/ocs-client-operator/blob/main/bundle/metadata/dependencies.yaml
-CSI_ADDONS_BUNDLE_FULL_IMAGE_NAME="quay.io/csiaddons/k8s-bundle:v0.12.0"
-CEPH_CSI_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/cephcsi-operator-bundle:main-feeea31"
+CSI_ADDONS_BUNDLE_FULL_IMAGE_NAME="quay.io/csiaddons/k8s-bundle:v0.14.0"
+CEPH_CSI_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/cephcsi-operator-bundle:main-bb74193"
 RECIPE_BUNDLE_FULL_IMAGE_NAME="quay.io/ramendr/recipe-bundle:latest"
 SNAPSHOT_CONTROLLER_BUNDLE_FULL_IMAGE_NAME="quay.io/ocs-dev/snapshot-controller-bundle:main-dfea221"
 

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -393,7 +393,7 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 
 		desiredClientConfigHash := getDesiredClientConfigHash(
 			channelName,
-			consumer,
+			zerodNonHashableFields(consumer),
 			cephConnection.Spec,
 			isEncryptionInTransitEnabled(storageCluster.Spec.Network),
 			inMaintenanceMode,
@@ -684,7 +684,7 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 
 	desiredClientConfigHash := getDesiredClientConfigHash(
 		channelName,
-		storageConsumer,
+		zerodNonHashableFields(storageConsumer),
 		cephConnection.Spec,
 		isEncryptionInTransitEnabled(storageCluster.Spec.Network),
 		inMaintenanceMode,
@@ -706,6 +706,15 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 		DesiredClientOperatorChannel: channelName,
 		DesiredConfigHash:            desiredClientConfigHash,
 	}, nil
+}
+
+func zerodNonHashableFields(consumer *ocsv1alpha1.StorageConsumer) *ocsv1alpha1.StorageConsumer {
+	consumerCopy := &ocsv1alpha1.StorageConsumer{}
+	consumerCopy.DeepCopyInto(consumer)
+	consumerCopy.ManagedFields = nil
+	consumerCopy.ResourceVersion = ""
+	consumerCopy.Status.LastHeartbeat.Time = time.Time{}
+	return consumerCopy
 }
 
 func getDesiredClientConfigHash(parts ...any) string {


### PR DESCRIPTION
for every heartbeat, consumer status gets updated with latest timestamp changing the resourceVersion of the resource effectively rendering the heartbeat mechanism for the reconciliation of resources at client less useful and we fix that by zeroing nonhashable fields before calculating hash.