### PR TITLE
util: disable reclaimspace for rbd virt storageclass

### DIFF
--- a/pkg/util/storageclasses.go
+++ b/pkg/util/storageclasses.go
@@ -159,7 +159,6 @@ func NewDefaultVirtRbdStorageClass(
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"description": "Provides RWO and RWX Block volumes suitable for Virtual Machine disks",
-				"reclaimspace.csiaddons.openshift.io/schedule": "@weekly",
 			},
 			Labels: map[string]string{},
 		},


### PR DESCRIPTION
This patch disables (automated) reclaimspace for virt storageclass to prevent sparsify operations from blacklisting the kRBD clients (VMs).