### PR TITLE
tls: fix wrong ssl option used to disable tls 1.2 for rgw

### DIFF
--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -324,9 +324,9 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 				if obj.Spec.Security.SslOptions == nil {
 					obj.Spec.Security.SslOptions = &cephv1.SslOptionsSpec{}
 				}
-				// rook by default disables older versions except 1.2 and we explicitly disable it
-				// making 1.3 as the default
-				obj.Spec.Security.SslOptions.SSLv2 = ptr.To(false)
+				// beast frontend enables TLS 1.2 by default; explicitly disable it
+				// so that TLS 1.3 becomes the minimum version
+				obj.Spec.Security.SslOptions.TLSv1_2 = ptr.To(false)
 			}
 			obj.Spec.Security.Ciphers = osstls.Ciphers
 			obj.Spec.Security.TlsGroups = osstls.Groups

--- a/internal/controller/storagecluster/cephobjectstores_test.go
+++ b/internal/controller/storagecluster/cephobjectstores_test.go
@@ -484,11 +484,11 @@ func TestRGWTLSConfig(t *testing.T) {
 		assert.Contains(t, stores[0].Spec.Security.Ciphers, "ECDHE-RSA-AES256-GCM-SHA384")
 		assert.Contains(t, stores[0].Spec.Security.TlsGroups, "prime256v1")
 		assert.Contains(t, stores[0].Spec.Security.TlsGroups, "secp384r1")
-		// TLS 1.2 must not set SSLv2 option
+		// TLS 1.2 must not set SslOptions
 		assert.Nil(t, stores[0].Spec.Security.SslOptions)
 	})
 
-	t.Run("TLS 1.3 profile with rook.io selector disables SSLv2", func(t *testing.T) {
+	t.Run("TLS 1.3 profile with rook.io selector disables TLS 1.2", func(t *testing.T) {
 		profile := makeTLSProfile(
 			"rook.io",
 			ocstlsv1.VersionTLS1_3,
@@ -500,7 +500,7 @@ func TestRGWTLSConfig(t *testing.T) {
 		assert.NotNil(t, stores[0].Spec.Security)
 		assert.Contains(t, stores[0].Spec.Security.TlsGroups, "x25519")
 		assert.NotNil(t, stores[0].Spec.Security.SslOptions)
-		assert.Equal(t, ptr.To(false), stores[0].Spec.Security.SslOptions.SSLv2)
+		assert.Equal(t, ptr.To(false), stores[0].Spec.Security.SslOptions.TLSv1_2)
 	})
 
 	t.Run("Profile with non-matching selector falls back to DEFAULT groups", func(t *testing.T) {


### PR DESCRIPTION
SSLv2 is already disabled by default in beast; setting it to false was a no-op. Use TLSv1_2=false instead, which is what beast enables by default and must be explicitly disabled to make TLS 1.3 the minimum.