### PR TITLE
Do not create RGW StorageClass when reconcileStrategy is ignore

### DIFF
--- a/internal/controller/storagecluster/obcstorageclasses.go
+++ b/internal/controller/storagecluster/obcstorageclasses.go
@@ -14,6 +14,10 @@ type obcStorageClasses struct{}
 var _ resourceManager = &obcStorageClasses{}
 
 func (s *obcStorageClasses) ensureCreated(r *StorageClusterReconciler, storageCluster *ocsv1.StorageCluster) (ctrl.Result, error) {
+	reconcileStrategy := ReconcileStrategy(storageCluster.Spec.ManagedResources.CephObjectStores.ReconcileStrategy)
+	if reconcileStrategy == ReconcileStrategyIgnore {
+		return ctrl.Result{}, nil
+	}
 
 	if skip, err := platform.PlatformsShouldSkipObjectStore(); err != nil {
 		r.Log.Error(err, "failed to identify if ObjectStore SC should be created")


### PR DESCRIPTION
[DFBUGS-7414](https://redhat.atlassian.net/browse/DFBUGS-7414)

Added reconcileStrategy check to prevent creating ocs-storagecluster-ceph-rgw StorageClass when CephObjectStores reconcileStrategy is set to "ignore" in block-only deployments.