### PR TITLE
Add multus network annotation to ocs-metrics-exporter deployment

### DIFF
--- a/internal/controller/storagecluster/exporter.go
+++ b/internal/controller/storagecluster/exporter.go
@@ -340,6 +340,15 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 		dnsPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
+	var multusNetwork string
+	if util.IsMultus(instance.Spec.Network) {
+		var err error
+		multusNetwork, err = getMultusPublicNetwork(instance)
+		if err != nil {
+			return err
+		}
+	}
+
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentDep, func() error {
 		if currentDep.CreationTimestamp.IsZero() {
 			// Selector is immutable. Inject it only while creating new object.
@@ -486,6 +495,12 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 					NodeAffinity: GetPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
 				},
 			},
+		}
+		if multusNetwork != "" {
+			if currentDep.Spec.Template.Annotations == nil {
+				currentDep.Spec.Template.Annotations = make(map[string]string)
+			}
+			currentDep.Spec.Template.Annotations["k8s.v1.cni.cncf.io/networks"] = multusNetwork
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
The ocs-metrics-exporter deployment was not receiving the required Multus network attachment annotation, preventing it from reaching the Ceph cluster in Multus-configured environments.


Ref: [DFBUGS-7391](https://redhat.atlassian.net/browse/DFBUGS-7391)