### PR TITLE
Updated pods to have annotations with openshift.io/required-scc

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: ocs-operator
     spec:

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -674,6 +674,8 @@ spec:
             type: Recreate
           template:
             metadata:
+              annotations:
+                openshift.io/required-scc: restricted-v2
               labels:
                 name: ocs-operator
             spec:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -693,6 +693,8 @@ spec:
             type: Recreate
           template:
             metadata:
+              annotations:
+                openshift.io/required-scc: restricted-v2
               labels:
                 name: ocs-operator
             spec:

--- a/internal/controller/storagecluster/blackbox_exporter.go
+++ b/internal/controller/storagecluster/blackbox_exporter.go
@@ -27,6 +27,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"go.uber.org/multierr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -81,12 +82,12 @@ func (r *StorageClusterReconciler) deployBlackboxExporter(ctx context.Context, i
 	}
 
 	// Build Multus annotation for Blackbox (attach to same networks as Ceph cluster)
-	var podAnnotations map[string]string
+	podAnnotations := map[string]string{
+		securityv1.RequiredSCCAnnotation: util.OdfBlackboxSccName,
+	}
 	multusValue := buildMultusAnnotation(cephClusterNetwork, instance.Namespace)
 	if multusValue != "" {
-		podAnnotations = map[string]string{
-			"k8s.v1.cni.cncf.io/networks": multusValue,
-		}
+		podAnnotations["k8s.v1.cni.cncf.io/networks"] = multusValue
 		r.Log.Info("Attaching Blackbox to Ceph cluster network", "networks", cephClusterNetwork)
 	}
 

--- a/internal/controller/storagecluster/blackbox_exporter_test.go
+++ b/internal/controller/storagecluster/blackbox_exporter_test.go
@@ -11,6 +11,7 @@ import (
 	fakeclientset "github.com/openshift/client-go/security/clientset/versioned/fake"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -139,7 +140,9 @@ func TestCreateBlackboxDeployment(t *testing.T) {
 		},
 	}
 
-	err := reconciler.createBlackboxDeployment(context.TODO(), instance, map[string]string{})
+	err := reconciler.createBlackboxDeployment(context.TODO(), instance, map[string]string{
+		securityv1.RequiredSCCAnnotation: util.OdfBlackboxSccName,
+	})
 	require.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -148,6 +151,8 @@ func TestCreateBlackboxDeployment(t *testing.T) {
 		Name:      blackboxExporterName,
 	}, deployment)
 	require.NoError(t, err)
+
+	assert.Equal(t, util.OdfBlackboxSccName, deployment.Spec.Template.Annotations[securityv1.RequiredSCCAnnotation])
 
 	container := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "quay.io/prometheus/blackbox-exporter:v0.25.0", container.Image)

--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -566,6 +566,7 @@ func newCephCluster(r *StorageClusterReconciler, sc *ocsv1.StorageCluster, kmsCo
 				rookCephv1.KeyMonitoring:   getCephClusterMonitoringLabels(*sc),
 				rookCephv1.KeyCephExporter: getCephClusterMonitoringLabels(*sc),
 			},
+			Annotations: util.GetRookCephDaemonSCCAnnotations(),
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: util.GetReadAffinityOptions(sc),
 				CephFS: rookCephv1.CSICephFSSpec{
@@ -759,6 +760,7 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, monitoringIP, monitoringPo
 				rookCephv1.KeyMonitoring:   getCephClusterMonitoringLabels(*sc),
 				rookCephv1.KeyCephExporter: getCephClusterMonitoringLabels(*sc),
 			},
+			Annotations:  util.GetRookCephDaemonSCCAnnotations(),
 			LogCollector: logCollector,
 			CSI: rookCephv1.CSIDriverSpec{
 				ReadAffinity: util.GetReadAffinityOptions(sc),

--- a/internal/controller/storagecluster/cephfilesystem.go
+++ b/internal/controller/storagecluster/cephfilesystem.go
@@ -8,6 +8,7 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
+	secv1 "github.com/openshift/api/security/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +45,9 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 				// set PriorityClassName for the MDS pods
 				PriorityClassName: systemClusterCritical,
 				Labels:            cephv1.Labels{defaults.ODFResourceProfileKey: initStorageCluster.Spec.ResourceProfile},
+				Annotations: map[string]string{
+					secv1.RequiredSCCAnnotation: util.RookCephSccName,
+				},
 			},
 		},
 	}

--- a/internal/controller/storagecluster/cephnfs.go
+++ b/internal/controller/storagecluster/cephnfs.go
@@ -7,6 +7,7 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
+	secv1 "github.com/openshift/api/security/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	v1 "k8s.io/api/core/v1"
@@ -39,6 +40,9 @@ func (r *StorageClusterReconciler) newCephNFSInstances(initData *ocsv1.StorageCl
 					// pods using NFS volumes.
 					PriorityClassName: systemClusterCritical,
 					LogLevel:          initData.Spec.NFS.LogLevel,
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RookCephSccName,
+					},
 				},
 			},
 		},

--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -10,6 +10,7 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/platform"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	secv1 "github.com/openshift/api/security/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -231,6 +232,9 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 					// set PriorityClassName for the rgw pods
 					PriorityClassName: systemClusterCritical,
 					Labels:            cephv1.Labels{defaults.ODFResourceProfileKey: initData.Spec.ResourceProfile},
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RookCephSccName,
+					},
 				},
 			},
 		},

--- a/internal/controller/storagecluster/cephrbdmirrors.go
+++ b/internal/controller/storagecluster/cephrbdmirrors.go
@@ -6,6 +6,8 @@ import (
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
+
+	secv1 "github.com/openshift/api/security/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +65,9 @@ func (r *StorageClusterReconciler) newCephRbdMirrorInstances(initData *ocsv1.Sto
 				}(),
 				Resources: getDaemonResources("rbd-mirror", initData),
 				Placement: GetPlacement(initData, "rbd-mirror"),
+				Annotations: map[string]string{
+					secv1.RequiredSCCAnnotation: util.RookCephSccName,
+				},
 			},
 		},
 	}

--- a/internal/controller/storagecluster/cephtoolbox.go
+++ b/internal/controller/storagecluster/cephtoolbox.go
@@ -10,6 +10,8 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
+	secv1 "github.com/openshift/api/security/v1"
+
 	nadclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -114,6 +116,9 @@ func newToolsDeployment(namespace string, tolerations []corev1.Toleration, nodeA
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": "rook-ceph-tools",
+					},
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RookCephSccName,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/storagecluster/cephtoolbox_test.go
+++ b/internal/controller/storagecluster/cephtoolbox_test.go
@@ -6,6 +6,9 @@ import (
 
 	v1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
+
+	secv1 "github.com/openshift/api/security/v1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -122,6 +125,10 @@ func TestEnsureToolsDeployment(t *testing.T) {
 			assert.Equalf(
 				t, tc.expectedNodeAffinity, cephtoolsDeployment.Spec.Template.Spec.Affinity.NodeAffinity,
 				"[%s]: failed to add node affinity to the ceph tool deployment resource", tc.label,
+			)
+			assert.Equalf(
+				t, util.RookCephSccName, cephtoolsDeployment.Spec.Template.Annotations[secv1.RequiredSCCAnnotation],
+				"[%s]: failed to add required-scc annotation to the ceph tool deployment resource", tc.label,
 			)
 		}
 	}

--- a/internal/controller/storagecluster/exporter.go
+++ b/internal/controller/storagecluster/exporter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"github.com/red-hat-storage/ocs-operator/v4/version"
 	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	secv1 "github.com/openshift/api/security/v1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -598,11 +599,16 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 				},
 			},
 		}
+		if currentDep.Spec.Template.Annotations == nil {
+			currentDep.Spec.Template.Annotations = make(map[string]string)
+		}
 		if multusNetwork != "" {
-			if currentDep.Spec.Template.Annotations == nil {
-				currentDep.Spec.Template.Annotations = make(map[string]string)
-			}
 			currentDep.Spec.Template.Annotations["k8s.v1.cni.cncf.io/networks"] = multusNetwork
+		}
+		if hostNetwork {
+			currentDep.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = util.HostNetworkV2SccName
+		} else {
+			currentDep.Spec.Template.Annotations[secv1.RequiredSCCAnnotation] = util.RestrictedV2SccName
 		}
 		return nil
 	}); err != nil {

--- a/internal/controller/storagecluster/exporter_test.go
+++ b/internal/controller/storagecluster/exporter_test.go
@@ -8,6 +8,7 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	secv1 "github.com/openshift/api/security/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,6 +47,7 @@ func TestDeployMetricsExporterSetsTLSProfileEnvironment(t *testing.T) {
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 	assert.Contains(t, env, corev1.EnvVar{Name: util.OperatorNamespaceEnvVar, Value: r.OperatorNamespace})
 	assert.Contains(t, env, corev1.EnvVar{Name: tlsProfileGenerationEnvName, Value: "7"})
+	assert.Equal(t, util.RestrictedV2SccName, deployment.Spec.Template.Annotations[secv1.RequiredSCCAnnotation])
 }
 
 func TestMetricsExporterCanGetTLSProfiles(t *testing.T) {

--- a/internal/controller/storagecluster/job_templates.go
+++ b/internal/controller/storagecluster/job_templates.go
@@ -6,7 +6,9 @@ import (
 	"os"
 
 	openshiftv1 "github.com/openshift/api/template/v1"
+	secv1 "github.com/openshift/api/security/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -160,6 +162,11 @@ func newExtendClusterJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephC
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RestrictedV2SccName,
+					},
+				},
 				Spec: corev1.PodSpec{
 
 					InitContainers: []corev1.Container{
@@ -277,6 +284,11 @@ func newosdCleanUpJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephComm
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RookCephSccName,
+					},
+				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: "rook-ceph-system",

--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -24,6 +24,8 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"github.com/red-hat-storage/ocs-operator/v4/services/provider/server"
+
+	secv1 "github.com/openshift/api/security/v1"
 )
 
 const (
@@ -314,6 +316,9 @@ func GetProviderAPIServerDeployment(instance *ocsv1.StorageCluster) *appsv1.Depl
 					Labels: map[string]string{
 						"app": "ocsProviderApiServer",
 					},
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RestrictedV2SccName,
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -462,6 +467,11 @@ func getOnboardingJobObject(instance *ocsv1.StorageCluster) *batchv1.Job {
 			// Eligible to delete automatically when job finishes
 			TTLSecondsAfterFinished: ptr.To(int32(0)),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RestrictedV2SccName,
+					},
+				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: onboardingValidationKeysGeneratorJobName,

--- a/internal/controller/storagecluster/provider_server_test.go
+++ b/internal/controller/storagecluster/provider_server_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"github.com/red-hat-storage/ocs-operator/v4/services/provider/server"
+
+	secv1 "github.com/openshift/api/security/v1"
 )
 
 func TestOcsProviderServerEnsureCreated(t *testing.T) {
@@ -360,6 +362,9 @@ func GetProviderAPIServerDeploymentForTest(instance *ocsv1.StorageCluster) *apps
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": "ocsProviderApiServer",
+					},
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RestrictedV2SccName,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/storagecluster/vault_agent.go
+++ b/internal/controller/storagecluster/vault_agent.go
@@ -7,6 +7,8 @@ import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
+
+	secv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -251,6 +253,9 @@ func (r *StorageClusterReconciler) createVaultAgentDeployment(instance *ocsv1.St
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: vaultAgentLabels,
+					Annotations: map[string]string{
+						secv1.RequiredSCCAnnotation: util.RestrictedV2SccName,
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: VaultAgentSAName,

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       app.kubernetes.io/name: ocs-metrics-exporter
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         app.kubernetes.io/component: ocs-metrics-exporter
         app.kubernetes.io/name: ocs-metrics-exporter

--- a/pkg/util/scc.go
+++ b/pkg/util/scc.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	secv1 "github.com/openshift/api/security/v1"
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+)
+
+const (
+	// OpenShift built-in SCCs used by low-privilege ODF workloads.
+	RestrictedV2SccName  = "restricted-v2"
+	HostNetworkV2SccName = "hostnetwork-v2"
+	NonRootV2SccName     = "nonroot-v2"
+
+	// ODF custom SCCs created or referenced by ocs-operator.
+	RookCephSccName    = "rook-ceph"
+	OdfBlackboxSccName = "odf-blackbox-scc"
+)
+
+// GetRookCephDaemonSCCAnnotations returns AnnotationsSpec entries for Ceph daemons
+// that use the rook-ceph SCC. Do not use KeyAll — CSI pods require rook-ceph-csi.
+func GetRookCephDaemonSCCAnnotations() rookCephv1.AnnotationsSpec {
+	scc := map[string]string{
+		secv1.RequiredSCCAnnotation: RookCephSccName,
+	}
+	return rookCephv1.AnnotationsSpec{
+		rookCephv1.KeyMon:             scc,
+		rookCephv1.KeyMgr:             scc,
+		rookCephv1.KeyOSD:             scc,
+		rookCephv1.KeyOSDPrepare:      scc,
+		rookCephv1.KeyCrashCollector:  scc,
+		rookCephv1.KeyCephExporter:    scc,
+		rookCephv1.KeyCleanup:         scc,
+		rookCephv1.KeyRotation:        scc,
+		rookCephv1.KeyCmdReporter:     scc,
+		rookCephv1.KeyMds:             scc,
+		rookCephv1.KeyRgw:             scc,
+		rookCephv1.KeyMonArbiter:      scc,
+		rookCephv1.KeyDashboard:       scc,
+		rookCephv1.KeyMonitoring:      scc,
+		rookCephv1.KeyClusterMetadata: scc,
+	}
+}

--- a/templates/alertmanager.go
+++ b/templates/alertmanager.go
@@ -2,7 +2,9 @@ package templates
 
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	secv1 "github.com/openshift/api/security/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
@@ -10,6 +12,11 @@ import (
 var AlertmanagerSpecTemplate = promv1.AlertmanagerSpec{
 	Replicas:  ptr.To(int32(1)),
 	Resources: defaults.MonitoringResources["alertmanager"],
+	PodMetadata: &promv1.EmbeddedObjectMetadata{
+		Annotations: map[string]string{
+			secv1.RequiredSCCAnnotation: util.NonRootV2SccName,
+		},
+	},
 	Tolerations: []corev1.Toleration{{
 		Key:      defaults.NodeTolerationKey,
 		Operator: corev1.TolerationOpEqual,

--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -5,7 +5,9 @@ import (
 	"os"
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	secv1 "github.com/openshift/api/security/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -33,6 +35,11 @@ var PrometheusSpecTemplate = promv1.PrometheusSpec{
 		ServiceMonitorSelector: &metav1.LabelSelector{},
 		ListenLocal:            true,
 		Resources:              defaults.MonitoringResources["prometheus"],
+		PodMetadata: &promv1.EmbeddedObjectMetadata{
+			Annotations: map[string]string{
+				secv1.RequiredSCCAnnotation: util.NonRootV2SccName,
+			},
+		},
 		Containers: []corev1.Container{{
 			Name:  "kube-rbac-proxy",
 			Image: os.Getenv("KUBE_RBAC_PROXY_IMAGE"),


### PR DESCRIPTION
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) [Enforce least-privileged Security Context Constraint (SCC) across ODF pods ](https://redhat.atlassian.net/browse/RHSTOR-8757)

Changes:

- Add `[pkg/util/scc.go](pkg/util/scc.go)` with SCC name constants and shared helpers:
  - `RequiredSCCForHostNetwork` — selects `hostnetwork-v2` or `restricted-v2` based on host networking
  - `RequiredSCCAnnotation` / `MergePodTemplateAnnotations` — set the annotation without clobbering existing keys
  - `RookCephDaemonRequiredSCCAnnotations` / `ToRookAnnotationsSpec` — apply `rook-ceph` SCC to Ceph daemon pods via Rook `AnnotationsSpec`
- Annotate workloads with the appropriate SCC:
  - **rook-ceph** — CephCluster daemons, toolbox, OSD cleanup job, CephFilesystem/NFS/ObjectStore/RBD mirror pods
  - **restricted-v2** — provider API server, onboarding job, vault agent, extend-cluster job, Prometheus Operator deployment
  - **nonroot-v2** — Prometheus and Alertmanager pods
  - **odf-blackbox-scc** — blackbox exporter
  - **hostnetwork-v2 / restricted-v2** — rook-ceph-operator and metrics exporter (via `RequiredSCCForHostNetwork`, depending on host networking)
- Update provider-server unit test fixture to match the deployment template
- Regenerate CSV bundle metadata (`createdAt` timestamp)

No runtime behavior change beyond SCC pinning; pod security contexts and service accounts are unchanged.