### PR TITLE
DFBUGS-8413: [release-4.16] Bump go (stdlib) from 1.21.9 to 1.21.13

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/api/v4
 
-go 1.21.9
+go 1.21.13
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20240319123706-4ee28d614c7c

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/v4
 
-go 1.21.9
+go 1.21.13
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ./api
 

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/metrics/v4
 
-go 1.21.9
+go 1.21.13
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ../api
 

--- a/metrics/vendor/modules.txt
+++ b/metrics/vendor/modules.txt
@@ -288,11 +288,11 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240327160100-bbe9d9d49462 => ../api
-## explicit; go 1.21.9
+## explicit; go 1.21.13
 github.com/red-hat-storage/ocs-operator/api/v4/v1
 github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1
 # github.com/red-hat-storage/ocs-operator/v4 v4.0.0-00010101000000-000000000000 => ../
-## explicit; go 1.21.9
+## explicit; go 1.21.13
 github.com/red-hat-storage/ocs-operator/v4/version
 # github.com/rook/rook v1.13.7
 ## explicit; go 1.20

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -387,7 +387,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.21
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240327160100-bbe9d9d49462 => ./api
-## explicit; go 1.21.9
+## explicit; go 1.21.13
 github.com/red-hat-storage/ocs-operator/api/v4/v1
 github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1
 # github.com/rook/rook/pkg/apis v0.0.0-20240327231646-b6b89a012a95


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.21.9` → `1.21.13` (in `api/go.mod`)
- **go (stdlib)**: `1.21.9` → `1.21.13` (in `go.mod`)
- **go (stdlib)**: `1.21.9` → `1.21.13` (in `metrics/go.mod`)
