### PR TITLE
DFBUGS-8415: [release-4.21] Bump go (stdlib) from 1.24.10 to 1.24.12

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/api/v4
 
 go 1.24.6
 
-toolchain go1.24.10
+toolchain go1.24.12
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20251118072940-a392e524a776

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/v4
 
 go 1.24.6
 
-toolchain go1.24.10
+toolchain go1.24.12
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ./api
 

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/metrics/v4
 
 go 1.24.6
 
-toolchain go1.24.10
+toolchain go1.24.12
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ../api
 

--- a/services/provider/api/go.mod
+++ b/services/provider/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/services/provider/api/v4
 
 go 1.24.6
 
-toolchain go1.24.10
+toolchain go1.24.12
 
 require (
 	google.golang.org/grpc v1.77.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `metrics/go.mod`)
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `services/provider/api/go.mod`)
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `api/go.mod`)
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `go.mod`)
