### PR TITLE
DFBUGS-5501: [release-4.19] Bump go (stdlib) from 1.23.5 to 1.23.10

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/api/v4
 
-go 1.23.5
+go 1.23.10
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20250325115430-401802f15851

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/v4
 
-go 1.23.5
+go 1.23.10
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ./api
 

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/metrics/v4
 
-go 1.23.5
+go 1.23.10
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ../api
 

--- a/metrics/vendor/modules.txt
+++ b/metrics/vendor/modules.txt
@@ -357,11 +357,11 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20250227172543-a22914aaf7d5 => ../api
-## explicit; go 1.23.5
+## explicit; go 1.23.10
 github.com/red-hat-storage/ocs-operator/api/v4/v1
 github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1
 # github.com/red-hat-storage/ocs-operator/v4 v4.0.0-20250227172543-a22914aaf7d5 => ../
-## explicit; go 1.23.5
+## explicit; go 1.23.10
 github.com/red-hat-storage/ocs-operator/v4/controllers/defaults
 github.com/red-hat-storage/ocs-operator/v4/controllers/util
 github.com/red-hat-storage/ocs-operator/v4/services

--- a/services/provider/api/go.mod
+++ b/services/provider/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/services/provider/api/v4
 
 go 1.23.0
 
-toolchain go1.23.4
+toolchain go1.23.10
 
 require (
 	google.golang.org/grpc v1.68.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -445,7 +445,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.23.0
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20250227172543-a22914aaf7d5 => ./api
-## explicit; go 1.23.5
+## explicit; go 1.23.10
 github.com/red-hat-storage/ocs-operator/api/v4/v1
 github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1
 # github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20250227172543-a22914aaf7d5 => ./services/provider/api


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.5` → `1.23.10` (in `api/go.mod`)
- **go (stdlib)**: `1.23.5` → `1.23.10` (in `go.mod`)
- **go (stdlib)**: `1.23.5` → `1.23.10` (in `metrics/go.mod`)
- **go (stdlib)**: `1.23.4` → `1.23.10` (in `services/provider/api/go.mod`)
