### PR TITLE
provider/client: replace grpc.DialContext+WithBlock with grpc.NewClient

### DIFF
--- a/services/provider/api/client/client.go
+++ b/services/provider/api/client/client.go
@@ -24,23 +24,15 @@ type OCSProviderClient struct {
 
 // NewProviderClient creates a client to talk to the external OCS storage provider server
 func NewProviderClient(ctx context.Context, serverAddr string, timeout time.Duration) (*OCSProviderClient, error) {
-	apiCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	config := &tls.Config{
 		InsecureSkipVerify: true,
 	}
 
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
-		// TODO fix deprecated warning
-		//nolint:golint,all
-		grpc.WithBlock(),
 	}
 
-	// TODO fix deprecated warning
-	//nolint:golint,all
-	conn, err := grpc.DialContext(apiCtx, serverAddr, opts...)
+	conn, err := grpc.NewClient(serverAddr, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %v", err)
 	}


### PR DESCRIPTION
grpc.WithBlock() causes the dial to block and retry TLS handshakes in a tight loop for the full context timeout duration whenever the provider endpoint is slow or unreachable. grpc.NewClient() connects lazily on the first RPC call, reducing connection attempts to exactly one per invocation. Per-call context timeouts are already applied on every method so the dial-level timeout context is no longer needed.

Both grpc.DialContext and grpc.WithBlock are deprecated upstream in favour of grpc.NewClient.