### PR TITLE
Apply centralized TLS profile to metrics exporter

### DIFF
--- a/internal/controller/storagecluster/exporter.go
+++ b/internal/controller/storagecluster/exporter.go
@@ -3,6 +3,7 @@ package storagecluster
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/imdario/mergo"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -10,6 +11,7 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"github.com/red-hat-storage/ocs-operator/v4/version"
+	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,16 +27,17 @@ import (
 )
 
 const (
-	metricsExporterName     = "ocs-metrics-exporter"
-	prometheusRoleName      = "ocs-metrics-svc"
-	metricsExporterRoleName = metricsExporterName
-	metricsMainPort         = 8443
-	metricsSelfPort         = 9443
-	portMetricsMain         = "https-main"
-	portMetricsSelf         = "https-self"
-	metricsPath             = "/metrics"
-	scrapeInterval          = "1m"
-	tlsCertPath             = "/etc/tls/private"
+	metricsExporterName         = "ocs-metrics-exporter"
+	prometheusRoleName          = "ocs-metrics-svc"
+	metricsExporterRoleName     = metricsExporterName
+	metricsMainPort             = 8443
+	metricsSelfPort             = 9443
+	portMetricsMain             = "https-main"
+	portMetricsSelf             = "https-self"
+	metricsPath                 = "/metrics"
+	scrapeInterval              = "1m"
+	tlsCertPath                 = "/etc/tls/private"
+	tlsProfileGenerationEnvName = "TLS_PROFILE_GENERATION"
 
 	componentLabel = "app.kubernetes.io/component"
 	nameLabel      = "app.kubernetes.io/name"
@@ -49,7 +52,7 @@ var exporterLabels = map[string]string{
 // enableMetricsExporter starts the metrics exporter deployment
 // and the needed services.
 func (r *StorageClusterReconciler) enableMetricsExporter(
-	ctx context.Context, instance *ocsv1.StorageCluster) error {
+	ctx context.Context, instance *ocsv1.StorageCluster, tlsProfile *ocstlsv1.TLSProfile) error {
 	// create the needed serviceaccount
 	if err := createMetricsExporterServiceAccount(ctx, r, instance); err != nil {
 		r.Log.Error(err, "unable to create serviceaccount for ocs metrics exporter")
@@ -98,7 +101,7 @@ func (r *StorageClusterReconciler) enableMetricsExporter(
 	}
 
 	// create the metrics exporter deployment
-	if err := deployMetricsExporter(ctx, r, instance); err != nil {
+	if err := deployMetricsExporter(ctx, r, instance, tlsProfile); err != nil {
 		r.Log.Error(err, "failed to create ocs-metric-exporter deployment")
 		return err
 	}
@@ -324,7 +327,7 @@ func createMetricsExporterServiceMonitor(ctx context.Context, r *StorageClusterR
 	return serviceMonitor, nil
 }
 
-func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster, tlsProfile *ocstlsv1.TLSProfile) error {
 	alertManagerURL := "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094"
 
 	currentDep := &appsv1.Deployment{
@@ -407,8 +410,12 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 							return args
 						}(),
 						Command: []string{"/usr/local/bin/metrics-exporter"},
-						Image:   r.images.OCSMetricsExporter,
-						Name:    metricsExporterName,
+						Env: []corev1.EnvVar{
+							{Name: util.OperatorNamespaceEnvVar, Value: r.OperatorNamespace},
+							{Name: tlsProfileGenerationEnvName, Value: strconv.FormatInt(tlsProfile.Generation, 10)},
+						},
+						Image: r.images.OCSMetricsExporter,
+						Name:  metricsExporterName,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          portMetricsMain,
@@ -689,6 +696,11 @@ func updateMetricsExporterClusterRoles(ctx context.Context, r *StorageClusterRec
 				APIGroups: []string{"csiaddons.openshift.io"},
 				Resources: []string{"csiaddonsnodes"},
 				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"ocs.openshift.io"},
+				Resources: []string{"tlsprofiles"},
+				Verbs:     []string{"get"},
 			},
 		}
 

--- a/internal/controller/storagecluster/exporter_test.go
+++ b/internal/controller/storagecluster/exporter_test.go
@@ -1,0 +1,62 @@
+package storagecluster
+
+import (
+	"context"
+	"testing"
+
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
+	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDeployMetricsExporterSetsTLSProfileEnvironment(t *testing.T) {
+	scheme := createFakeScheme(t)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &StorageClusterReconciler{
+		Client:            kubeClient,
+		OperatorNamespace: "openshift-storage",
+		images:            ImageMap{OCSMetricsExporter: "metrics-exporter:test"},
+	}
+	storageCluster := &ocsv1.StorageCluster{
+		TypeMeta: metav1.TypeMeta{APIVersion: ocsv1.GroupVersion.String(), Kind: "StorageCluster"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-storagecluster",
+			Namespace: "openshift-storage-extended",
+		},
+	}
+	profile := &ocstlsv1.TLSProfile{ObjectMeta: metav1.ObjectMeta{Generation: 7}}
+
+	require.NoError(t, deployMetricsExporter(context.Background(), r, storageCluster, profile))
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, kubeClient.Get(context.Background(), types.NamespacedName{
+		Name: metricsExporterName, Namespace: storageCluster.Namespace,
+	}, deployment))
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+	assert.Contains(t, env, corev1.EnvVar{Name: util.OperatorNamespaceEnvVar, Value: r.OperatorNamespace})
+	assert.Contains(t, env, corev1.EnvVar{Name: tlsProfileGenerationEnvName, Value: "7"})
+}
+
+func TestMetricsExporterCanGetTLSProfiles(t *testing.T) {
+	scheme := createFakeScheme(t)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &StorageClusterReconciler{Client: kubeClient}
+
+	require.NoError(t, updateMetricsExporterClusterRoles(context.Background(), r))
+
+	role := &rbacv1.ClusterRole{}
+	require.NoError(t, kubeClient.Get(context.Background(), types.NamespacedName{Name: metricsExporterName}, role))
+	assert.Contains(t, role.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"ocs.openshift.io"},
+		Resources: []string{"tlsprofiles"},
+		Verbs:     []string{"get"},
+	})
+}

--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -727,7 +727,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 				ReconcileStrategy: string(ReconcileStrategyUnknown),
 			}
 		}
-		if err := r.enableMetricsExporter(ctx, instance); err != nil {
+		if err := r.enableMetricsExporter(ctx, instance, tlsProfile); err != nil {
 			r.Log.Error(err, "Failed to reconcile metrics exporter.")
 			return reconcile.Result{}, err
 		}

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           initialDelaySeconds: 15
         image: quay.io/ocs-dev/ocs-operator
         name: ocs-metrics-exporter
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
           - name: https-main
             containerPort: 8443

--- a/metrics/deploy/rbac.yaml
+++ b/metrics/deploy/rbac.yaml
@@ -87,6 +87,12 @@ rules:
     - list
     - watch
 - apiGroups:
+  - ocs.openshift.io
+  resources:
+  - tlsprofiles
+  verbs:
+    - get
+- apiGroups:
   - operators.coreos.com
   resources:
   - operatorconditions

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-00010101000000-000000000000
 	github.com/red-hat-storage/ocs-operator/v4 v4.0.0-00010101000000-000000000000
+	github.com/red-hat-storage/ocs-tls-profiles/api v0.0.0-20260427105901-0c5f6d8fcd65
 	github.com/rook/rook v1.20.0-alpha.0.0.20260707223529-6c2a3a5f2b08
 	github.com/rook/rook/pkg/apis v0.0.0-20260707223529-6c2a3a5f2b08
 	github.com/spf13/pflag v1.0.10

--- a/metrics/go.sum
+++ b/metrics/go.sum
@@ -828,6 +828,8 @@ github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4Ul
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/red-hat-storage/external-snapshotter/client/v8 v8.2.1-0.20260409102146-bd705f8eebd0 h1:AF2uVg2hK1xg5ekWAeobDFKiRq+IJ71H1ISNdhEm5KE=
 github.com/red-hat-storage/external-snapshotter/client/v8 v8.2.1-0.20260409102146-bd705f8eebd0/go.mod h1:5cstVYzNXZ6Fo8TKv7XpnlxXfTre5PQhK6EkP5lr3tE=
+github.com/red-hat-storage/ocs-tls-profiles/api v0.0.0-20260427105901-0c5f6d8fcd65 h1:Ie0cAiC3lrzy6S5vZ7tKCs3SjAAIs3wFbNJkGrx6tXg=
+github.com/red-hat-storage/ocs-tls-profiles/api v0.0.0-20260427105901-0c5f6d8fcd65/go.mod h1:jBStZ67yVkhiTlaIB/cqm7DI0BvVp6ynTFUs7BzlAVc=
 github.com/red-hat-storage/rook/pkg/apis v0.0.0-20260805051950-73bd6cc64015 h1:fy4QimkVFkxnaUWJoxaQbeQ478f1lRhyIdgaKklb/zw=
 github.com/red-hat-storage/rook/pkg/apis v0.0.0-20260805051950-73bd6cc64015/go.mod h1:79nbfxfJ+jQZKPvj2ZPvULSP5g+hEpXA0sj63m42GBA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/metrics/internal/tlsprofile/config.go
+++ b/metrics/internal/tlsprofile/config.go
@@ -1,0 +1,41 @@
+package tlsprofile
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
+	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetConfig gets the centralized TLS profile configuration for metrics-exporter.
+func GetConfig(ctx context.Context, restConfig *rest.Config, namespace string) (*tls.Config, error) {
+	scheme := runtime.NewScheme()
+	if err := ocstlsv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+	return load(ctx, kubeClient, namespace)
+}
+
+func load(ctx context.Context, kubeClient client.Client, namespace string) (*tls.Config, error) {
+	profile := &ocstlsv1.TLSProfile{}
+	err := kubeClient.Get(ctx, types.NamespacedName{Name: defaults.TLSProfileName, Namespace: namespace}, profile)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	config, found := ocstlsv1.GetConfigForServer(profile, "ocs.openshift.io", "metrics-exporter")
+	if !found {
+		return &tls.Config{MinVersion: tls.VersionTLS12}, nil
+	}
+	return ocstlsv1.GetGoTLSConfig(config), nil
+}

--- a/metrics/internal/tlsprofile/config_test.go
+++ b/metrics/internal/tlsprofile/config_test.go
@@ -1,0 +1,80 @@
+package tlsprofile
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+
+	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+const testNamespace = "openshift-storage"
+
+func TestLoad(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, ocstlsv1.AddToScheme(scheme))
+	profile := &ocstlsv1.TLSProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "ocs-tls-profile", Namespace: testNamespace},
+		Spec: ocstlsv1.TLSProfileSpec{Rules: []ocstlsv1.TLSProfileRules{{
+			Selectors: []ocstlsv1.Selector{"ocs.openshift.io/metrics-exporter"},
+			Config: ocstlsv1.TLSConfig{
+				Version: ocstlsv1.VersionTLS1_3,
+				Ciphers: []ocstlsv1.TLSCipherSuite{"TLS_AES_128_GCM_SHA256"},
+				Groups:  []ocstlsv1.TLSGroupName{"X25519MLKEM768"},
+			},
+		}}},
+	}
+
+	config, err := load(context.Background(), fake.NewClientBuilder().WithScheme(scheme).WithObjects(profile).Build(), testNamespace)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS13), config.MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS13), config.MaxVersion)
+	assert.Equal(t, []tls.CurveID{tls.X25519MLKEM768}, config.CurvePreferences)
+}
+
+func TestLoadUsesDefaultsWithoutMatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, ocstlsv1.AddToScheme(scheme))
+
+	for _, profile := range []*ocstlsv1.TLSProfile{
+		nil,
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ocs-tls-profile", Namespace: testNamespace},
+			Spec: ocstlsv1.TLSProfileSpec{Rules: []ocstlsv1.TLSProfileRules{{
+				Selectors: []ocstlsv1.Selector{"other.io"},
+				Config:    ocstlsv1.TLSConfig{Version: ocstlsv1.VersionTLS1_3},
+			}}},
+		},
+	} {
+		builder := fake.NewClientBuilder().WithScheme(scheme)
+		if profile != nil {
+			builder.WithObjects(profile)
+		}
+		config, err := load(context.Background(), builder.Build(), testNamespace)
+		require.NoError(t, err)
+		assert.Equal(t, uint16(tls.VersionTLS12), config.MinVersion)
+		assert.Zero(t, config.MaxVersion)
+	}
+}
+
+func TestLoadReturnsClientError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, ocstlsv1.AddToScheme(scheme))
+	want := errors.New("forbidden")
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+			return want
+		},
+	}).Build()
+
+	_, err := load(context.Background(), kubeClient, testNamespace)
+	assert.ErrorIs(t, err, want)
+}

--- a/metrics/main.go
+++ b/metrics/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/red-hat-storage/ocs-operator/metrics/v4/internal/exporter"
 	"github.com/red-hat-storage/ocs-operator/metrics/v4/internal/handler"
 	"github.com/red-hat-storage/ocs-operator/metrics/v4/internal/options"
+	"github.com/red-hat-storage/ocs-operator/metrics/v4/internal/tlsprofile"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -68,7 +70,17 @@ func main() {
 
 	// Create authentication filter if secure serving is enabled
 	var authFilter metricsserver.Filter
+	var baseTLSConfig *tls.Config
 	if opts.SecureServing {
+		operatorNamespace, err := util.GetOperatorNamespace()
+		if err != nil {
+			klog.Fatal(err)
+		}
+		baseTLSConfig, err = tlsprofile.GetConfig(context.Background(), kubeconfig, operatorNamespace)
+		if err != nil {
+			klog.Fatalf("failed to configure TLS: %v", err)
+		}
+
 		httpClient, err := rest.HTTPClientFor(kubeconfig)
 		if err != nil {
 			klog.Fatalf("failed to create http client: %v", err)
@@ -173,8 +185,8 @@ func main() {
 
 	// Add servers to run group
 	if opts.SecureServing {
-		rg.Add(listenAndServeTLS(ctx, customResourceHandler, opts.Host, opts.Port, opts.TLSCertFile, opts.TLSKeyFile))
-		rg.Add(listenAndServeTLS(ctx, exporterHandler, opts.ExporterHost, opts.ExporterPort, opts.TLSCertFile, opts.TLSKeyFile))
+		rg.Add(listenAndServeTLS(ctx, customResourceHandler, opts.Host, opts.Port, opts.TLSCertFile, opts.TLSKeyFile, baseTLSConfig))
+		rg.Add(listenAndServeTLS(ctx, exporterHandler, opts.ExporterHost, opts.ExporterPort, opts.TLSCertFile, opts.TLSKeyFile, baseTLSConfig))
 		klog.Infof("Running metrics server (HTTPS) on %s:%v", opts.Host, opts.Port)
 		klog.Infof("Running telemetry server (HTTPS) on %s:%v", opts.ExporterHost, opts.ExporterPort)
 	} else {
@@ -207,7 +219,7 @@ func listenAndServe(ctx context.Context, handler http.Handler, host string, port
 	return serverRunFuncs(ctx, server, addr)
 }
 
-func listenAndServeTLS(ctx context.Context, handler http.Handler, host string, port int, certFile, keyFile string) (func() error, func(error)) {
+func listenAndServeTLS(ctx context.Context, handler http.Handler, host string, port int, certFile, keyFile string, baseTLSConfig *tls.Config) (func() error, func(error)) {
 	addr := net.JoinHostPort(host, strconv.Itoa(port))
 
 	// Create certificate watcher for automatic cert reload
@@ -218,10 +230,8 @@ func listenAndServeTLS(ctx context.Context, handler http.Handler, host string, p
 		}, func(error) {}
 	}
 
-	tlsConfig := &tls.Config{
-		GetCertificate: certWatcher.GetCertificate,
-		MinVersion:     tls.VersionTLS12,
-	}
+	tlsConfig := baseTLSConfig.Clone()
+	tlsConfig.GetCertificate = certWatcher.GetCertificate
 
 	server := &http.Server{
 		Addr:      addr,


### PR DESCRIPTION
Apply the matching central TLSProfile configuration to both
metrics-exporter HTTPS listeners.

Restart the deployment when the profile generation changes, preserve Go
TLS defaults when no rule matches, and grant the exporter access to the
profile.

Refs: [RHSTOR-8586](https://redhat.atlassian.net/browse/RHSTOR-8586)

Signed-off-by: Divyansh Kamboj <dkamboj@redhat.com>