### PR TITLE
Lower ocs-operator CPU request from 50m to 10m

### DIFF
--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -744,7 +744,7 @@ spec:
                     cpu: 250m
                     memory: 512Mi
                   requests:
-                    cpu: 50m
+                    cpu: 10m
                     memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -265,7 +265,7 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
 	// set default mem/cpu requests/limits value in csv
 	templateStrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 		Limits: corev1.ResourceList{


### PR DESCRIPTION
The 50m CPU request was added in #3339 as part of a general effort to set requests/limits on every pod. That value was a pure approximation number used across operators at the time, not based on measured needs. ocs-operator had been fine with no CPU request before that. Operator pods are mostly idle and only briefly wake to reconcile, so lower the request to 10m and keep the 250m limit so bursts are still allowed.

Ref-https://redhat.atlassian.net/browse/RHSTOR-9518