### PR TITLE
Fix MonitoringResources for prometheus kube-rbac-proxy

### DIFF
--- a/pkg/defaults/resources.go
+++ b/pkg/defaults/resources.go
@@ -64,26 +64,6 @@ var (
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 		},
-		"kube-rbac-proxy-main": {
-			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("40Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-			Limits: corev1.ResourceList{
-				"memory": resource.MustParse("40Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-		},
-		"kube-rbac-proxy-self": {
-			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("40Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-			Limits: corev1.ResourceList{
-				"memory": resource.MustParse("40Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -361,12 +341,6 @@ var (
 				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 		},
-		"kube-rbac-proxy-main": {
-			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("40Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-		},
 		"ocs-provider-server": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -404,6 +378,16 @@ var (
 	}
 
 	MonitoringResources = map[string]corev1.ResourceRequirements{
+		"kube-rbac-proxy": {
+			Requests: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+		},
 		"alertmanager": {
 			Requests: corev1.ResourceList{
 				"cpu":    resource.MustParse("100m"),


### PR DESCRIPTION
Since PR https://github.com/red-hat-storage/ocs-operator/pull/3508 removed MonitoringResources["kube-rbac-proxy"] while
moving metrics-exporter sidecars to DaemonResources keys
(kube-rbac-proxy-main/self), [templates/prometheus.go](https://github.com/red-hat-storage/ocs-operator/blob/c76322ad38016437d6e418816c9d2615f82263cb/templates/prometheus.go#L63) has been looking
up a missing map key and applying empty ResourceRequirements to the
Prometheus kube-rbac-proxy sidecar.

Restore the entry with 40Mi/50m (matching the limits introduced in https://github.com/red-hat-storage/ocs-operator/pull/3508)
and drop unused kube-rbac-proxy-main/self defaults now that
metrics-exporter no longer uses those sidecars (PR https://github.com/red-hat-storage/ocs-operator/pull/3755).