### PR TITLE
Lower metrics and blackbox exporter CPU requests

### DIFF
--- a/internal/controller/storagecluster/resources_test.go
+++ b/internal/controller/storagecluster/resources_test.go
@@ -299,7 +299,7 @@ func TestGetDaemonResources(t *testing.T) {
 			},
 			expectedResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"), // from daemon resources
+					corev1.ResourceCPU:    resource.MustParse("50m"), // from daemon resources
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 				},
 				Limits: corev1.ResourceList{

--- a/pkg/defaults/resources.go
+++ b/pkg/defaults/resources.go
@@ -37,7 +37,7 @@ var (
 		"ocs-metrics-exporter": {
 			Requests: corev1.ResourceList{
 				"memory": resource.MustParse("250Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"cpu":    resource.MustParse("50m"),
 			},
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("1.5Gi"),
@@ -47,7 +47,7 @@ var (
 		"odf-blackbox-exporter": {
 			Requests: corev1.ResourceList{
 				"memory": resource.MustParse("50Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"cpu":    resource.MustParse("10m"),
 			},
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("50Mi"),

--- a/pkg/defaults/resources.go
+++ b/pkg/defaults/resources.go
@@ -14,24 +14,14 @@ var (
 				corev1.ResourceStorage: resource.MustParse("50Gi"),
 			},
 		},
-		"nfs": {
+		"ocs-provider-server": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
-			},
-		},
-		"rbd-mirror": {
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 		},
 		"ocs-metrics-exporter": {
@@ -52,6 +42,26 @@ var (
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("50Mi"),
 				"cpu":    resource.MustParse("100m"),
+			},
+		},
+		"nfs": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		"rbd-mirror": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},
 		"vault-agent": {
@@ -92,16 +102,6 @@ var (
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("0.05"),
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
-			},
-		},
-		"ocs-provider-server": {
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("128Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 		},
 		"mgr-sidecar": {


### PR DESCRIPTION
## Summary
- Lower `ocs-metrics-exporter` CPU request from **100m → 50m**
- Lower `odf-blackbox-exporter` CPU request from **100m → 10m**
- Keep existing limits unchanged so workloads can still burst when needed

Ref-https://redhat.atlassian.net/browse/RHSTOR-9536

## Reasoning

### ocs-metrics-exporter
Custom Prometheus exporter that watches OCS/Ceph CRs and runs background Ceph RBD/CephFS scans (default every 5m), scraped every 1m. Workload is mostly idle with short CPU bursts.

Test results showed main-container average/peak CPU in the **~44–55m** range, so **50m** is a better request fit than 100m. The **1 CPU** limit is kept for scrape/scan bursts.

### odf-blackbox-exporter
Upstream Prometheus blackbox-exporter probing OSD/MON IPs with ICMP every 30s for network latency alerts. Very lightweight. Current **100m** was oversized for the workload.