### PR TITLE
add networkpolicy for ocs-metrics-exporter

### DIFF
--- a/internal/controller/storagecluster/exporter.go
+++ b/internal/controller/storagecluster/exporter.go
@@ -15,6 +15,7 @@ import (
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,6 +99,20 @@ func (r *StorageClusterReconciler) enableMetricsExporter(
 	_, err := createMetricsExporterService(ctx, r, instance)
 	if err != nil {
 		return err
+	}
+
+	// Create the network policy for the metrics exporter only when not on host network.
+	// NetworkPolicy operates at the CNI layer and has no effect on host-networked pods.
+	if !util.ShouldUseHostNetworking(instance) {
+		if err := createMetricsExporterNetworkPolicy(ctx, r, instance); err != nil {
+			r.Log.Error(err, "failed to create networkpolicy for metrics exporter")
+			return err
+		}
+	} else {
+		if err := deleteMetricsExporterNetworkPolicy(ctx, r, instance); err != nil {
+			r.Log.Error(err, "failed to delete networkpolicy for metrics exporter on host network")
+			return err
+		}
 	}
 
 	// create the metrics exporter deployment
@@ -199,6 +214,86 @@ func createMetricsExporterService(ctx context.Context, r *StorageClusterReconcil
 		return nil, fmt.Errorf("failed to update service %v. %v", namespacedName, err)
 	}
 	return service, nil
+}
+
+// createMetricsExporterNetworkPolicy creates the NetworkPolicy for the metrics exporter
+func createMetricsExporterNetworkPolicy(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      metricsExporterName,
+			Namespace: instance.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, networkPolicy, func() error {
+		networkPolicy.Labels = map[string]string{
+			componentLabel: exporterLabels[componentLabel],
+			nameLabel:      exporterLabels[nameLabel],
+			versionLabel:   version.Version,
+		}
+		if err := controllerutil.SetControllerReference(instance, networkPolicy, r.Scheme); err != nil {
+			return err
+		}
+
+		networkPolicy.Spec = networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					nameLabel: metricsExporterName,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": "openshift-monitoring",
+								},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: ptr.To(corev1.ProtocolTCP),
+							Port:     ptr.To(intstr.FromInt32(metricsMainPort)),
+						},
+						{
+							Protocol: ptr.To(corev1.ProtocolTCP),
+							Port:     ptr.To(intstr.FromInt32(metricsSelfPort)),
+						},
+					},
+				},
+			},
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to create/update NetworkPolicy for metrics exporter: %v", err)
+	}
+
+	r.Log.Info("Successfully created/updated NetworkPolicy for metrics exporter", "Namespace", instance.Namespace, "Name", metricsExporterName)
+	return nil
+}
+
+// deleteMetricsExporterNetworkPolicy removes the NetworkPolicy if it exists.
+// Called when the exporter switches to host networking, where NetworkPolicy has no effect.
+func deleteMetricsExporterNetworkPolicy(ctx context.Context, r *StorageClusterReconciler, instance *ocsv1.StorageCluster) error {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      metricsExporterName,
+			Namespace: instance.Namespace,
+		},
+	}
+	err := r.Delete(ctx, networkPolicy)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete NetworkPolicy for metrics exporter: %v", err)
+	}
+	return nil
 }
 
 func getMetricsExporterServiceMonitor(instance *ocsv1.StorageCluster) *monitoringv1.ServiceMonitor {

--- a/internal/controller/storagecluster/exporter_test.go
+++ b/internal/controller/storagecluster/exporter_test.go
@@ -2,6 +2,7 @@ package storagecluster
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
@@ -11,10 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 )
 
 func TestDeployMetricsExporterSetsTLSProfileEnvironment(t *testing.T) {
@@ -59,4 +62,42 @@ func TestMetricsExporterCanGetTLSProfiles(t *testing.T) {
 		Resources: []string{"tlsprofiles"},
 		Verbs:     []string{"get"},
 	})
+}
+
+func TestMetricsExporterNetworkPolicyMatchesYAML(t *testing.T) {
+	const namespace = "openshift-storage"
+
+	scheme := createFakeScheme(t)
+	require.NoError(t, networkingv1.AddToScheme(scheme))
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &StorageClusterReconciler{
+		Client: kubeClient,
+		Scheme: scheme,
+	}
+	instance := &ocsv1.StorageCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ocsv1.GroupVersion.String(),
+			Kind:       "StorageCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-storagecluster",
+			Namespace: namespace,
+		},
+	}
+
+	require.NoError(t, createMetricsExporterNetworkPolicy(context.Background(), r, instance))
+
+	generated := &networkingv1.NetworkPolicy{}
+	require.NoError(t, kubeClient.Get(context.Background(), types.NamespacedName{
+		Name: metricsExporterName, Namespace: namespace,
+	}, generated))
+
+	yamlBytes, err := os.ReadFile("../../../metrics/deploy/networkpolicy.yaml")
+	require.NoError(t, err, "failed to read networkpolicy.yaml — if the file moved, update the path")
+
+	fromYAML := &networkingv1.NetworkPolicy{}
+	require.NoError(t, yaml.Unmarshal(yamlBytes, fromYAML))
+
+	assert.Equal(t, fromYAML.Spec, generated.Spec,
+		"the YAML in metrics/deploy/networkpolicy.yaml has drifted from the Go code in exporter.go — update one to match the other")
 }

--- a/metrics/deploy/networkpolicy.yaml
+++ b/metrics/deploy/networkpolicy.yaml
@@ -1,0 +1,33 @@
+#################################################################################################################
+# NetworkPolicy definitions for the ocs-metrics-exporter operand pod.
+# This policy restricts ingress to only the monitoring namespace.
+# Egress is left unrestricted (default-open) because the exporter needs access to the
+# host-networked API server (impossible to target with selectors) and to cross-namespace
+# ClusterIP services (AlertManager) whose DNAT evaluation under OVN-Kubernetes makes
+# selector-based egress rules unreliable.
+#
+# This file is for manual testing only and is expected to be identical to the policy generated
+# by the operator in exporter.go (createMetricsExporterNetworkPolicy).
+#################################################################################################################
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocs-metrics-exporter
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ocs-metrics-exporter
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow OpenShift Monitoring (Prometheus) to scrape metrics from the exporter
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+      ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 9443


### PR DESCRIPTION
this commit adds network policy for
ocs-metrics-exporter

```
oc get networkpolicy ocs-metrics-exporter -n openshift-storage -o yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: ocs-metrics-exporter
  namespace: openshift-storage
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-monitoring
    ports:
    - port: 8443
      protocol: TCP
    - port: 9443
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: ocs-metrics-exporter
  policyTypes:
  - Ingress
```

API Server Connectivity — PASS

```
$ oc exec -n openshift-storage ocs-metrics-exporter-77d45cbb8d-8hdjs -- curl -sk --max-time 5 https://172.30.0.1:443/healthz
ok

$ oc exec -n openshift-storage ocs-metrics-exporter-77d45cbb8d-8hdjs -- env | grep KUBERNETES_SERVICE
KUBERNETES_SERVICE_HOST=172.30.0.1
KUBERNETES_SERVICE_PORT_HTTPS=443
KUBERNETES_SERVICE_PORT=443
```
```
oc exec -n openshift-storage ocs-metrics-exporter-77d45cbb8d-8hdjs -- curl -sk --connect-timeout 5 --max-time 10 \
    https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094/api/v2/status \
    -o /dev/null -w 'http_code=%{http_code} time_connect=%{time_connect} time_total=%{time_total}'
http_code=401 time_connect=0.006422 time_total=0.017218
(HTTP 401 in 6ms — connected, auth handled by exporter's TLS client)
```

DNS Resolution — PASS

```
$ oc exec -n openshift-storage ocs-metrics-exporter-77d45cbb8d-8hdjs -- cat /etc/resolv.conf
search openshift-storage.svc.cluster.local svc.cluster.local cluster.local us-west-2.compute.internal
nameserver 172.30.0.10
options ndots:5

$ oc exec -n openshift-storage ocs-metrics-exporter-77d45cbb8d-8hdjs -- curl -sk --connect-timeout 3 --max-time 5 \
    https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094/ \
    -o /dev/null -w 'resolved_ip=%{remote_ip}'
resolved_ip=172.30.170.251
```

 Established TCP Connections — ALL EXPECTED

```
$ oc exec -n openshift-storage ocs-metrics-exporter-77d45cbb8d-8hdjs -- cat /proc/net/tcp | awk '...$4=="01"...'
      2 172.30.75.21:3300 [ESTABLISHED]    # Ceph monitor (ClusterIP)
      2 10.129.2.23:6800 [ESTABLISHED]     # Ceph manager
      1 172.30.0.1:443 [ESTABLISHED]       # API server (ClusterIP)
      1 10.128.4.6:6800 [ESTABLISHED]      # Ceph manager
```
