### PR TITLE
DFBUGS-9032:[release-4.18] fix verbosity value

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=2"
         ports:
         - containerPort: 8443
           name: https

--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -387,7 +387,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 							"--tls-private-key-file", "/etc/tls/private/tls.key",
 							"--tls-cipher-suites", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 							"--config-file", "/etc/kube-rbac-policy/config.yaml",
-							"--v", "10",
+							"--v", "2",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -426,7 +426,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 							"--tls-private-key-file", "/etc/tls/private/tls.key",
 							"--tls-cipher-suites", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 							"--config-file", "/etc/kube-rbac-policy/config.yaml",
-							"--v", "10",
+							"--v", "2",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
           - '--config-file=/etc/kube-rbac-policy/config.yaml'
           - '--logtostderr=true'
-          - '--v=10'
+          - '--v=2'
         volumeMounts:
         - mountPath: /etc/tls/private
           name: ocs-metrics-exporter-tls
@@ -83,7 +83,7 @@ spec:
           - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
           - '--config-file=/etc/kube-rbac-policy/config.yaml'
           - '--logtostderr=true'
-          - '--v=10'
+          - '--v=2'
         volumeMounts:
         - mountPath: /etc/tls/private
           name: ocs-metrics-exporter-tls


### PR DESCRIPTION
Jira Link: https://redhat.atlassian.net/browse/DFBUGS-9032

Signed-off-by: Harshvardhan Handa Harshvardhan.handa1@ibm.com/hhanda@redhat.com

The bearer token is visible in clear text since the verbosity value is 10. Reducing it to 7 will resolve this issue.

Output when v = 7: 

harshvardhanhanda@Harshvardhans-MacBook-Pro ocs-operator % oc logs -n openshift-storage ocs-metrics-exporter-599fbf6b84-9sgm2 -c kube-rbac-proxy-main
I0812 12:34:48.860963       1 flags.go:64] FLAG: --add-dir-header="false"
I0812 12:34:48.861051       1 flags.go:64] FLAG: --allow-paths="[]"
I0812 12:34:48.861059       1 flags.go:64] FLAG: --alsologtostderr="false"
I0812 12:34:48.861062       1 flags.go:64] FLAG: --auth-header-fields-enabled="false"
I0812 12:34:48.861064       1 flags.go:64] FLAG: --auth-header-groups-field-name="x-remote-groups"
I0812 12:34:48.861068       1 flags.go:64] FLAG: --auth-header-groups-field-separator="|"
I0812 12:34:48.861071       1 flags.go:64] FLAG: --auth-header-user-field-name="x-remote-user"
I0812 12:34:48.861074       1 flags.go:64] FLAG: --auth-token-audiences="[]"
I0812 12:34:48.861077       1 flags.go:64] FLAG: --client-ca-file=""
I0812 12:34:48.861080       1 flags.go:64] FLAG: --config-file="/etc/kube-rbac-policy/config.yaml"
I0812 12:34:48.861083       1 flags.go:64] FLAG: --help="false"
I0812 12:34:48.861087       1 flags.go:64] FLAG: --http2-disable="false"
I0812 12:34:48.861089       1 flags.go:64] FLAG: --http2-max-concurrent-streams="100"
I0812 12:34:48.861092       1 flags.go:64] FLAG: --http2-max-size="262144"
I0812 12:34:48.861095       1 flags.go:64] FLAG: --ignore-paths="[]"
I0812 12:34:48.861099       1 flags.go:64] FLAG: --insecure-listen-address=""
I0812 12:34:48.861101       1 flags.go:64] FLAG: --kube-api-burst="0"
I0812 12:34:48.861106       1 flags.go:64] FLAG: --kube-api-qps="0"
I0812 12:34:48.861111       1 flags.go:64] FLAG: --kubeconfig=""
I0812 12:34:48.861115       1 flags.go:64] FLAG: --log-backtrace-at=""
I0812 12:34:48.861119       1 flags.go:64] FLAG: --log-dir=""
I0812 12:34:48.861123       1 flags.go:64] FLAG: --log-file=""
I0812 12:34:48.861126       1 flags.go:64] FLAG: --log-file-max-size="0"
I0812 12:34:48.861129       1 flags.go:64] FLAG: --log-flush-frequency="5s"
I0812 12:34:48.861133       1 flags.go:64] FLAG: --logtostderr="false"
I0812 12:34:48.861135       1 flags.go:64] FLAG: --oidc-ca-file=""
I0812 12:34:48.861143       1 flags.go:64] FLAG: --oidc-clientID=""
I0812 12:34:48.861146       1 flags.go:64] FLAG: --oidc-groups-claim="groups"
I0812 12:34:48.861149       1 flags.go:64] FLAG: --oidc-groups-prefix=""
I0812 12:34:48.861151       1 flags.go:64] FLAG: --oidc-issuer=""
I0812 12:34:48.861153       1 flags.go:64] FLAG: --oidc-sign-alg="[RS256]"
I0812 12:34:48.861165       1 flags.go:64] FLAG: --oidc-username-claim="email"
I0812 12:34:48.861168       1 flags.go:64] FLAG: --oidc-username-prefix=""
I0812 12:34:48.861170       1 flags.go:64] FLAG: --one-output="false"
I0812 12:34:48.861173       1 flags.go:64] FLAG: --proxy-endpoints-port="0"
I0812 12:34:48.861175       1 flags.go:64] FLAG: --secure-listen-address="0.0.0.0:8443"
I0812 12:34:48.861178       1 flags.go:64] FLAG: --skip-headers="false"
I0812 12:34:48.861180       1 flags.go:64] FLAG: --skip-log-headers="false"
I0812 12:34:48.861183       1 flags.go:64] FLAG: --stderrthreshold=""
I0812 12:34:48.861185       1 flags.go:64] FLAG: --tls-cert-file="/etc/tls/private/tls.crt"
I0812 12:34:48.861188       1 flags.go:64] FLAG: --tls-cipher-suites="[TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305]"
I0812 12:34:48.861195       1 flags.go:64] FLAG: --tls-min-version="VersionTLS12"
I0812 12:34:48.861199       1 flags.go:64] FLAG: --tls-private-key-file="/etc/tls/private/tls.key"
I0812 12:34:48.861202       1 flags.go:64] FLAG: --tls-reload-interval="1m0s"
I0812 12:34:48.861205       1 flags.go:64] FLAG: --upstream="http://127.0.0.1:8080/"
I0812 12:34:48.861208       1 flags.go:64] FLAG: --upstream-ca-file=""
I0812 12:34:48.861210       1 flags.go:64] FLAG: --upstream-client-cert-file=""
I0812 12:34:48.861213       1 flags.go:64] FLAG: --upstream-client-key-file=""
I0812 12:34:48.861216       1 flags.go:64] FLAG: --upstream-force-h2c="false"
I0812 12:34:48.861218       1 flags.go:64] FLAG: --v="7"
I0812 12:34:48.861221       1 flags.go:64] FLAG: --version="false"
I0812 12:34:48.861225       1 flags.go:64] FLAG: --vmodule=""
I0812 12:34:48.861233       1 kube-rbac-proxy.go:530] Reading config file: /etc/kube-rbac-policy/config.yaml
I0812 12:34:48.861941       1 kube-rbac-proxy.go:233] Valid token audiences: 
I0812 12:34:48.958352       1 kube-rbac-proxy.go:347] Reading certificate files
I0812 12:34:48.958431       1 reloader.go:99] reloading key /etc/tls/private/tls.key certificate /etc/tls/private/tls.crt
I0812 12:34:48.958726       1 kube-rbac-proxy.go:395] Starting TCP socket on 0.0.0.0:8443
I0812 12:34:48.959013       1 kube-rbac-proxy.go:402] Listening securely on 0.0.0.0:8443
I0812 12:35:15.988190       1 round_trippers.go:463] POST https://172.30.0.1:443/apis/authentication.k8s.io/v1/tokenreviews
I0812 12:35:15.988206       1 round_trippers.go:469] Request Headers:
I0812 12:35:15.988220       1 round_trippers.go:473]     Authorization: Bearer <masked>
I0812 12:35:15.988225       1 round_trippers.go:473]     User-Agent: kube-rbac-proxy/v0.0.0 (linux/amd64) kubernetes/$Format
I0812 12:35:15.988228       1 round_trippers.go:473]     Accept: application/json, */*
I0812 12:35:15.988230       1 round_trippers.go:473]     Content-Type: application/json
I0812 12:35:16.161347       1 round_trippers.go:574] Response Status: 201 Created in 173 milliseconds
I0812 12:35:17.435818       1 round_trippers.go:463] POST https://172.30.0.1:443/apis/authentication.k8s.io/v1/tokenreviews
I0812 12:35:17.435831       1 round_trippers.go:469] Request Headers:
I0812 12:35:17.435840       1 round_trippers.go:473]     Accept: application/json, */*
I0812 12:35:17.435843       1 round_trippers.go:473]     Content-Type: application/json
I0812 12:35:17.435847       1 round_trippers.go:473]     User-Agent: kube-rbac-proxy/v0.0.0 (linux/amd64) kubernetes/$Format
I0812 12:35:17.435851       1 round_trippers.go:473]     Authorization: Bearer <masked>
I0812 12:35:17.437327       1 round_trippers.go:574] Response Status: 201 Created in 1 milliseconds


Output when v = 2: 
harshvardhanhanda@Harshvardhans-MacBook-Pro ocs-operator % oc logs -n openshift-storage ocs-metrics-exporter-744cd56976-dwbbv -c kube-rbac-proxy-main
I0812 12:39:15.058681       1 flags.go:64] FLAG: --add-dir-header="false"
I0812 12:39:15.058788       1 flags.go:64] FLAG: --allow-paths="[]"
I0812 12:39:15.058795       1 flags.go:64] FLAG: --alsologtostderr="false"
I0812 12:39:15.058798       1 flags.go:64] FLAG: --auth-header-fields-enabled="false"
I0812 12:39:15.058801       1 flags.go:64] FLAG: --auth-header-groups-field-name="x-remote-groups"
I0812 12:39:15.058806       1 flags.go:64] FLAG: --auth-header-groups-field-separator="|"
I0812 12:39:15.058808       1 flags.go:64] FLAG: --auth-header-user-field-name="x-remote-user"
I0812 12:39:15.058811       1 flags.go:64] FLAG: --auth-token-audiences="[]"
I0812 12:39:15.058817       1 flags.go:64] FLAG: --client-ca-file=""
I0812 12:39:15.058820       1 flags.go:64] FLAG: --config-file="/etc/kube-rbac-policy/config.yaml"
I0812 12:39:15.058823       1 flags.go:64] FLAG: --help="false"
I0812 12:39:15.058826       1 flags.go:64] FLAG: --http2-disable="false"
I0812 12:39:15.058828       1 flags.go:64] FLAG: --http2-max-concurrent-streams="100"
I0812 12:39:15.058832       1 flags.go:64] FLAG: --http2-max-size="262144"
I0812 12:39:15.058835       1 flags.go:64] FLAG: --ignore-paths="[]"
I0812 12:39:15.058839       1 flags.go:64] FLAG: --insecure-listen-address=""
I0812 12:39:15.058841       1 flags.go:64] FLAG: --kube-api-burst="0"
I0812 12:39:15.058845       1 flags.go:64] FLAG: --kube-api-qps="0"
I0812 12:39:15.058848       1 flags.go:64] FLAG: --kubeconfig=""
I0812 12:39:15.058851       1 flags.go:64] FLAG: --log-backtrace-at=""
I0812 12:39:15.058853       1 flags.go:64] FLAG: --log-dir=""
I0812 12:39:15.058855       1 flags.go:64] FLAG: --log-file=""
I0812 12:39:15.058858       1 flags.go:64] FLAG: --log-file-max-size="0"
I0812 12:39:15.058862       1 flags.go:64] FLAG: --log-flush-frequency="5s"
I0812 12:39:15.058865       1 flags.go:64] FLAG: --logtostderr="false"
I0812 12:39:15.058868       1 flags.go:64] FLAG: --oidc-ca-file=""
I0812 12:39:15.058870       1 flags.go:64] FLAG: --oidc-clientID=""
I0812 12:39:15.058872       1 flags.go:64] FLAG: --oidc-groups-claim="groups"
I0812 12:39:15.058875       1 flags.go:64] FLAG: --oidc-groups-prefix=""
I0812 12:39:15.058882       1 flags.go:64] FLAG: --oidc-issuer=""
I0812 12:39:15.058885       1 flags.go:64] FLAG: --oidc-sign-alg="[RS256]"
I0812 12:39:15.058894       1 flags.go:64] FLAG: --oidc-username-claim="email"
I0812 12:39:15.058897       1 flags.go:64] FLAG: --oidc-username-prefix=""
I0812 12:39:15.058899       1 flags.go:64] FLAG: --one-output="false"
I0812 12:39:15.058901       1 flags.go:64] FLAG: --proxy-endpoints-port="0"
I0812 12:39:15.058904       1 flags.go:64] FLAG: --secure-listen-address="0.0.0.0:8443"
I0812 12:39:15.058906       1 flags.go:64] FLAG: --skip-headers="false"
I0812 12:39:15.058909       1 flags.go:64] FLAG: --skip-log-headers="false"
I0812 12:39:15.058912       1 flags.go:64] FLAG: --stderrthreshold=""
I0812 12:39:15.058914       1 flags.go:64] FLAG: --tls-cert-file="/etc/tls/private/tls.crt"
I0812 12:39:15.058917       1 flags.go:64] FLAG: --tls-cipher-suites="[TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305]"
I0812 12:39:15.058925       1 flags.go:64] FLAG: --tls-min-version="VersionTLS12"
I0812 12:39:15.058928       1 flags.go:64] FLAG: --tls-private-key-file="/etc/tls/private/tls.key"
I0812 12:39:15.058931       1 flags.go:64] FLAG: --tls-reload-interval="1m0s"
I0812 12:39:15.058939       1 flags.go:64] FLAG: --upstream="http://127.0.0.1:8080/"
I0812 12:39:15.058942       1 flags.go:64] FLAG: --upstream-ca-file=""
I0812 12:39:15.058944       1 flags.go:64] FLAG: --upstream-client-cert-file=""
I0812 12:39:15.058947       1 flags.go:64] FLAG: --upstream-client-key-file=""
I0812 12:39:15.058950       1 flags.go:64] FLAG: --upstream-force-h2c="false"
I0812 12:39:15.058952       1 flags.go:64] FLAG: --v="2"
I0812 12:39:15.058955       1 flags.go:64] FLAG: --version="false"
I0812 12:39:15.058959       1 flags.go:64] FLAG: --vmodule=""
I0812 12:39:15.058969       1 kube-rbac-proxy.go:530] Reading config file: /etc/kube-rbac-policy/config.yaml
I0812 12:39:15.059691       1 kube-rbac-proxy.go:233] Valid token audiences: 
I0812 12:39:15.060700       1 kube-rbac-proxy.go:347] Reading certificate files
I0812 12:39:15.060959       1 kube-rbac-proxy.go:395] Starting TCP socket on 0.0.0.0:8443
I0812 12:39:15.061185       1 kube-rbac-proxy.go:402] Listening securely on 0.0.0.0:8443
