### PR TITLE
update blackbox exporter to create network policy

### DIFF
--- a/internal/controller/storagecluster/blackbox_exporter.go
+++ b/internal/controller/storagecluster/blackbox_exporter.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/multierr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,6 +110,10 @@ func (r *StorageClusterReconciler) deployBlackboxExporter(ctx context.Context, i
 		r.Log.Error(err, "unable to create service for blackbox metrics exporter")
 		return err
 	}
+	if err := r.createBlackboxNetworkPolicy(ctx, instance); err != nil {
+		r.Log.Error(err, "unable to create networkpolicy for blackbox metrics exporter")
+		return err
+	}
 	if err := r.createBlackboxProbe(ctx, instance, cephClusterNetwork); err != nil {
 		r.Log.Error(err, "unable to create probe for blackbox metrics exporter")
 		return err
@@ -123,6 +128,7 @@ func (r *StorageClusterReconciler) deleteBlackboxExporter(ctx context.Context, i
 	// Namespaced resources to delete using cached client
 	resources := []client.Object{
 		&monitoringv1.Probe{ObjectMeta: metav1.ObjectMeta{Name: blackboxExporterName, Namespace: instance.Namespace}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: blackboxExporterName, Namespace: instance.Namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: blackboxExporterName, Namespace: instance.Namespace}},
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: blackboxExporterName, Namespace: instance.Namespace}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: blackboxConfigMapName, Namespace: instance.Namespace}},
@@ -688,6 +694,94 @@ func (r *StorageClusterReconciler) createBlackboxService(ctx context.Context, in
 		r.Log.Info("Updated Service", "Service", actual.Name)
 	}
 
+	return nil
+}
+
+// createBlackboxNetworkPolicy creates or updates the NetworkPolicy for the blackbox exporter.
+func (r *StorageClusterReconciler) createBlackboxNetworkPolicy(ctx context.Context, instance *ocsv1.StorageCluster) error {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      blackboxExporterName,
+			Namespace: instance.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, networkPolicy, func() error {
+		networkPolicy.Labels = blackboxExporterLabels
+		if err := controllerutil.SetControllerReference(instance, networkPolicy, r.Scheme); err != nil {
+			return err
+		}
+
+		networkPolicy.Spec = networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: blackboxExporterLabels,
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					// Allow Prometheus (openshift-monitoring) to scrape probe results
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": "openshift-monitoring",
+								},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: ptr.To(corev1.ProtocolTCP),
+							Port:     ptr.To(intstr.FromInt32(blackboxPortNumber)),
+						},
+					},
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					// Allow ICMP to Ceph OSD and MON pods for latency probing.
+					// No ports field: NetworkPolicy port rules only support TCP/UDP/SCTP,
+					// so omitting ports allows all protocols including ICMP.
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": instance.Namespace,
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "rook-ceph-osd",
+								},
+							},
+						},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": instance.Namespace,
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "rook-ceph-mon",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create/update NetworkPolicy for blackbox exporter: %v", err)
+	}
+
+	r.Log.Info("Successfully created/updated NetworkPolicy for blackbox exporter", "Namespace", instance.Namespace, "Name", blackboxExporterName)
 	return nil
 }
 

--- a/internal/controller/storagecluster/blackbox_exporter_test.go
+++ b/internal/controller/storagecluster/blackbox_exporter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -461,4 +462,71 @@ func TestGetCephDaemonPodIPsFromNetworks(t *testing.T) {
 			assert.ElementsMatch(t, tt.expectedIPs, ips)
 		})
 	}
+}
+
+func TestCreateBlackboxNetworkPolicy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = ocsv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &StorageClusterReconciler{
+		Client: fakeClient,
+		Log:    log,
+		Scheme: scheme,
+	}
+
+	instance := &ocsv1.StorageCluster{
+		TypeMeta: metav1.TypeMeta{APIVersion: ocsv1.GroupVersion.String(), Kind: "StorageCluster"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocs-storagecluster",
+			Namespace: "openshift-storage",
+			UID:       "test-uid",
+		},
+	}
+
+	// First call: create
+	err := reconciler.createBlackboxNetworkPolicy(context.TODO(), instance)
+	require.NoError(t, err)
+
+	np := &networkingv1.NetworkPolicy{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: "openshift-storage",
+		Name:      blackboxExporterName,
+	}, np)
+	require.NoError(t, err)
+
+	// Labels
+	assert.Equal(t, blackboxExporterLabels, np.Labels)
+
+	// OwnerReference set by SetControllerReference
+	require.Len(t, np.OwnerReferences, 1)
+	assert.Equal(t, instance.Name, np.OwnerReferences[0].Name)
+	assert.Equal(t, instance.UID, np.OwnerReferences[0].UID)
+	require.NotNil(t, np.OwnerReferences[0].Controller)
+	assert.True(t, *np.OwnerReferences[0].Controller)
+
+	// PolicyTypes
+	assert.ElementsMatch(t, []networkingv1.PolicyType{
+		networkingv1.PolicyTypeIngress,
+		networkingv1.PolicyTypeEgress,
+	}, np.Spec.PolicyTypes)
+
+	// Ingress: Prometheus on TCP 9115
+	require.Len(t, np.Spec.Ingress, 1)
+	require.Len(t, np.Spec.Ingress[0].From, 1)
+	assert.Equal(t, "openshift-monitoring",
+		np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	require.Len(t, np.Spec.Ingress[0].Ports, 1)
+	assert.Equal(t, int32(blackboxPortNumber), np.Spec.Ingress[0].Ports[0].Port.IntVal)
+
+	// Egress: OSD + MON peers
+	require.Len(t, np.Spec.Egress, 1)
+	require.Len(t, np.Spec.Egress[0].To, 2)
+	assert.Equal(t, "rook-ceph-osd", np.Spec.Egress[0].To[0].PodSelector.MatchLabels["app"])
+	assert.Equal(t, "rook-ceph-mon", np.Spec.Egress[0].To[1].PodSelector.MatchLabels["app"])
+
+	// Second call: update path must succeed (ResourceVersion preserved)
+	err = reconciler.createBlackboxNetworkPolicy(context.TODO(), instance)
+	require.NoError(t, err, "second call (update) must not fail — ResourceVersion must be preserved")
 }


### PR DESCRIPTION
this updates the blackbox exporter to create
network policy

```
oc get networkpolicy odf-blackbox-exporter -n openshift-storage -o yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
spec:
  egress:
  - to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-storage
      podSelector:
        matchLabels:
          app: rook-ceph-osd
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-storage
      podSelector:
        matchLabels:
          app: rook-ceph-mon
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-monitoring
    ports:
    - port: 9115
      protocol: TCP
  podSelector:
    matchLabels:
      app: odf-blackbox-exporter
  policyTypes:
  - Ingress
  - Egress


CMP probe per target:
  $ oc exec -n openshift-storage odf-blackbox-exporter-65b74fc849-zg2bf -- wget -qO- --timeout=5 'http://localhost:9115/probe?target=10.128.4.6&module=icmp_internal'
  probe_success 1   # OSD

  $ oc exec ... target=10.131.0.31  → probe_success 1   # MON-a
  $ oc exec ... target=10.128.2.27  → probe_success 1   # MON-b
  $ oc exec ... target=10.129.2.22  → probe_success 1   # MON-c

  Prometheus metrics:
  $ oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- curl -s 'http://localhost:9090/api/v1/query?query=probe_success'
    10.131.0.31  probe_success=1 [OK]
    10.129.2.22  probe_success=1 [OK]
    10.128.2.27  probe_success=1 [OK]
    10.128.4.6   probe_success=1 [OK]

  $ ... query=probe_duration_seconds
    10.131.0.31  latency=2.45ms
    10.129.2.22  latency=0.28ms
    10.128.2.27  latency=2.90ms
    10.128.4.6   latency=6.05ms
```