### PR TITLE
grpc: only allow ingress from namespace clients

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -251,6 +251,17 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - noobaa.io
   resources:
   - noobaas

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -407,6 +407,17 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - noobaa.io
           resources:
           - noobaas

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -426,6 +426,17 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - noobaa.io
           resources:
           - noobaas

--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,12 +47,52 @@ func (o *ocsProviderServer) ensureCreated(r *StorageClusterReconciler, instance 
 		return res, err
 	}
 
+	if res, err := o.createNetworkPolicy(r, instance); err != nil || !res.IsZero() {
+		return res, err
+	}
+
 	if res, err := o.createDeployment(r, instance); err != nil || !res.IsZero() {
 		return res, err
 	}
 
 	if res, err := o.createJob(r, instance); err != nil || !res.IsZero() {
 		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (o *ocsProviderServer) createNetworkPolicy(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+	desiredService := GetProviderAPIServerService(instance)
+
+	networkPolicy := &networkingv1.NetworkPolicy{}
+	networkPolicy.Name = ocsProviderServerName
+	networkPolicy.Namespace = instance.Namespace
+
+	if err := r.Get(r.ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy); client.IgnoreNotFound(err) != nil {
+		r.Log.Error(err, "Failed to get networkpolicy", "Name", networkPolicy.Name)
+		return reconcile.Result{}, err
+	}
+
+	if desiredService.Spec.Type != corev1.ServiceTypeClusterIP {
+		if networkPolicy.UID != "" {
+			if err := r.Delete(r.ctx, networkPolicy); err != nil {
+				r.Log.Error(err, "Failed to delete networkpolicy", "Name", networkPolicy.Name)
+				return reconcile.Result{}, err
+			}
+		}
+		return reconcile.Result{}, nil
+	}
+
+	desiredNetworkPolicy := getProviderAPIServerNetworkPolicy(instance)
+
+	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, networkPolicy, func() error {
+		networkPolicy.Spec = desiredNetworkPolicy.Spec
+		return controllerutil.SetControllerReference(instance, networkPolicy, r.Client.Scheme())
+	})
+	if err != nil {
+		r.Log.Error(err, "Failed to create/update networkpolicy", "Name", desiredNetworkPolicy.Name)
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
@@ -67,8 +108,12 @@ func (o *ocsProviderServer) ensureDeleted(r *StorageClusterReconciler, instance 
 	apiServerService := &corev1.Service{}
 	apiServerService.Name = ocsProviderServerName
 	apiServerService.Namespace = instance.Namespace
+	apiServerNetworkPolicy := &networkingv1.NetworkPolicy{}
+	apiServerNetworkPolicy.Name = ocsProviderServerName
+	apiServerNetworkPolicy.Namespace = instance.Namespace
 	for _, resource := range []client.Object{
 		apiServerService,
+		apiServerNetworkPolicy,
 		GetProviderAPIServerDeployment(instance),
 	} {
 		err := r.Delete(r.ctx, resource)
@@ -365,6 +410,43 @@ func GetProviderAPIServerService(instance *ocsv1.StorageCluster) *corev1.Service
 				},
 			},
 			Type: serviceType,
+		},
+	}
+}
+
+func getProviderAPIServerNetworkPolicy(instance *ocsv1.StorageCluster) *networkingv1.NetworkPolicy {
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ocsProviderServerName,
+			Namespace: instance.Namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "ocsProviderApiServer",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": instance.Namespace,
+								},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: ptr.To(corev1.ProtocolTCP),
+							Port:     ptr.To(intstr.FromInt32(ocsProviderServicePort)),
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/internal/controller/storagecluster/provider_server_test.go
+++ b/internal/controller/storagecluster/provider_server_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -193,7 +194,67 @@ func TestOcsProviderServerEnsureCreated(t *testing.T) {
 		assert.NoError(t, r.Get(context.TODO(), client.ObjectKeyFromObject(service), service))
 		expectedService := GetClusterIPProviderAPIServerServiceForTest(instance)
 		assert.Equal(t, expectedService.Spec, service.Spec)
+
+		networkPolicy := &networkingv1.NetworkPolicy{}
+		networkPolicy.Name = ocsProviderServerName
+		assert.NoError(t, r.Get(context.TODO(), client.ObjectKeyFromObject(networkPolicy), networkPolicy))
+		expectedNetworkPolicy := getProviderAPIServerNetworkPolicy(instance)
+		assert.Equal(t, expectedNetworkPolicy.Spec, networkPolicy.Spec)
 	})
+
+	t.Run("NetworkPolicy is not created when ProviderAPIServerServiceType is not ClusterIP", func(t *testing.T) {
+
+		r, instance := createSetupForOcsProviderTest(t, corev1.ServiceTypeLoadBalancer)
+
+		obj := &ocsProviderServer{}
+		res, err := obj.ensureCreated(r, instance)
+		assert.NoError(t, err)
+		assert.False(t, res.IsZero())
+
+		service := &corev1.Service{}
+		service.Name = ocsProviderServerName
+		service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+			{
+				Hostname: "fake",
+			},
+		}
+		err = r.Status().Update(context.TODO(), service)
+		assert.NoError(t, err)
+
+		res, err = obj.ensureCreated(r, instance)
+		assert.NoError(t, err)
+		assert.False(t, res.IsZero())
+
+		deployment := &appsv1.Deployment{}
+		deployment.Name = ocsProviderServerName
+		deployment.Status.AvailableReplicas = 1
+		err = r.Status().Update(context.TODO(), deployment)
+		assert.NoError(t, err)
+
+		res, err = obj.ensureCreated(r, instance)
+		assert.NoError(t, err)
+		assert.True(t, res.IsZero())
+
+		networkPolicy := &networkingv1.NetworkPolicy{}
+		networkPolicy.Name = ocsProviderServerName
+		assert.True(t, errors.IsNotFound(r.Get(context.TODO(), client.ObjectKeyFromObject(networkPolicy), networkPolicy)))
+	})
+
+	t.Run("NetworkPolicy is not created when service type is not ClusterIP after being created", func(t *testing.T) {
+
+		r, instance := createSetupForOcsProviderTest(t, corev1.ServiceTypeLoadBalancer)
+
+		obj := &ocsProviderServer{}
+		res, err := obj.createNetworkPolicy(r, instance)
+		assert.NoError(t, err)
+		assert.True(t, res.IsZero())
+
+		networkPolicy := &networkingv1.NetworkPolicy{}
+		networkPolicy.Name = ocsProviderServerName
+		networkPolicy.Namespace = instance.Namespace
+		assert.True(t, errors.IsNotFound(r.Get(context.TODO(), client.ObjectKeyFromObject(networkPolicy), networkPolicy)))
+	})
+
 
 }
 
@@ -215,15 +276,17 @@ func TestOcsProviderServerEnsureDeleted(t *testing.T) {
 
 func assertNotFoundProviderResources(t *testing.T, cli client.Client) {
 
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: ocsProviderServerName},
-	}
+	deployment := &appsv1.Deployment{}
+	deployment.Name = ocsProviderServerName
 	assert.True(t, errors.IsNotFound(cli.Get(context.TODO(), client.ObjectKeyFromObject(deployment), deployment)))
 
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: ocsProviderServerName},
-	}
+	service := &corev1.Service{}
+	service.Name = ocsProviderServerName
 	assert.True(t, errors.IsNotFound(cli.Get(context.TODO(), client.ObjectKeyFromObject(service), service)))
+
+	networkPolicy := &networkingv1.NetworkPolicy{}
+	networkPolicy.Name = ocsProviderServerName
+	assert.True(t, errors.IsNotFound(cli.Get(context.TODO(), client.ObjectKeyFromObject(networkPolicy), networkPolicy)))
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: ocsProviderServerName},
@@ -264,6 +327,7 @@ func createSetupForOcsProviderTest(t *testing.T, providerAPIServerServiceType co
 		Client:   fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(node, clientConfigMap).Build(),
 		Scheme:   scheme,
 		Log:      logf.Log.WithName("controller_storagecluster_test"),
+		ctx:      context.TODO(),
 	}
 
 	instance := &ocsv1.StorageCluster{
@@ -445,3 +509,4 @@ func GetClusterIPProviderAPIServerServiceForTest(instance *ocsv1.StorageCluster)
 		},
 	}
 }
+

--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -102,6 +102,7 @@ var storageClusterFinalizer = "storagecluster.ocs.openshift.io"
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=watch;create;update;delete;get;list
 // +kubebuilder:rbac:groups=core,resources=pods;services;serviceaccounts;endpoints;persistentvolumes;persistentvolumeclaims;events;configmaps;secrets;nodes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,verbs=get;create
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;probes;prometheusrules,verbs=get;list;watch;create;update;delete

--- a/internal/controller/storagecluster/storagecluster_controller.go
+++ b/internal/controller/storagecluster/storagecluster_controller.go
@@ -26,6 +26,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -293,6 +294,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.PersistentVolumeClaim{}, builder.WithPredicates(pvcPredicate)).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&networkingv1.NetworkPolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.ConfigMap{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&routev1.Route{}).

--- a/internal/controller/storagecluster/storagecluster_controller_test.go
+++ b/internal/controller/storagecluster/storagecluster_controller_test.go
@@ -38,6 +38,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1266,6 +1267,11 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 	err = appsv1.AddToScheme(scheme)
 	if err != nil {
 		assert.Fail(t, "failed to add appsv1 scheme")
+	}
+
+	err = networkingv1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add networkingv1 scheme")
 	}
 
 	err = quotav1.AddToScheme(scheme)


### PR DESCRIPTION
when the provider api server is exposed on clusterip no other client outside of current namespace requires ingress and this effectively locks down traffic from other namespaces.
