### PR TITLE
DFBUGS-9402: [release-4.22] Increase 'CephxKeyGenerationFailed' alert's trigger time

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -797,6 +797,6 @@ spec:
         storage_type: ceph
       expr: |
         ocs_cephx_daemon_key_rotation_mismatch{job="ocs-metrics-exporter"} == 1
-      for: 5m
+      for: 1h
       labels:
         severity: warning


### PR DESCRIPTION
According to the discussion, we should not be triggering this alert in a large cluster where it takes some time for the keyrotation to complete. The existing '5m' is very low. So increasing the time to 1 hour.