### PR TITLE
Fix StorageCluster retaining stale negative conditions after recovery

### DIFF
--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -681,26 +681,27 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			}
 		}
 	} else {
-		// If any component operator reports negatively we want to write that to
-		// the instance while preserving it's lastTransitionTime.
-		// For example, consider the resource has the Available condition
-		// type with type "False". When reconciling the resource we would
-		// add it to the in-memory representation of OCS's conditions (r.conditions)
-		// and here we are simply writing it back to the server.
+
+		// Component mappers only emit negatives
+		// Without clearing unreported types, old errors can remain on status.
+		// Example: Ceph recovered but Noobaa is still Progressing.
+		// Reset healthy defaults for types not in r.conditions.
+		// Then apply the negatives from this reconcile.
+		// This clears recovered conditions while keeping active failures.
+
+		reason := ocsv1.ReconcileCompleted
+		message := ocsv1.ReconcileCompletedMessage
+		util.ResetUnreportedStandardConditions(&instance.Status.Conditions, r.conditions, reason, message)
+
+		// Merge negatives from r.conditions and write them back to the server.
+		// SetStatusCondition does not change lastTransitionTime if the status value is unchanged.
 		// One shortcoming is that only one failure of a particular condition can be
 		// captured at one time (ie. if resource1 and resource2 are both reporting !Available,
 		// you will only see resource2q as it updates last).
+
 		for _, condition := range r.conditions {
 			conditionsv1.SetStatusCondition(&instance.Status.Conditions, condition)
 		}
-		reason := ocsv1.ReconcileCompleted
-		message := ocsv1.ReconcileCompletedMessage
-		conditionsv1.SetStatusCondition(&instance.Status.Conditions, conditionsv1.Condition{
-			Type:    ocsv1.ConditionReconcileComplete,
-			Status:  corev1.ConditionTrue,
-			Reason:  reason,
-			Message: message,
-		})
 
 		// If for any reason we marked ourselves !upgradeable...then unset readiness
 		if conditionsv1.IsStatusConditionFalse(instance.Status.Conditions, conditionsv1.ConditionUpgradeable) {

--- a/internal/controller/storagecluster/storagecluster_controller_test.go
+++ b/internal/controller/storagecluster/storagecluster_controller_test.go
@@ -970,6 +970,67 @@ func TestStorageClusterInitConditions(t *testing.T) {
 	assertExpectedCondition(t, actual.Status.Conditions)
 }
 
+// stale Ceph error conditions must clear after Ceph recovers
+// even when another component (Noobaa) still reports Progressing; phase must not be Error.
+func TestStorageClusterClearsStaleCephConditions(t *testing.T) {
+	testSkipPrometheusRules = true
+
+	cephErrorMessage := "CephCluster error"
+
+	cc := &rookCephv1.CephCluster{}
+	mockCephCluster.DeepCopyInto(cc)
+	nodeList := &corev1.NodeList{}
+	mockNodeList.DeepCopyInto(nodeList)
+	cc.Status.State = rookCephv1.ClusterStateCreated
+	cc.Status.CephStatus = &rookCephv1.CephStatus{
+		Health: "HealthOK",
+	}
+
+	sc := mockStorageCluster.DeepCopy()
+	sc.Status.DefaultCephDeviceClass = "ssd"
+	sc.Status.Phase = api.PhaseError
+	sc.Status.Conditions = []conditionsv1.Condition{
+		{
+			Type:    conditionsv1.ConditionAvailable,
+			Status:  corev1.ConditionFalse,
+			Reason:  "ClusterStateError",
+			Message: cephErrorMessage,
+		},
+		{
+			Type:    conditionsv1.ConditionDegraded,
+			Status:  corev1.ConditionTrue,
+			Reason:  "ClusterStateError",
+			Message: cephErrorMessage,
+		},
+	}
+
+	reconciler := createFakeStorageClusterReconciler(t, sc, cc, nodeList, networkConfig)
+	result, err := reconciler.Reconcile(context.TODO(), mockStorageClusterRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	actual := &api.StorageCluster{}
+	err = reconciler.Get(context.TODO(), mockStorageClusterRequest.NamespacedName, actual)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actual.Status.Conditions)
+	assert.Len(t, actual.Status.Conditions, 6)
+	assert.Equal(t, api.PhaseProgressing, actual.Status.Phase)
+
+	assertExpectedCondition(t, actual.Status.Conditions)
+
+	available := conditionsv1.FindStatusCondition(actual.Status.Conditions, conditionsv1.ConditionAvailable)
+	assert.NotNil(t, available)
+	assert.NotEqual(t, "ClusterStateError", available.Reason)
+
+	degraded := conditionsv1.FindStatusCondition(actual.Status.Conditions, conditionsv1.ConditionDegraded)
+	assert.NotNil(t, degraded)
+	assert.NotEqual(t, "ClusterStateError", degraded.Reason)
+
+	progressing := conditionsv1.FindStatusCondition(actual.Status.Conditions, conditionsv1.ConditionProgressing)
+	assert.NotNil(t, progressing)
+	assert.Equal(t, "NoobaaInitializing", progressing.Reason)
+}
+
 func TestStorageClusterFinalizer(t *testing.T) {
 	// TODO (leelavg): revisit after convergence
 	t.Skip("this test is flaky as even without new updates it fails occasionally")
@@ -1046,7 +1107,7 @@ func TestStorageClusterFinalizer(t *testing.T) {
 func assertExpectedCondition(t *testing.T, conditions []conditionsv1.Condition) {
 	expectedConditions := map[conditionsv1.ConditionType]corev1.ConditionStatus{
 		api.ConditionReconcileComplete:    corev1.ConditionTrue,
-		conditionsv1.ConditionAvailable:   corev1.ConditionFalse,
+		conditionsv1.ConditionAvailable:   corev1.ConditionTrue,
 		conditionsv1.ConditionProgressing: corev1.ConditionTrue,
 		conditionsv1.ConditionDegraded:    corev1.ConditionFalse,
 		conditionsv1.ConditionUpgradeable: corev1.ConditionFalse,

--- a/pkg/util/status.go
+++ b/pkg/util/status.go
@@ -103,6 +103,36 @@ func SetCompleteCondition(conditions *[]conditionsv1.Condition, reason string, m
 	})
 }
 
+// ResetUnreportedStandardConditions resets unreported standard condition types to healthy defaults.
+// Only ReconcileComplete, Available, Progressing, and Degraded are reset here.
+// Upgradeable is handled separately based on cluster readiness.
+// Reported types that are still negative are not changed.
+// Recovered conditions are cleared.
+// lastTransitionTime for active failures does not change.
+func ResetUnreportedStandardConditions(conditions *[]conditionsv1.Condition, reportedNegatives []conditionsv1.Condition, reason string, message string) {
+	reported := make(map[conditionsv1.ConditionType]struct{}, len(reportedNegatives))
+	for _, c := range reportedNegatives {
+		reported[c.Type] = struct{}{}
+	}
+
+	setIfNotReported := func(conditionType conditionsv1.ConditionType, status corev1.ConditionStatus) {
+		if _, ok := reported[conditionType]; ok {
+			return
+		}
+		conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
+			Type:    conditionType,
+			Status:  status,
+			Reason:  reason,
+			Message: message,
+		})
+	}
+
+	setIfNotReported(ocsv1.ConditionReconcileComplete, corev1.ConditionTrue)
+	setIfNotReported(conditionsv1.ConditionAvailable, corev1.ConditionTrue)
+	setIfNotReported(conditionsv1.ConditionProgressing, corev1.ConditionFalse)
+	setIfNotReported(conditionsv1.ConditionDegraded, corev1.ConditionFalse)
+}
+
 // MapCephClusterNegativeConditions maps the status states from CephCluster resource into ocs status conditions.
 // This will only look for negative conditions: !Available, Degraded, Progressing
 func MapCephClusterNegativeConditions(conditions *[]conditionsv1.Condition, found *cephv1.CephCluster) {


### PR DESCRIPTION
[DFBUGS-9427](https://redhat.atlassian.net/browse/DFBUGS-9427)
**Root Cause:**
Component mappers only emit negatives, and reconcile merged them into StorageCluster status without clearing conditions that had recovered.
After a transient CephCluster Error, Available=False / Degraded=True could stay on the CR even once Ceph was healthy again, as long as any other component still reported a negative (e.g. Noobaa Progressing).
That left the StorageCluster stuck in Error phase with a stale Ceph failure, instead of reflecting the current state (e.g. Progressing while Noobaa initializes).

**What this fix does**
Reset healthy defaults only for standard condition types not reported in r.conditions, then apply the negatives from the current reconcile. Recovered conditions are cleared; active ones keep their reason, message, and lastTransitionTime. Phase follows the resulting conditions (Degraded → Error, Progressing / !Available → Progressing, otherwise Ready), so a recovered Ceph failure no longer keeps the cluster in Error.