### PR TITLE
Speed up iterative local Docker image rebuilds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# VCS
+.git
+.gitignore
+
+# Local build artifacts
+bin/
+_cache/
+_output/
+build/_output/
+.metrics-devel-container-id
+
+# Vendored dependencies (not used)
+vendor/
+
+# Dev/test tooling and docs not required for image builds
+tools/
+functests/
+docs/
+.github/
+
+# Test binaries
+*.test
+
+# Editor/IDE
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,24 @@ FROM docker.io/library/golang:1.26 AS builder
 
 WORKDIR /workspace
 
+# Cache module downloads in a separate layer.
+COPY go.mod go.sum go.work ./
+COPY api/go.mod api/go.sum ./api/
+COPY metrics/go.mod metrics/go.sum ./metrics/
+COPY services/provider/api/go.mod services/provider/api/go.sum ./services/provider/api/
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go work sync && \
+    go mod download
+
 COPY . .
 
 ARG LDFLAGS
 
-RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o ocs-operator cmd/main.go
-RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o provider-api services/provider/main.go
-RUN go build -tags netgo,osusergo -o onboarding-validation-keys-gen onboarding-validation-keys-generator/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o ocs-operator cmd/main.go && \
+    go build -ldflags "$LDFLAGS" -tags netgo,osusergo -o provider-api services/provider/main.go && \
+    go build -tags netgo,osusergo -o onboarding-validation-keys-gen onboarding-validation-keys-generator/main.go
 
 # Build stage 2
 

--- a/hack/docker-common.sh
+++ b/hack/docker-common.sh
@@ -15,4 +15,10 @@ if [ -z "$IMAGE_BUILD_CMD" ]; then
     exit 1
 fi
 
+# Dockerfile cache mounts (RUN --mount=type=cache) require BuildKit on Docker.
+# Podman supports the same syntax natively; no equivalent env var is needed.
+if [[ "$(basename "${IMAGE_BUILD_CMD}")" == docker ]]; then
+    export DOCKER_BUILDKIT=1
+fi
+
 IMAGE_RUN_CMD="${IMAGE_RUN_CMD:-${IMAGE_BUILD_CMD} run --rm -it}"

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -39,11 +39,22 @@ ENV GOROOT=${GOROOT} \
 
 WORKDIR /workspace
 
+# Cache module downloads in a separate layer.
+COPY go.mod go.sum go.work ./
+COPY api/go.mod api/go.sum ./api/
+COPY metrics/go.mod metrics/go.sum ./metrics/
+COPY services/provider/api/go.mod services/provider/api/go.sum ./services/provider/api/
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go work sync && \
+    go mod download
+
 COPY . .
 
 ARG LDFLAGS
 
-RUN go build -ldflags "$LDFLAGS" -tags netgo,osusergo,${CEPH_VERSION} -o metrics-exporter ./metrics/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go build -ldflags "$LDFLAGS" -tags netgo,osusergo,${CEPH_VERSION} -o metrics-exporter ./metrics/main.go
 
 # Build stage 2
 


### PR DESCRIPTION
## Summary
- Isolate Go module downloads in a separate Dockerfile layer so local rebuilds skip `go mod download` when `go.mod`/`go.work` are unchanged
- Use BuildKit cache mounts for `/go/pkg/mod` to reuse downloaded modules across rebuilds
- Add `.dockerignore` to shrink the Docker build context, which also speeds up first-time builds (including CI) by excluding `vendor/`, `.git/`, and other files not needed for the image

The layer splitting and cache mounts mainly benefit iterative local rebuilds. Cold CI builds still download and compile dependencies each run, but benefit from the smaller build context.

## Test plan
- [x] `make ocs-operator` (Docker image build succeeds)
- [x] `make ocs-metrics-exporter` (metrics image build succeeds)