### PR TITLE
fix: add missing fsName parameter to NFS VolumeGroupSnapshotClass

### DIFF
--- a/pkg/util/groupsnapshotclasses.go
+++ b/pkg/util/groupsnapshotclasses.go
@@ -89,6 +89,7 @@ func NewDefaultNfsGroupSnapshotClass(
 	clusterID,
 	provisionerSecret,
 	namespace,
+	fsName,
 	storageId string,
 ) *groupsnapapi.VolumeGroupSnapshotClass {
 
@@ -102,6 +103,7 @@ func NewDefaultNfsGroupSnapshotClass(
 			"clusterID": clusterID,
 			"csi.storage.k8s.io/group-snapshotter-secret-name":      provisionerSecret,
 			"csi.storage.k8s.io/group-snapshotter-secret-namespace": namespace,
+			"fsName": fsName,
 		},
 		DeletionPolicy: snapapi.VolumeSnapshotContentDelete,
 	}

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -2227,6 +2227,7 @@ func (s *OCSProviderServer) appendVolumeGroupSnapshotClassKubeResources(
 				consumerConfig.GetNfsClientProfileName(),
 				consumerConfig.GetCsiNfsProvisionerCephUserName(),
 				consumer.Status.Client.OperatorNamespace,
+				util.GenerateNameForCephFilesystem(storageCluster.Name),
 				cephFsStorageId,
 			)
 		}


### PR DESCRIPTION
The NFS group snapshot class was missing the required fsName parameter, causing group snapshot creation to fail with "missing or empty fsName".