### PR TITLE
nvmeof: use shared client profile for internal consumer

### DIFF
--- a/internal/controller/storagecluster/storageconsumer.go
+++ b/internal/controller/storagecluster/storageconsumer.go
@@ -142,12 +142,15 @@ func (s *storageConsumer) ensureCreated(r *StorageClusterReconciler, storageClus
 			resourceMap.ReplaceRbdClientProfileName("openshift-storage")
 			resourceMap.ReplaceCephFsClientProfileName("openshift-storage")
 			resourceMap.ReplaceNfsClientProfileName("openshift-storage")
+			resourceMap.ReplaceNvmeofClientProfileName("openshift-storage")
 			resourceMap.ReplaceCsiRbdNodeCephUserName("rook-csi-rbd-node")
 			resourceMap.ReplaceCsiRbdProvisionerCephUserName("rook-csi-rbd-provisioner")
 			resourceMap.ReplaceCsiCephFsNodeCephUserName("rook-csi-cephfs-node")
 			resourceMap.ReplaceCsiCephFsProvisionerCephUserName("rook-csi-cephfs-provisioner")
 			resourceMap.ReplaceCsiNfsNodeCephUserName("rook-csi-nfs-node")
 			resourceMap.ReplaceCsiNfsProvisionerCephUserName("rook-csi-nfs-provisioner")
+			resourceMap.ReplaceCsiNvmeofNodeCephUserName("rook-csi-nvmeof-node")
+			resourceMap.ReplaceCsiNvmeofProvisionerCephUserName("rook-csi-nvmeof-provisioner")
 		} else {
 			backwardCompatibleInfo := &util.BackwardCompatabilityInfo{}
 			if err := json.Unmarshal([]byte(backwardCompatibleValue), backwardCompatibleInfo); err != nil {


### PR DESCRIPTION
NVMeoF was using the `storageConsumer` UID as its `ClientProfile` name, creating a separate `ceph-csi-config` entry. During teardown, this entry was deleted along with the `ClientProfile`, leaving PVs unable to resolve their `clusterID` for deletion.

Align NVMeoF with `RBD/CephFS/NFS` by using the shared "openshift-storage" `ClientProfile`. This ensures the `ceph-csi-config` entry persists during NVMeoF teardown, allowing PV cleanup to complete.

Tested on private image `quay.io/oviner/ocs-operator:nvmeof-5`
```
Test Procedure – NVMeoF Enable/Disable with Graceful Teardown
=============================================================

1. Enable NVMeoF via StorageCluster
   $ oc patch storagecluster ocs-storagecluster -n openshift-storage --type merge \
     -p '{"spec":{"nvmeof":{"enable":true}}}'
   Wait for StorageClass, Driver CR, CSI pods, and NVMeoF gateways to come up:
   $ oc get sc ocs-storagecluster-ceph-nvmeof
   $ oc get driver openshift-storage.nvmeof.csi.ceph.com -n openshift-storage
   $ oc get pods -n openshift-storage | grep nvmeof

2. Create PVCs + Pod + Run IO
   $ oc apply -f - <<EOF
   apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: nvmeof-pvc-1
     namespace: openshift-storage
   spec:
     accessModes: [ReadWriteOnce]
     resources:
       requests:
         storage: 2Gi
     storageClassName: ocs-storagecluster-ceph-nvmeof
   ---
   apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: nvmeof-pvc-2
     namespace: openshift-storage
   spec:
     accessModes: [ReadWriteOnce]
     resources:
       requests:
         storage: 2Gi
     storageClassName: ocs-storagecluster-ceph-nvmeof
   ---
   apiVersion: v1
   kind: Pod
   metadata:
     name: nvmeof-io-test
     namespace: openshift-storage
   spec:
     containers:
     - name: io-test
       image: registry.access.redhat.com/ubi9/ubi-minimal
       command: ["/bin/sh", "-c"]
       args:
       - |
         while true; do
           dd if=/dev/urandom of=/mnt/data1/testfile bs=1M count=10 conv=fsync 2>&1
           dd if=/dev/urandom of=/mnt/data2/testfile bs=1M count=10 conv=fsync 2>&1
           sleep 5
         done
       volumeMounts:
       - {name: vol1, mountPath: /mnt/data1}
       - {name: vol2, mountPath: /mnt/data2}
     volumes:
     - {name: vol1, persistentVolumeClaim: {claimName: nvmeof-pvc-1}}
     - {name: vol2, persistentVolumeClaim: {claimName: nvmeof-pvc-2}}
   EOF
   Verify PVCs are Bound and IO is running:
   $ oc get pvc -n openshift-storage | grep nvmeof
   $ oc logs nvmeof-io-test -n openshift-storage --tail=5

3. Disable NVMeoF via StorageCluster (while PVCs + Pod still exist)
   $ oc patch storagecluster ocs-storagecluster -n openshift-storage --type merge \
     -p '{"spec":{"nvmeof":{"enable":false}}}'

4. Verify only StorageClass is deleted — existing workloads are NOT disrupted
   StorageClass should be gone (prevents new NVMeoF PVC creation):
   $ oc get sc ocs-storagecluster-ceph-nvmeof
     → Expected: NotFound

   Everything else must still exist:
   $ oc get pvc -n openshift-storage | grep nvmeof
     → Expected: nvmeof-pvc-1 and nvmeof-pvc-2 in Bound state
   $ oc get pv | grep nvmeof
     → Expected: both PVs in Bound state
   $ oc get pod nvmeof-io-test -n openshift-storage
     → Expected: Running, IO continues without interruption
   $ oc get driver openshift-storage.nvmeof.csi.ceph.com -n openshift-storage
     → Expected: still present (CSI driver kept alive for existing volumes)
   $ oc get pods -n openshift-storage | grep nvmeof.csi
     → Expected: ctrlplugin + nodeplugin pods still Running
   $ oc get cephblockpool -n openshift-storage | grep nvmeof
     → Expected: builtin-nvmeof and ocs-storagecluster-nvmeof in Ready state
   $ oc get cephnvmeofgateway -n openshift-storage
     → Expected: nvmeof-gw in Ready state

5. Delete the Pod + PVCs (user-initiated cleanup)
   $ oc delete pod nvmeof-io-test -n openshift-storage
   $ oc delete pvc nvmeof-pvc-1 nvmeof-pvc-2 -n openshift-storage
   Verify PVs are automatically cleaned up (ReclaimPolicy: Delete):
   $ oc get pv | grep nvmeof
     → Expected: PVs transition to Released and then get deleted

6. Verify full teardown — GW pods, CSI pods, and pools are cleaned up
   Once all PVCs/PVs are gone, the operator completes the teardown:
   $ oc get cephnvmeofgateway -n openshift-storage
     → Expected: NotFound
   $ oc get pods -n openshift-storage | grep nvmeof
     → Expected: no nvmeof CSI or gateway pods
   $ oc get driver openshift-storage.nvmeof.csi.ceph.com -n openshift-storage
     → Expected: NotFound
   $ oc get cephblockpool -n openshift-storage | grep nvmeof
     → Expected: no nvmeof pools
```