### PR TITLE
ceph: wait for the cephcluster to be health ok before creating pools

### DIFF
--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -402,6 +402,11 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		sc.Status.DefaultCephDeviceClass = determineDefaultCephDeviceClass(found.Status.CephStorage.DeviceClasses, sc.Spec.ManagedResources.CephNonResilientPools.Enable, sc.Status.FailureDomainValues)
 	}
 
+	if !sc.Spec.ExternalStorage.Enable && (found.Status.CephStatus == nil || sc.Status.DefaultCephDeviceClass == "") {
+		r.Log.Info("Waiting on CephCluster to initialise device classes.", "CephCluster", klog.KRef(found.Namespace, found.Name))
+		return reconcile.Result{}, fmt.Errorf("CephCluster didn't initialise the device class ")
+	}
+
 	// Update the currentMonCount field in StoragCluster status from the cephCluster CR
 	if !sc.Spec.ExternalStorage.Enable {
 		sc.Status.CurrentMonCount = cephCluster.Spec.Mon.Count

--- a/internal/controller/storagecluster/cephcluster_test.go
+++ b/internal/controller/storagecluster/cephcluster_test.go
@@ -57,6 +57,7 @@ func TestEnsureCephCluster(t *testing.T) {
 		},
 		{
 			label:            "Reconcile CephCluster not reporting state",
+			shouldCreate:     true,
 			cephClusterState: "",
 		},
 		{
@@ -90,12 +91,16 @@ func TestEnsureCephCluster(t *testing.T) {
 		sc := &ocsv1.StorageCluster{}
 		mockStorageCluster.DeepCopyInto(sc)
 		sc.Status.Images.Ceph = &ocsv1.ComponentImageStatus{}
+		sc.Status.DefaultCephDeviceClass = "ssd"
 
 		reconciler := createFakeStorageClusterReconciler(t, networkConfig)
 
 		expected := newCephCluster(reconciler, mockStorageCluster.DeepCopy(), nil)
 		expected.Spec.Network.IPFamily = rookCephv1.IPv4
 		expected.Status.State = c.cephClusterState
+		expected.Status.CephStatus = &rookCephv1.CephStatus{
+			Health: "HealthOK",
+		}
 
 		if c.shouldCreate {
 			majorAndMinorVersion, err := version.GetMajorAndMinorVersion()
@@ -270,6 +275,7 @@ func TestSetCephXFeaturesSpec(t *testing.T) {
 }
 
 func TestCephClusterMonTimeout(t *testing.T) {
+	testSkipPrometheusRules = true
 	// cases for testing
 	cases := []struct {
 		label    string
@@ -292,8 +298,11 @@ func TestCephClusterMonTimeout(t *testing.T) {
 		sc := &ocsv1.StorageCluster{}
 		mockStorageCluster.DeepCopyInto(sc)
 		sc.Status.Images.Ceph = &ocsv1.ComponentImageStatus{}
+		sc.Status.DefaultCephDeviceClass = "ssd"
 
-		reconciler := createFakeStorageClusterReconciler(t, mockCephCluster.DeepCopy(), networkConfig)
+		mockCC := mockCephCluster.DeepCopy()
+		mockCC.Status.CephStatus = &rookCephv1.CephStatus{Health: "HEALTH_OK"}
+		reconciler := createFakeStorageClusterReconciler(t, mockCC, networkConfig)
 		var obj ocsCephCluster
 		_, err := obj.ensureCreated(reconciler, sc)
 		assert.NilError(t, err)
@@ -1880,11 +1889,13 @@ func TestEnsureRDRMigration(t *testing.T) {
 	sc := &ocsv1.StorageCluster{}
 	mockStorageCluster.DeepCopyInto(sc)
 	sc.Status.Images.Ceph = &ocsv1.ComponentImageStatus{}
+	sc.Status.DefaultCephDeviceClass = "ssd"
 	reconciler := createFakeStorageClusterReconciler(t, networkConfig)
 
 	expected := newCephCluster(reconciler, mockStorageCluster.DeepCopy(), nil)
 
 	expected.Spec.Storage.Store.Type = string(rookCephv1.StoreTypeBlueStoreRDR)
+	expected.Status.CephStatus = &rookCephv1.CephStatus{Health: "HEALTH_OK"}
 	err := reconciler.Create(context.TODO(), expected)
 	assert.NilError(t, err)
 

--- a/internal/controller/storagecluster/storagecluster_controller_test.go
+++ b/internal/controller/storagecluster/storagecluster_controller_test.go
@@ -719,9 +719,12 @@ func TestNonWatchedReconcileWithTheCephClusterType(t *testing.T) {
 	cc := &rookCephv1.CephCluster{}
 	mockCephCluster.DeepCopyInto(cc)
 	cc.Status.State = rookCephv1.ClusterStateCreated
+	cc.Status.CephStatus = &rookCephv1.CephStatus{
+		Health: "HealthOK",
+	}
 	sc := &api.StorageCluster{}
 	mockStorageCluster.DeepCopyInto(sc)
-
+	sc.Status.DefaultCephDeviceClass = "ssd"
 	reconciler := createFakeStorageClusterReconciler(t, sc, cc, nodeList, networkConfig)
 	result, err := reconciler.Reconcile(context.TODO(), mockStorageClusterRequest)
 	assert.NoError(t, err)
@@ -947,8 +950,13 @@ func TestStorageClusterInitConditions(t *testing.T) {
 	nodeList := &corev1.NodeList{}
 	mockNodeList.DeepCopyInto(nodeList)
 	cc.Status.State = rookCephv1.ClusterStateCreated
+	cc.Status.CephStatus = &rookCephv1.CephStatus{
+		Health: "HealthOK",
+	}
 
-	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster.DeepCopy(), cc, nodeList, networkConfig)
+	sc := mockStorageCluster.DeepCopy()
+	sc.Status.DefaultCephDeviceClass = "ssd"
+	reconciler := createFakeStorageClusterReconciler(t, sc, cc, nodeList, networkConfig)
 	result, err := reconciler.Reconcile(context.TODO(), mockStorageClusterRequest)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
@@ -1041,7 +1049,7 @@ func assertExpectedCondition(t *testing.T, conditions []conditionsv1.Condition) 
 		conditionsv1.ConditionAvailable:   corev1.ConditionFalse,
 		conditionsv1.ConditionProgressing: corev1.ConditionTrue,
 		conditionsv1.ConditionDegraded:    corev1.ConditionFalse,
-		conditionsv1.ConditionUpgradeable: corev1.ConditionUnknown,
+		conditionsv1.ConditionUpgradeable: corev1.ConditionFalse,
 		api.ConditionVersionMismatch:      corev1.ConditionFalse,
 	}
 	for cType, status := range expectedConditions {


### PR DESCRIPTION

Currently, we don't wait for the Ceph health to be okay before proceeding, which creates the pool with an empty device class
and later it reconcile it updates the pool, and updates the device class, which is not allowed by Rook as it can harm data
So lets wait for the Ceph cluster to be health ok before proceeding