### PR TITLE
Skip local StorageConsumer in unsupported client count for upgradability

### DIFF
--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -1064,7 +1064,8 @@ func getUnsupportedClientsCount(r *StorageClusterReconciler, namespace string) (
 	var count int
 	providerVersion, _ := semver.Make(version.Version)
 	for idx := range scList.Items {
-		if scList.Items[idx].Status.Client != nil {
+		// Local client operator subscription is managed by ODF operator; exclude it from this check.
+		if scList.Items[idx].GetName() != defaults.LocalStorageConsumerName && scList.Items[idx].Status.Client != nil {
 			clientVersion, err := semver.Make(scList.Items[idx].Status.Client.OperatorVersion)
 			if err == nil {
 				if providerVersion.Major != clientVersion.Major || providerVersion.Minor > clientVersion.Minor {


### PR DESCRIPTION
On local clusters, ODF operator controls all the subscriptions together and upgrades all subscriptions together, including the client operator. Sometimes the client operator can finish before ocs-operator, which makes the unsupported client version check treats the local StorageConsumer as out of sync and block the upgrade with no recovery path. So exclude the local StorageConsumer from this count.