### PR TITLE
remove unused rook-ceph-csi SCC creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/ceph/ceph-csi-operator/api v0.0.0-20260720045108-15b278476fc9
-	github.com/ceph/ceph-csi/api v0.0.0-20260414210325-d6f0ea81b6d4
 	github.com/csi-addons/kubernetes-csi-addons v0.14.0
 	github.com/go-logr/logr v1.4.4
 	github.com/google/go-cmp v0.7.0
@@ -71,7 +70,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.23.1 // indirect
@@ -148,7 +146,6 @@ require (
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.36.3 // indirect
 	k8s.io/component-base v0.36.3 // indirect
 	k8s.io/kube-aggregator v0.36.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,6 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/ceph/ceph-csi-operator/api v0.0.0-20260720045108-15b278476fc9 h1:wXvtb1XT8SVf2V1VLQETVeKtzt+aVJaldjtuXugBmcI=
 github.com/ceph/ceph-csi-operator/api v0.0.0-20260720045108-15b278476fc9/go.mod h1:hVNR0YmP/mODVmwLV/SCCIMGz7cktxFGJpOwCxJYPf8=
-github.com/ceph/ceph-csi/api v0.0.0-20260414210325-d6f0ea81b6d4 h1:A/JW0sO9hDLRotdbw4o4VDT0y2FAKKjeMK2CDsLiJMI=
-github.com/ceph/ceph-csi/api v0.0.0-20260414210325-d6f0ea81b6d4/go.mod h1:eBCXn6Ry8pB90jD2LY4wNiBHmc35x9AV8Q2doUR+0GU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -236,7 +234,6 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
@@ -1535,7 +1532,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/controller/ocsinitialization/sccs.go
+++ b/internal/controller/ocsinitialization/sccs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	cephcsi "github.com/ceph/ceph-csi/api/deploy/ocp"
 	secv1 "github.com/openshift/api/security/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -44,7 +43,6 @@ func (r *OCSInitializationReconciler) ensureSCCs(initialData *ocsv1.OCSInitializ
 func getAllSCCs(namespace string) []*secv1.SecurityContextConstraints {
 	return []*secv1.SecurityContextConstraints{
 		newRookCephSCC(namespace),
-		newRookCephCSISCC(namespace),
 	}
 }
 
@@ -53,16 +51,5 @@ func newRookCephSCC(namespace string) *secv1.SecurityContextConstraints {
 	// host networking could still be enabled in the cluster for prototyping
 	scc.AllowHostNetwork = true
 	scc.AllowHostPorts = true
-	return scc
-}
-
-func newRookCephCSISCC(namespace string) *secv1.SecurityContextConstraints {
-	rookValues := cephcsi.SecurityContextConstraintsValues{
-		Namespace: namespace,
-		Deployer:  "rook",
-	}
-
-	scc, _ := cephcsi.NewSecurityContextConstraints(rookValues)
-
 	return scc
 }


### PR DESCRIPTION
ocs-operator no longer needs to create the rook-ceph-csi SecurityContextConstraint;
drop newRookCephCSISCC and the ceph-csi/api dependency used only for it.
Requirement: https://github.com/red-hat-storage/ocs-operator/pull/3964#issuecomment-4989200975