### PR TITLE
Fix Dependabot skipping root go.mod

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,7 +1,7 @@
 go 1.26.5
 
 use (
-	./
+	.
 	./api
 	./metrics
 	./services/provider/api


### PR DESCRIPTION
## Summary
- Change `go.work` root entry from `./` to `.` so Dependabot's workspace parser includes root `go.mod`/`go.sum` (Dependabot historically mishandles `./` for the root module; see [dependabot-core#14909](https://github.com/dependabot/dependabot-core/pull/14909)).

## Problem
Insights → Dependency graph → Dependabot listed `api/`, `metrics/`, and `services/provider/api` manifests under `go.work`, but **not** root `go.mod`. Dependabot therefore did not propose root-module updates; only `dependabot-refresh` (`make deps-update`) synced root.


Made with [Cursor](https://cursor.com)