### PR TITLE
WIP: Wait for .nvmeof pool readiness before creating GW

### DIFF
--- a/internal/controller/storagecluster/cephnvmeof.go
+++ b/internal/controller/storagecluster/cephnvmeof.go
@@ -2,6 +2,7 @@ package storagecluster
 
 import (
 	"cmp"
+	"time"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
@@ -16,7 +17,9 @@ import (
 )
 
 const (
-	defaultNVMeOFGatewayGroup = "group-a"
+	defaultNVMeOFGatewayGroup    = "group-a"
+	nvmeofMetadataPoolName       = "builtin-nvmeof"
+	nvmeofPoolReadyRequeuePeriod = 5 * time.Second
 )
 
 type ocsCephNVMeOF struct{}
@@ -32,11 +35,38 @@ func (obj *ocsCephNVMeOF) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.S
 		return reconcile.Result{}, nil
 	}
 
+	ready, err := obj.isNVMeOFMetadataPoolReady(r, sc)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !ready {
+		r.Log.Info("Waiting for .nvmeof metadata pool to be ready before creating CephNVMeOFGateway.")
+		return reconcile.Result{RequeueAfter: nvmeofPoolReadyRequeuePeriod}, nil
+	}
+
 	if res, err := obj.ensureNVMeOFGateway(r, sc); err != nil || !res.IsZero() {
 		return res, err
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// isNVMeOFMetadataPoolReady checks whether the .nvmeof metadata CephBlockPool is in Ready phase.
+// This prevents creating the CephNVMeOFGateway before the pool exists in RADOS,
+// avoiding transient CrashLoopBackOff on gateway pods during initial deployment.
+func (obj *ocsCephNVMeOF) isNVMeOFMetadataPoolReady(r *StorageClusterReconciler, sc *ocsv1.StorageCluster) (bool, error) {
+	pool := &cephv1.CephBlockPool{}
+	pool.Name = nvmeofMetadataPoolName
+	pool.Namespace = sc.Namespace
+
+	if err := r.Get(r.ctx, client.ObjectKeyFromObject(pool), pool); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return pool.Status != nil && pool.Status.Phase == cephv1.ConditionReady, nil
 }
 
 // ensureDeleted deletes NVMe-oF backend resources owned by the StorageCluster.

--- a/internal/controller/storagecluster/cephnvmeof_test.go
+++ b/internal/controller/storagecluster/cephnvmeof_test.go
@@ -16,6 +16,33 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// setNVMeOFMetadataPoolReady sets the .nvmeof metadata pool status to Ready,
+// simulating Rook having finished creating the pool in RADOS.
+func setNVMeOFMetadataPoolReady(t *testing.T, reconciler *StorageClusterReconciler, request reconcile.Request) {
+	pool := &cephv1.CephBlockPool{}
+	request.Name = nvmeofMetadataPoolName
+	err := reconciler.Get(context.TODO(), request.NamespacedName, pool)
+	assert.NoError(t, err)
+
+	if pool.Status == nil {
+		pool.Status = &cephv1.CephBlockPoolStatus{}
+	}
+	pool.Status.Phase = cephv1.ConditionReady
+	err = reconciler.Status().Update(context.TODO(), pool)
+	assert.NoError(t, err)
+}
+
+// initStorageClusterResourceCreateUpdateTestWithRequeue is like initStorageClusterResourceCreateUpdateTest
+// but expects the reconcile to return a RequeueAfter (e.g. waiting for pool readiness).
+func initStorageClusterResourceCreateUpdateTestWithRequeue(t *testing.T, runtimeObjs []client.Object,
+	customSpec *api.StorageClusterSpec) (*testing.T, *StorageClusterReconciler, *api.StorageCluster, reconcile.Request) {
+	t, reconciler, cr, request := initStorageClusterResourceCreateUpdateTestNoAssert(t, runtimeObjs, customSpec)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+	assert.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "expected requeue while waiting for metadata pool")
+	return t, reconciler, cr, request
+}
+
 func TestCephNVMeOF(t *testing.T) {
 	var objects []client.Object
 	nvmeofSpec := &api.StorageClusterSpec{
@@ -24,10 +51,16 @@ func TestCephNVMeOF(t *testing.T) {
 			GatewayInstances: 2,
 		},
 	}
-	t, reconciler, cr, request := initStorageClusterResourceCreateUpdateTest(t, objects, nvmeofSpec)
+	t, reconciler, cr, request := initStorageClusterResourceCreateUpdateTestWithRequeue(t, objects, nvmeofSpec)
 
 	assertNVMeOFBlockPool(t, reconciler, cr, request)
 	assertNVMeOFMetadataBlockPool(t, reconciler, cr, request)
+
+	setNVMeOFMetadataPoolReady(t, reconciler, request)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
 	assertNVMeOFGateway(t, reconciler, cr, request)
 }
 
@@ -40,12 +73,17 @@ func TestCephNVMeOFCustomGroupAndInstances(t *testing.T) {
 			GatewayInstances: 4,
 		},
 	}
-	t, reconciler, cr, request := initStorageClusterResourceCreateUpdateTest(t, objects, nvmeofSpec)
+	t, reconciler, cr, request := initStorageClusterResourceCreateUpdateTestWithRequeue(t, objects, nvmeofSpec)
+
+	setNVMeOFMetadataPoolReady(t, reconciler, request)
+	result, err := reconciler.Reconcile(context.TODO(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	gwName := util.GenerateNameForCephNVMeOFGateway(cr)
 	actualGW := &cephv1.CephNVMeOFGateway{}
 	request.Name = gwName
-	err := reconciler.Get(context.TODO(), request.NamespacedName, actualGW)
+	err = reconciler.Get(context.TODO(), request.NamespacedName, actualGW)
 	assert.NoError(t, err)
 	assert.Equal(t, "group-b", actualGW.Spec.Group)
 	assert.Equal(t, 4, actualGW.Spec.Instances)

--- a/internal/controller/storagecluster/initialization_reconciler_test.go
+++ b/internal/controller/storagecluster/initialization_reconciler_test.go
@@ -333,6 +333,51 @@ func initStorageClusterResourceCreateUpdateTest(t *testing.T, runtimeObjs []clie
 	return t, reconciler, cr, requestOCSInit
 }
 
+// initStorageClusterResourceCreateUpdateTestNoAssert is like initStorageClusterResourceCreateUpdateTest
+// but does not assert that the reconcile result is empty. Use when the reconcile is expected to
+// return a non-zero result (e.g. RequeueAfter for NVMe-oF pool readiness).
+func initStorageClusterResourceCreateUpdateTestNoAssert(t *testing.T, runtimeObjs []client.Object,
+	customSpec *api.StorageClusterSpec) (*testing.T, *StorageClusterReconciler,
+	*api.StorageCluster, reconcile.Request) {
+	cr := createDefaultStorageCluster()
+	if customSpec != nil {
+		_ = mergo.Merge(&cr.Spec, customSpec)
+	}
+	requestOCSInit := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "ocsinit",
+			Namespace: "",
+		},
+	}
+
+	rtObjsToCreateReconciler := []runtime.Object{&nbv1.NooBaa{}}
+	if runtimeObjs != nil {
+		tbd := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rook-ceph-tools",
+			},
+		}
+		rtObjsToCreateReconciler = append(rtObjsToCreateReconciler, tbd)
+	}
+	reconciler := createFakeInitializationStorageClusterReconciler(
+		t, rtObjsToCreateReconciler...)
+
+	_ = reconciler.Create(context.TODO(), cr)
+	for _, rtObj := range runtimeObjs {
+		_ = reconciler.Create(context.TODO(), rtObj)
+	}
+
+	err := os.Setenv("OPERATOR_NAMESPACE", cr.Namespace)
+	assert.NoError(t, err)
+	err = os.Setenv(util.DesiredCephxKeyGenEnvVarName, "2")
+	assert.NoError(t, err)
+	_, err = reconciler.Reconcile(context.TODO(), requestOCSInit)
+	assert.NoError(t, err)
+	err = os.Setenv("WATCH_NAMESPACE", cr.Namespace)
+	assert.NoError(t, err)
+	return t, reconciler, cr, requestOCSInit
+}
+
 func createFakeInitializationStorageClusterReconciler(t *testing.T, obj ...runtime.Object) *StorageClusterReconciler {
 	sc := &api.StorageCluster{}
 	scheme := createFakeScheme(t)
@@ -478,7 +523,7 @@ func createFakeInitializationStorageClusterReconciler(t *testing.T, obj ...runti
 		createOdfVolumeGroupSnapshotClassCRD(),
 		createRookCephOperatorCSV(sc.Namespace),
 	)
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj...).WithStatusSubresource(sc).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj...).WithStatusSubresource(sc, &cephv1.CephBlockPool{}).Build()
 
 	r := &StorageClusterReconciler{
 		Client:            client,

--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -512,6 +512,9 @@ func (o *ocsProviderServer) createJob(r *StorageClusterReconciler, instance *ocs
 	if errors.IsNotFound(err) {
 		onboardingSecretGeneratorJob := getOnboardingJobObject(instance)
 		err = r.Create(r.ctx, onboardingSecretGeneratorJob)
+		if errors.IsAlreadyExists(err) {
+			err = nil
+		}
 	}
 	if err != nil {
 		r.Log.Error(err, "failed to create/ensure secret")


### PR DESCRIPTION
The NVMe-oF gateway pods crash-loop during initial deployment because the `.nvmeof` RADOS pool has not been created yet when the gateway tries to connect.

Observed in cluster: both gateway pods (`gw-a`, `gw-b`) restarted 2 times with the following error in logs:

```
ERROR state.py:966: Unable to create OMAP, exiting!
rados.ObjectNotFound: [errno 2] RADOS object not found (error opening pool '.nvmeof')
```

The gateway containers exited with code 1 within `~1s` of starting, then recovered after `~13s` once the pool was available.

Add a readiness check on the metadata `CephBlockPool` before creating the `CephNVMeOFGateway` CR, requeuing every `5s` until the pool is Ready. This eliminates transient `CrashLoopBackOff` on gateway pods during cluster bring-up.
