### PR TITLE
DFBUGS-7829:[release-4.19] kube-rbac-proxy: reduce verbosity to prevent bearer token exposure

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=2"
         ports:
         - containerPort: 8443
           name: https

--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -398,7 +398,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 							"--tls-private-key-file", "/etc/tls/private/tls.key",
 							"--tls-cipher-suites", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 							"--config-file", "/etc/kube-rbac-policy/config.yaml",
-							"--v", "10",
+							"--v", "2",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -437,7 +437,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 							"--tls-private-key-file", "/etc/tls/private/tls.key",
 							"--tls-cipher-suites", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 							"--config-file", "/etc/kube-rbac-policy/config.yaml",
-							"--v", "10",
+							"--v", "2",
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
           - '--config-file=/etc/kube-rbac-policy/config.yaml'
           - '--logtostderr=true'
-          - '--v=10'
+          - '--v=2'
         volumeMounts:
         - mountPath: /etc/tls/private
           name: ocs-metrics-exporter-tls
@@ -83,7 +83,7 @@ spec:
           - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
           - '--config-file=/etc/kube-rbac-policy/config.yaml'
           - '--logtostderr=true'
-          - '--v=10'
+          - '--v=2'
         volumeMounts:
         - mountPath: /etc/tls/private
           name: ocs-metrics-exporter-tls


### PR DESCRIPTION
kube-rbac-proxy was configured with --v=10, causing it to log the full TokenReview response body including the bearer token in clear text. Reduce verbosity to 2 to prevent sensitive token data from being exposed in logs.