### PR TITLE
Fix false positives and description formatting in ODFNodeNICBandwidthSaturation alert

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -731,8 +731,8 @@ spec:
       expr: |
         (
           sum by (instance, device) (
-            rate(node_network_receive_bytes_total{job="node-exporter", device!~"^(veth|docker|flannel|cali|tun|tap).*"}[5m])
-          + rate(node_network_transmit_bytes_total{job="node-exporter", device!~"^(veth|docker|flannel|cali|tun|tap).*"}[5m])
+            rate(node_network_receive_bytes_total{job="node-exporter", device!~"^(veth|docker|flannel|cali|tun|tap|[0-9a-f]{12}).*"}[5m])
+          + rate(node_network_transmit_bytes_total{job="node-exporter", device!~"^(veth|docker|flannel|cali|tun|tap|[0-9a-f]{12}).*"}[5m])
           )
         )
         /
@@ -746,7 +746,7 @@ spec:
         component: odf
       annotations:
         summary: "ODF node NIC bandwidth > 90% saturation"
-        description: "Node {{ $labels.instance }} interface {{ $labels.device }} is at {{ printf \"%.0f\" $value }}% bandwidth utilization. May impact Ceph performance."
+        description: "Node {{ $labels.instance }} interface {{ $labels.device }} is at {{ $value | humanizePercentage }} bandwidth utilization. May impact Ceph performance."
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeNICBandwidthSaturation.md
 
     - alert: ODFDiskUtilizationHigh


### PR DESCRIPTION
Fix false positives and description formatting in ODFNodeNICBandwidthSaturation alert

  - Added 12-character hexadecimal CNI/OVN interface pattern (`[0-9a-f]{12}`) to the PromQL blacklist regex to prevent virtual devices (e.g., 840d59118385c_3) from triggering false alerts.

  - Updated alert description annotation to use `humanizePercentage` filter, fixing an issue where decimal ratio values (e.g., 0.92) were improperly rounded to "1%" instead of "92%".

Fixes: https://redhat.atlassian.net/browse/DFBUGS-10108