### PR TITLE
DFBUGS-8515:[release-4.21] controllers: add multus network annotation to ocs-metrics-exporter

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -344,6 +344,16 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 			Namespace: instance.Namespace,
 		},
 	}
+
+	var multusNetwork string
+	if util.IsMultus(instance.Spec.Network) {
+		var err error
+		multusNetwork, err = getMultusPublicNetwork(instance)
+		if err != nil {
+			return err
+		}
+	}
+
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentDep, func() error {
 		if currentDep.ObjectMeta.CreationTimestamp.IsZero() {
 			// Selector is immutable. Inject it only while creating new object.
@@ -554,6 +564,12 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 					NodeAffinity: GetPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
 				},
 			},
+		}
+		if multusNetwork != "" {
+			if currentDep.Spec.Template.Annotations == nil {
+				currentDep.Spec.Template.Annotations = make(map[string]string)
+			}
+			currentDep.Spec.Template.Annotations["k8s.v1.cni.cncf.io/networks"] = multusNetwork
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
The ocs-metrics-exporter deployment was not receiving the required Multus network attachment annotation, while the rook-ceph-tools deployment already had this handled correctly. Add the same annotation logic used by rook-ceph-tools to the metrics exporter deployment.