### PR TITLE
DFBUGS-8516: [release-4.20] controllers: add multus network annotation to ocs-metrics-exporter

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -339,6 +339,16 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 			Namespace: instance.Namespace,
 		},
 	}
+	
+	var multusNetwork string
+	if util.IsMultus(instance.Spec.Network) {
+		var err error
+		multusNetwork, err = getMultusPublicNetwork(instance)
+		if err != nil {
+			return err
+		}
+	}
+
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentDep, func() error {
 		if currentDep.ObjectMeta.CreationTimestamp.IsZero() {
 			// Selector is immutable. Inject it only while creating new object.
@@ -540,6 +550,12 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 					NodeAffinity: GetPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
 				},
 			},
+		}
+		if multusNetwork != "" {
+			if currentDep.Spec.Template.Annotations == nil {
+				currentDep.Spec.Template.Annotations = make(map[string]string)
+			}
+			currentDep.Spec.Template.Annotations["k8s.v1.cni.cncf.io/networks"] = multusNetwork
 		}
 		return nil
 	}); err != nil {

--- a/controllers/util/clusters.go
+++ b/controllers/util/clusters.go
@@ -5,7 +5,9 @@ import (
 	"sort"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 )
 
 type Clusters struct {
@@ -156,4 +158,12 @@ func (c *Clusters) HasMultipleStorageClustersWithSameName(name string) bool {
 	}
 
 	return count > 1
+}
+
+// IsMultus checks if the NetworkSpec in the storage cluster is configured to use Multus
+func IsMultus(nwSpec *rookCephv1.NetworkSpec) bool {
+	if nwSpec != nil {
+		return nwSpec.IsMultus()
+	}
+	return false
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/clusters.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/clusters.go
@@ -5,7 +5,9 @@ import (
 	"sort"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 )
 
 type Clusters struct {
@@ -156,4 +158,12 @@ func (c *Clusters) HasMultipleStorageClustersWithSameName(name string) bool {
 	}
 
 	return count > 1
+}
+
+// IsMultus checks if the NetworkSpec in the storage cluster is configured to use Multus
+func IsMultus(nwSpec *rookCephv1.NetworkSpec) bool {
+	if nwSpec != nil {
+		return nwSpec.IsMultus()
+	}
+	return false
 }


### PR DESCRIPTION
The ocs-metrics-exporter deployment was not receiving the required Multus network attachment annotation, while the rook-ceph-tools deployment already had this handled correctly. Add the same annotation logic used by rook-ceph-tools to the metrics exporter deployment.


(cherry picked from commit https://github.com/red-hat-storage/ocs-operator/commit/6aed1c73fa88b0ef2fa3d5f3090161c8bb19140f)

This is a manual backport of #3963.

Since the original PR could not be cherry-picked cleanly 
onto this release branch, changes in the files clusters.go were manually added.