### PR TITLE
DFBUGS-8518: [release-4.18] controllers: add multus network annotation to ocs-metrics-exporter

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -8,6 +8,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	"github.com/red-hat-storage/ocs-operator/v4/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -324,6 +325,16 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 			Namespace: instance.Namespace,
 		},
 	}
+
+	var multusNetwork string
+	if util.IsMultus(instance.Spec.Network) {
+		var err error
+		multusNetwork, err = getMultusPublicNetwork(instance)
+		if err != nil {
+			return err
+		}
+	}
+
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, currentDep, func() error {
 		if currentDep.ObjectMeta.CreationTimestamp.IsZero() {
 			// Selector is immutable. Inject it only while creating new object.
@@ -523,6 +534,12 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 					NodeAffinity: getPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
 				},
 			},
+		}
+		if multusNetwork != "" {
+			if currentDep.Spec.Template.Annotations == nil {
+				currentDep.Spec.Template.Annotations = make(map[string]string)
+			}
+			currentDep.Spec.Template.Annotations["k8s.v1.cni.cncf.io/networks"] = multusNetwork
 		}
 		return nil
 	}); err != nil {

--- a/controllers/util/clusters.go
+++ b/controllers/util/clusters.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -156,4 +157,12 @@ func (c *Clusters) HasMultipleStorageClustersWithSameName(name string) bool {
 	}
 
 	return count > 1
+}
+
+// IsMultus checks if the NetworkSpec in the storage cluster is configured to use Multus
+func IsMultus(nwSpec *rookCephv1.NetworkSpec) bool {
+	if nwSpec != nil {
+		return nwSpec.IsMultus()
+	}
+	return false
 }

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/clusters.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/clusters.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -156,4 +157,12 @@ func (c *Clusters) HasMultipleStorageClustersWithSameName(name string) bool {
 	}
 
 	return count > 1
+}
+
+// IsMultus checks if the NetworkSpec in the storage cluster is configured to use Multus
+func IsMultus(nwSpec *rookCephv1.NetworkSpec) bool {
+	if nwSpec != nil {
+		return nwSpec.IsMultus()
+	}
+	return false
 }


### PR DESCRIPTION
The ocs-metrics-exporter deployment was not receiving the required Multus network attachment annotation, while the rook-ceph-tools deployment already had this handled correctly. Add the same annotation logic used by rook-ceph-tools to the metrics exporter deployment.