### PR TITLE
 Fix odf-blackbox-scc priority to prevent incorrect SCC selection

### DIFF
--- a/internal/controller/storagecluster/blackbox_exporter.go
+++ b/internal/controller/storagecluster/blackbox_exporter.go
@@ -235,7 +235,7 @@ func (r *StorageClusterReconciler) createBlackboxSCC(ctx context.Context, instan
 		AllowedCapabilities:  []corev1.Capability{"NET_RAW"},
 		AllowedUnsafeSysctls: []string{"net.ipv4.ping_group_range"},
 		SeccompProfiles:      []string{"runtime/default"},
-		Priority:             ptr.To[int32](10),
+		Priority:             ptr.To[int32](0),
 	}
 	actual, err := r.SecurityClient.SecurityContextConstraints().Get(ctx, desired.Name, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
[DFBUGS-10132](https://redhat.atlassian.net/browse/DFBUGS-10132)
Fix odf-blackbox-scc priority from 10 to 0 to prevent incorrect SCC selection by workloads