### PR TITLE
DFBUGS-10186: Remove the device class match code that was mistakenly added in #3833

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -80,7 +80,6 @@ const (
 	networkProvider           = "multus"
 	publicNetworkSelectorKey  = "public"
 	clusterNetworkSelectorKey = "cluster"
-	deviceClassPlacementKey   = "device-class"
 )
 
 const (
@@ -869,30 +868,8 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rookCephv1.StorageCla
 		count, replica := countAndReplicaOf(&ds)
 		for i := range replica {
 			// Default placements for osd and prepareosd
-			defaultPlacement := GetPlacement(sc, "osd")
-			defaultPreparePlacement := GetPlacement(sc, "prepareosd")
-
-			// Annotation crushDeviceClass ensures osd with different CRUSH device class than the one detected by Ceph
-			crushDeviceClass := ds.DeviceType
-			if ds.DeviceClass != "" {
-				crushDeviceClass = ds.DeviceClass
-			}
-
-			annotations := map[string]string{
-				"crushDeviceClass": crushDeviceClass,
-			}
-			// create a device class match expression
-			deviceClassMatchExpression := metav1.LabelSelectorRequirement{
-				Key:      deviceClassPlacementKey,
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{crushDeviceClass},
-			}
-			// append the device class match expression to the topology spread constraints
-			// we are appending to the first topology spread constraint as the first one will have topologyKey as failureDomain
-			placement := *defaultPlacement.DeepCopy()
-			placement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions = append(placement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions, deviceClassMatchExpression)
-			preparePlacement := *defaultPreparePlacement.DeepCopy()
-			preparePlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions = append(preparePlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions, deviceClassMatchExpression)
+			placement := GetPlacement(sc, "osd")
+			preparePlacement := GetPlacement(sc, "prepareosd")
 
 			switch {
 			case !isPlacementEmpty(ds.Placement) && !isPlacementEmpty(ds.PreparePlacement):
@@ -912,6 +889,15 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rookCephv1.StorageCla
 				// If none of osd or prepareosd placements are specified, use their defaults
 			}
 
+			// Annotation crushDeviceClass ensures osd with different CRUSH device class than the one detected by Ceph
+			crushDeviceClass := ds.DeviceType
+			if ds.DeviceClass != "" {
+				crushDeviceClass = ds.DeviceClass
+			}
+
+			annotations := map[string]string{
+				"crushDeviceClass": crushDeviceClass,
+			}
 			// Annotation crushInitialWeight is an optional, explicit weight to set upon OSD's init (as float, in TiB units).
 			// ROOK & Ceph do not want any (optional) Ti[B] suffix, so trim it here.
 			// If not set, Ceph will define OSD's weight based on its capacity.

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -661,21 +661,8 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 				assert.DeepEqual(t, deviceSet.DataPVCTemplate.Spec, scds.VolumeClaimTemplates[0].Spec)
 				assert.Equal(t, true, scds.Portable)
 				assert.Equal(t, sc.Spec.Encryption.ClusterWide, scds.Encrypted)
-				defaultExpectedOSDPlacement := GetPlacement(sc, "osd")
-				defaultExpectedPreparePlacement := GetPlacement(sc, "prepareosd")
-
-				// create a device class match expression
-				deviceClassMatchExpression := metav1.LabelSelectorRequirement{
-					Key:      deviceClassPlacementKey,
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{deviceSet.DeviceClass},
-				}
-				// append the device class match expression to the topology spread constraints
-				// we are appending to the first topology spread constraint as the first one will have topologyKey as failureDomain
-				expectedOSDPlacement := *defaultExpectedOSDPlacement.DeepCopy()
-				expectedOSDPlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions = append(expectedOSDPlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions, deviceClassMatchExpression)
-				expectedPreparePlacement := *defaultExpectedPreparePlacement.DeepCopy()
-				expectedPreparePlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions = append(expectedPreparePlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions, deviceClassMatchExpression)
+				expectedOSDPlacement := GetPlacement(sc, "osd")
+				expectedPreparePlacement := GetPlacement(sc, "prepareosd")
 
 				if c.hasCustomPlacement {
 					// Handle different custom placement scenarios based on the new placement logic
@@ -898,16 +885,6 @@ func TestStorageClassDeviceSetCreationForArbiter(t *testing.T) {
 		deviceSet := c.sc.Spec.StorageDeviceSets[0]
 
 		for i, scds := range actual {
-			defaultOsdPlacement := GetPlacement(c.sc, "osd")
-			// create a device class match expression
-			deviceClassMatchExpression := metav1.LabelSelectorRequirement{
-				Key:      deviceClassPlacementKey,
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{deviceSet.DeviceClass},
-			}
-			osdPlacement := *defaultOsdPlacement.DeepCopy()
-			osdPlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions = append(osdPlacement.TopologySpreadConstraints[0].LabelSelector.MatchExpressions, deviceClassMatchExpression)
-
 			assert.Equal(t, fmt.Sprintf("%s-%d", deviceSet.Name, i), scds.Name)
 			assert.Equal(t, deviceSet.Count, scds.Count)
 			assert.DeepEqual(t, getDaemonResources("osd", c.sc), scds.Resources)
@@ -915,7 +892,7 @@ func TestStorageClassDeviceSetCreationForArbiter(t *testing.T) {
 			assert.DeepEqual(t, deviceSet.DataPVCTemplate.Spec, scds.VolumeClaimTemplates[0].Spec)
 			assert.Equal(t, true, scds.Portable)
 			assert.Equal(t, c.sc.Spec.Encryption.ClusterWide, scds.Encrypted)
-			assert.DeepEqual(t, osdPlacement, scds.Placement)
+			assert.DeepEqual(t, GetPlacement(c.sc, "osd"), scds.Placement)
 			topologyKey := scds.PreparePlacement.TopologySpreadConstraints[0].TopologyKey
 			assert.Equal(t, c.topologyKey, topologyKey)
 		}


### PR DESCRIPTION
PR #3833 mistakenly added the device class match code to 4.20 branch. but the corresponding code required in rook is not present in 4.20 branch. This commit removes the device class match code from 4.20 branch.