### PR TITLE
provider: allow cross-cluster ingress to ocs-provider-server

### DIFF
--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -451,6 +451,17 @@ func getProviderAPIServerNetworkPolicy(instance *ocsv1.StorageCluster) *networki
 						},
 					},
 				},
+				{
+					// Allow cross-cluster peering via Submariner/Globalnet.
+					// Traffic from remote clusters arrives with GlobalNet CIDR
+					// source IPs that don't match any namespaceSelector.
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: ptr.To(corev1.ProtocolTCP),
+							Port:     ptr.To(intstr.FromInt32(ocsProviderServicePort)),
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The ocs-provider-server NetworkPolicy only allowed ingress from the local `openshift-storage` namespace. When `StorageClusterPeer` peering uses `Submariner` with Globalnet, cross-cluster traffic arrives with GlobalNet CIDR source IPs that don't match any namespaceSelector, causing `CONNECTION_FAILED` on the peering.

Add a port-only ingress rule (no source restriction) for port 50051 so remote clusters can reach the provider API server via `Submariner`. The server already authenticates via onboarding tokens.


## Before fix (current)

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: ocs-provider-server
  namespace: openshift-storage
spec:
  podSelector:
    matchLabels:
      app: ocsProviderApiServer
  policyTypes:
    - Ingress
  ingress:
    - from:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: openshift-storage
      ports:
        - protocol: TCP
          port: 50051
```

## After fix (proposed)

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: ocs-provider-server
  namespace: openshift-storage
spec:
  podSelector:
    matchLabels:
      app: ocsProviderApiServer
  policyTypes:
    - Ingress
  ingress:
    - from:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: openshift-storage
      ports:
        - protocol: TCP
          port: 50051
    - ports:
        - protocol: TCP
          port: 50051
```

The second ingress rule has no `from` field — allowing any source to reach port `50051`. This permits Submariner/Globalnet cross-cluster traffic where the source IP is a GlobalNet CIDR that doesn't match any namespace label.