### PR TITLE
Revert "provider: allow cross-cluster ingress to ocs-provider-server"

### DIFF
--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -451,17 +451,6 @@ func getProviderAPIServerNetworkPolicy(instance *ocsv1.StorageCluster) *networki
 						},
 					},
 				},
-				{
-					// Allow cross-cluster peering via Submariner/Globalnet.
-					// Traffic from remote clusters arrives with GlobalNet CIDR
-					// source IPs that don't match any namespaceSelector.
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: ptr.To(corev1.ProtocolTCP),
-							Port:     ptr.To(intstr.FromInt32(ocsProviderServicePort)),
-						},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
Reverts red-hat-storage/ocs-operator#4167

This was merged automatically by the bot when conversation was not approved by the whole team. Let's rever this so that we can continue discussions

More: https://github.com/red-hat-storage/ocs-operator/pull/4167#issuecomment-5443145332

If reverting this is not what is desired, feel free to close this PR. Thanks