### PR TITLE
provider: skip NetworkPolicy during DR peering

### DIFF
--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -76,7 +76,15 @@ func (o *ocsProviderServer) createNetworkPolicy(r *StorageClusterReconciler, ins
 		return reconcile.Result{}, err
 	}
 
-	if desiredService.Spec.Type != corev1.ServiceTypeClusterIP {
+	// Cross-cluster DR traffic via Submariner/Globalnet cannot match any
+	// namespaceSelector, so the NetworkPolicy must not exist when a peer is present.
+	hasPeers, err := hasStorageClusterPeers(r, instance.Namespace)
+	if err != nil {
+		r.Log.Error(err, "Failed to list StorageClusterPeer resources")
+		return reconcile.Result{}, err
+	}
+
+	if desiredService.Spec.Type != corev1.ServiceTypeClusterIP || hasPeers {
 		if networkPolicy.UID != "" {
 			if err := r.Delete(r.ctx, networkPolicy); err != nil {
 				r.Log.Error(err, "Failed to delete networkpolicy", "Name", networkPolicy.Name)
@@ -88,16 +96,24 @@ func (o *ocsProviderServer) createNetworkPolicy(r *StorageClusterReconciler, ins
 
 	desiredNetworkPolicy := getProviderAPIServerNetworkPolicy(instance)
 
-	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, networkPolicy, func() error {
+	if _, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, networkPolicy, func() error {
 		networkPolicy.Spec = desiredNetworkPolicy.Spec
 		return controllerutil.SetControllerReference(instance, networkPolicy, r.Client.Scheme())
-	})
-	if err != nil {
+	}); err != nil {
 		r.Log.Error(err, "Failed to create/update networkpolicy", "Name", desiredNetworkPolicy.Name)
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func hasStorageClusterPeers(r *StorageClusterReconciler, namespace string) (bool, error) {
+	peerList := &metav1.PartialObjectMetadataList{}
+	peerList.SetGroupVersionKind(ocsv1.GroupVersion.WithKind("StorageClusterPeerList"))
+	if err := r.List(r.ctx, peerList, client.InNamespace(namespace), client.Limit(1)); err != nil {
+		return false, err
+	}
+	return len(peerList.Items) > 0, nil
 }
 
 func (o *ocsProviderServer) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
@@ -444,17 +460,6 @@ func getProviderAPIServerNetworkPolicy(instance *ocsv1.StorageCluster) *networki
 							},
 						},
 					},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: ptr.To(corev1.ProtocolTCP),
-							Port:     ptr.To(intstr.FromInt32(ocsProviderServicePort)),
-						},
-					},
-				},
-				{
-					// Allow cross-cluster peering via Submariner/Globalnet.
-					// Traffic from remote clusters arrives with GlobalNet CIDR
-					// source IPs that don't match any namespaceSelector.
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: ptr.To(corev1.ProtocolTCP),

--- a/internal/controller/storagecluster/provider_server_test.go
+++ b/internal/controller/storagecluster/provider_server_test.go
@@ -257,6 +257,28 @@ func TestOcsProviderServerEnsureCreated(t *testing.T) {
 		assert.True(t, errors.IsNotFound(r.Get(context.TODO(), client.ObjectKeyFromObject(networkPolicy), networkPolicy)))
 	})
 
+	t.Run("NetworkPolicy is not created when StorageClusterPeer exists", func(t *testing.T) {
+
+		r, instance := createSetupForOcsProviderTest(t, corev1.ServiceTypeClusterIP)
+
+		peer := &ocsv1.StorageClusterPeer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-peer",
+				Namespace: instance.Namespace,
+			},
+		}
+		assert.NoError(t, r.Create(context.TODO(), peer))
+
+		obj := &ocsProviderServer{}
+		res, err := obj.createNetworkPolicy(r, instance)
+		assert.NoError(t, err)
+		assert.True(t, res.IsZero())
+
+		networkPolicy := &networkingv1.NetworkPolicy{}
+		networkPolicy.Name = ocsProviderServerName
+		networkPolicy.Namespace = instance.Namespace
+		assert.True(t, errors.IsNotFound(r.Get(context.TODO(), client.ObjectKeyFromObject(networkPolicy), networkPolicy)))
+	})
 
 }
 


### PR DESCRIPTION
Revert the open ingress rule added in #4167, which allowed any source to reach port `tcp/50051` on the `ocs-provider-server`. That approach weakened security by exposing the API to everything in the cluster.

Instead, extend the existing conditional NP removal logic (already used for NodePort/host-network) to detect DR scenarios: when a StorageClusterPeer exists in the namespace, skip NP creation entirely.

This is needed because `Submariner`/`Globalnet` rewrites source IPs to a GlobalNet `CIDR` that no `namespaceSelector` can match, blocking both the initial peering handshake and ongoing cross-cluster traffic. Checking for peer existence (any state) rather than Peered avoids a deadlock where the NP blocks the very traffic needed to reach Peered.

The provider API server already authenticates all callers via onboarding tokens, so removing the NP in DR setups does not leave it unprotected.

Fixes: #4167
See also: #4168