### PR TITLE
Fix Go bump workflow after actions/checkout credential change

### DIFF
--- a/.github/workflows/go-minor-version-bump.yaml
+++ b/.github/workflows/go-minor-version-bump.yaml
@@ -90,6 +90,7 @@ jobs:
           ref: ${{ matrix.branch }}
           fetch-depth: 1
           path: work
+          persist-credentials: false
 
       - name: Compare versions
         id: compare
@@ -236,8 +237,6 @@ jobs:
 
           fork_owner="${FORK_REPO%%/*}"
           fork_url="https://x-access-token:${GH_PAT}@github.com/${FORK_REPO}.git"
-
-          git config --unset-all http.https://github.com/.extraheader
 
           git push "${fork_url}" "HEAD:refs/heads/${HEAD_BRANCH}" --force
 


### PR DESCRIPTION
## Summary
- The last step of the weekly Go bump workflow started failing with **exit code 5** after [#4169](https://github.com/red-hat-storage/ocs-operator/pull/4169) bumped `actions/checkout` from 5.0.0 to 7.0.1 (Dependabot comment still says v5; the pin is 7.0.1). See [failed job](https://github.com/red-hat-storage/ocs-operator/actions/runs/33465620329/job/99724738201).
- `git config --unset-all http.https://github.com/.extraheader` used to strip the `GITHUB_TOKEN` header that checkout v5.0.0 wrote into `.git/config`. From checkout v6 onward (and in 7.0.1), that header lives in a temp file referenced via `includeIf.gitdir`, so the key is no longer in local config. Git treats unsetting a missing key as exit 5; `set -euo pipefail` then aborted the step before `git push` or `gh api` ran.
- Set `persist-credentials: false` on checkout so `GITHUB_TOKEN` is never left behind, and drop the now-broken unset. The push already authenticates with `GH_PAT` in the remote URL.


Made with [Cursor](https://cursor.com)