### PR TITLE
server: disable cache for *Classes to support proper removals

### DIFF
--- a/functests/ocs/noobaa_tls_test.go
+++ b/functests/ocs/noobaa_tls_test.go
@@ -132,6 +132,30 @@ func (obj *NooBaaTLS) restoreOriginalState() error {
 	return obj.deleteTLSProfile()
 }
 
+func (obj *NooBaaTLS) addFailureReport() {
+	nb := &nbv1.NooBaa{}
+	nbErr := obj.client.Get(context.TODO(), client.ObjectKey{
+		Name:      "noobaa",
+		Namespace: obj.namespace,
+	}, nb)
+
+	profile := &ocstlsv1.TLSProfile{}
+	profileErr := obj.client.Get(context.TODO(), client.ObjectKey{
+		Name:      defaults.TLSProfileName,
+		Namespace: obj.namespace,
+	}, profile)
+
+	ginkgo.AddReportEntry("NooBaa TLS state", fmt.Sprintf(
+		"NooBaa get error: %v\nNooBaa resource version: %q\nAPIServerSecurity: %#v\nTLSProfile get error: %v\nTLSProfile generation: %d\nTLSProfile spec: %#v",
+		nbErr,
+		nb.ResourceVersion,
+		nb.Spec.Security.APIServerSecurity,
+		profileErr,
+		profile.Generation,
+		profile.Spec,
+	))
+}
+
 func (obj *NooBaaTLS) waitForNooBaaReconcile(expectedVersion *nbv1.TLSProtocolVersion, expectedCiphers []string) {
 	gomega.Eventually(func() error {
 		nb := &nbv1.NooBaa{}
@@ -147,15 +171,17 @@ func (obj *NooBaaTLS) waitForNooBaaReconcile(expectedVersion *nbv1.TLSProtocolVe
 			if expectedVersion == nil {
 				return nil
 			}
-			return fmt.Errorf("NooBaa APIServerSecurity is nil, expected TLS configuration")
+			return fmt.Errorf("NooBaa APIServerSecurity is nil, expected TLS configuration (resourceVersion=%q)", nb.ResourceVersion)
 		}
 
 		if expectedVersion == nil {
-			return fmt.Errorf("NooBaa has TLS configuration but none was expected")
+			return fmt.Errorf("NooBaa has TLS configuration but none was expected (resourceVersion=%q, security=%#v)",
+				nb.ResourceVersion, nb.Spec.Security.APIServerSecurity)
 		}
 
 		if nb.Spec.Security.APIServerSecurity.TLSMinVersion == nil {
-			return fmt.Errorf("TLSMinVersion is nil")
+			return fmt.Errorf("TLSMinVersion is nil (resourceVersion=%q, security=%#v)",
+				nb.ResourceVersion, nb.Spec.Security.APIServerSecurity)
 		}
 		if *nb.Spec.Security.APIServerSecurity.TLSMinVersion != *expectedVersion {
 			return fmt.Errorf("TLSMinVersion mismatch: got %v, expected %v",
@@ -163,8 +189,9 @@ func (obj *NooBaaTLS) waitForNooBaaReconcile(expectedVersion *nbv1.TLSProtocolVe
 		}
 
 		if len(nb.Spec.Security.APIServerSecurity.TLSCiphers) != len(expectedCiphers) {
-			return fmt.Errorf("TLSCiphers count mismatch: got %d, expected %d",
-				len(nb.Spec.Security.APIServerSecurity.TLSCiphers), len(expectedCiphers))
+			return fmt.Errorf("TLSCiphers count mismatch: got %d, expected %d (resourceVersion=%q, ciphers=%v)",
+				len(nb.Spec.Security.APIServerSecurity.TLSCiphers), len(expectedCiphers),
+				nb.ResourceVersion, nb.Spec.Security.APIServerSecurity.TLSCiphers)
 		}
 
 		cipherMap := make(map[string]bool)
@@ -173,7 +200,8 @@ func (obj *NooBaaTLS) waitForNooBaaReconcile(expectedVersion *nbv1.TLSProtocolVe
 		}
 		for _, expectedCipher := range expectedCiphers {
 			if !cipherMap[expectedCipher] {
-				return fmt.Errorf("expected cipher %s not found in NooBaa TLSCiphers", expectedCipher)
+				return fmt.Errorf("expected cipher %s not found in NooBaa TLSCiphers (resourceVersion=%q, ciphers=%v)",
+					expectedCipher, nb.ResourceVersion, nb.Spec.Security.APIServerSecurity.TLSCiphers)
 			}
 		}
 
@@ -201,6 +229,9 @@ func NooBaaTLSTest() {
 	ginkgo.AfterEach(func() {
 		if ginkgo.CurrentSpecReport().Failed() {
 			tests.SuiteFailed = tests.SuiteFailed || true
+			if tlsObj != nil {
+				tlsObj.addFailureReport()
+			}
 		}
 
 		if tlsObj != nil {

--- a/pkg/util/groupreplicationclasses.go
+++ b/pkg/util/groupreplicationclasses.go
@@ -70,7 +70,7 @@ func VolumeGroupReplicationClassFromTemplate(
 		AddLabel(vgrc, ramenDRStorageIDLabelKey, rbdStorageId)
 		AddLabel(vgrc, ramenDRGroupReplicationIDLabelKey, groupReplicationID)
 	default:
-		return nil, fmt.Errorf("unsupported Provisioner for VolumeGroupReplicationClass")
+		return nil, ErrUnsupportedDriver
 	}
 	return vgrc, nil
 }

--- a/pkg/util/replicationclasses.go
+++ b/pkg/util/replicationclasses.go
@@ -61,7 +61,7 @@ func VolumeReplicationClassFromTemplate(
 		AddLabel(vrc, ramenDRStorageIDLabelKey, rbdStorageId)
 		AddLabel(vrc, ramenDRReplicationIDLabelKey, replicationID)
 	default:
-		return nil, ErrUnsupportedProvisioner
+		return nil, ErrUnsupportedDriver
 	}
 	return vrc, nil
 }

--- a/pkg/util/snapshotclasses.go
+++ b/pkg/util/snapshotclasses.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -18,10 +17,6 @@ const (
 	RbdSnapshotter    SnapshotterType = "rbd"
 	CephfsSnapshotter SnapshotterType = "cephfs"
 	NfsSnapshotter    SnapshotterType = "nfs"
-)
-
-var (
-	ErrUnsupportedDriver = errors.New("unsupportedDriver")
 )
 
 // GenerateNameForSnapshotClass function generates 'SnapshotClass' name.

--- a/pkg/util/storageclasses.go
+++ b/pkg/util/storageclasses.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	ErrUnsupportedProvisioner = errors.New("unsupportedProvisioner")
+	ErrUnsupportedDriver = errors.New("unsupportedDriver")
 )
 
 func GenerateNameForCephBlockPoolStorageClass(storageCluster *ocsv1.StorageCluster) string {
@@ -544,7 +544,7 @@ func StorageClassFromExisting(
 	case NoobaaProvisionerName:
 		return storageClass, nil
 	default:
-		return nil, ErrUnsupportedProvisioner
+		return nil, ErrUnsupportedDriver
 	}
 
 	params["clusterID"] = clientProfileName

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -159,6 +159,16 @@ func NewOCSProviderServer(ctx context.Context, namespace string) (*OCSProviderSe
 		Scheme: scheme,
 		Cache: &client.CacheOptions{
 			Reader: cache,
+			DisableFor: []client.Object{
+				&storagev1.StorageClass{},
+				&storagev1.VolumeAttributesClass{},
+				&snapapi.VolumeSnapshotClass{},
+				&groupsnapapi.VolumeGroupSnapshotClass{},
+				&odfgsapiv1b1.VolumeGroupSnapshotClass{},
+				&replicationv1alpha1.VolumeReplicationClass{},
+				&replicationv1alpha1.VolumeGroupReplicationClass{},
+				&csiaddonsv1alpha1.NetworkFenceClass{},
+			},
 		},
 	})
 	if err != nil {
@@ -1940,7 +1950,7 @@ func (s *OCSProviderServer) appendCephClientSecretKubeResource(
 	cephUserSecret.Namespace = consumer.Namespace
 
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(cephUserSecret), cephUserSecret); err != nil {
-		return records, fmt.Errorf("failed to get %s secret. %v", cephUserSecret, err)
+		return nil, fmt.Errorf("failed to get %s secret. %v", cephUserSecret, err)
 	}
 
 	cephUserSecret.Name = destSecretName
@@ -2091,7 +2101,7 @@ func (s *OCSProviderServer) appendStorageClassKubeResources(
 
 	nvmeofSCName := util.GenerateNameForNVMeOFStorageClass(storageCluster)
 	nvmeofDisabled := storageCluster.Spec.NVMeOF == nil || !storageCluster.Spec.NVMeOF.Enable
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.StorageClasses,
 		"StorageClass",
@@ -2118,6 +2128,9 @@ func (s *OCSProviderServer) appendStorageClassKubeResources(
 			}
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2164,7 +2177,7 @@ func (s *OCSProviderServer) appendVolumeSnapshotClassKubeResources(
 		}
 	}
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.VolumeSnapshotClasses,
 		"VolumeSnapshotClass",
@@ -2185,6 +2198,9 @@ func (s *OCSProviderServer) appendVolumeSnapshotClassKubeResources(
 			}
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2239,7 +2255,7 @@ func (s *OCSProviderServer) appendVolumeGroupSnapshotClassKubeResources(
 		}
 	}
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.VolumeGroupSnapshotClasses,
 		"volumegroupsnapshotclass.groupsnapshot.storage.k8s.io",
@@ -2260,6 +2276,9 @@ func (s *OCSProviderServer) appendVolumeGroupSnapshotClassKubeResources(
 			}
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2287,7 +2306,7 @@ func (s *OCSProviderServer) appendOdfVolumeGroupSnapshotClassKubeResources(
 		}
 	}
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.VolumeGroupSnapshotClasses,
 		"volumegroupsnapshotclass.groupsnapshot.storage.openshift.io",
@@ -2306,6 +2325,9 @@ func (s *OCSProviderServer) appendOdfVolumeGroupSnapshotClassKubeResources(
 			}
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2344,7 +2366,7 @@ func (s *OCSProviderServer) appendNetworkFenceClassKubeResources(
 		}
 	}
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.NetworkFenceClasses,
 		"networkfenceclass",
@@ -2356,6 +2378,9 @@ func (s *OCSProviderServer) appendNetworkFenceClassKubeResources(
 			}
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2368,7 +2393,7 @@ func (s *OCSProviderServer) appendVolumeAttributesClassKubeResources(
 	consumer *ocsv1alpha1.StorageConsumer,
 ) ([]kubeObjectWithOpRecord, error) {
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.VolumeAttributesClasses,
 		"VolumeAttributesClass",
@@ -2380,6 +2405,9 @@ func (s *OCSProviderServer) appendVolumeAttributesClassKubeResources(
 			)
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2395,7 +2423,7 @@ func (s *OCSProviderServer) appendVolumeReplicationClassKubeResources(
 	remoteRbdStorageId string,
 ) ([]kubeObjectWithOpRecord, error) {
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.VolumeReplicationClasses,
 		"VolumeReplicationClass",
@@ -2411,6 +2439,9 @@ func (s *OCSProviderServer) appendVolumeReplicationClassKubeResources(
 			)
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2427,7 +2458,7 @@ func (s *OCSProviderServer) appendVolumeGroupReplicationClassKubeResources(
 	remoteRbdStorageId string,
 ) ([]kubeObjectWithOpRecord, error) {
 
-	resources := getKubeResourcesForClass(
+	resources, err := getKubeResourcesForClass(
 		logger,
 		consumer.Spec.VolumeGroupReplicationClasses,
 		"VolumeGroupReplicationClass",
@@ -2443,6 +2474,9 @@ func (s *OCSProviderServer) appendVolumeGroupReplicationClassKubeResources(
 			)
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, resources...)
 
 	return records, nil
@@ -2494,7 +2528,7 @@ func (s *OCSProviderServer) appendClientProfileMappingKubeResources(
 ) ([]kubeObjectWithOpRecord, error) {
 	cbpList := &rookCephv1.CephBlockPoolList{}
 	if err := s.client.List(ctx, cbpList, client.InNamespace(s.namespace)); err != nil {
-		return records, fmt.Errorf("failed to list cephBlockPools in namespace. %v", err)
+		return nil, fmt.Errorf("failed to list cephBlockPools in namespace. %v", err)
 	}
 	blockPoolMapping := []csiopv1.BlockPoolIdPair{}
 	for i := range cbpList.Items {
@@ -2872,7 +2906,7 @@ func (s *OCSProviderServer) appendRGWAccountCredentialsKubeResources(
 
 	rookSecret, err := s.getRGWRootUserCredentialsSecret(ctx, consumer, consumerConfig)
 	if err != nil {
-		return records, err
+		return nil, err
 	}
 	if rookSecret == nil {
 		return records, nil
@@ -2882,18 +2916,18 @@ func (s *OCSProviderServer) appendRGWAccountCredentialsKubeResources(
 	account.Name = consumerConfig.GetRGWAccountName()
 	account.Namespace = s.namespace
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(account), account); err != nil {
-		return records, fmt.Errorf("failed to get CephObjectStoreAccount %s: %w", account.Name, err)
+		return nil, fmt.Errorf("failed to get CephObjectStoreAccount %s: %w", account.Name, err)
 	}
 
 	rgwRoute := &routev1.Route{}
 	rgwRoute.Name = util.GenerateNameForCephObjectStoreSecureRoute(storageCluster)
 	rgwRoute.Namespace = s.namespace
 	if err := s.client.Get(ctx, client.ObjectKeyFromObject(rgwRoute), rgwRoute); err != nil {
-		return records, fmt.Errorf("failed to get RGW secure Route %s: %w", rgwRoute.Name, err)
+		return nil, fmt.Errorf("failed to get RGW secure Route %s: %w", rgwRoute.Name, err)
 	}
 	host, found := util.GetAdmittedRouteHost(rgwRoute)
 	if !found {
-		return records, fmt.Errorf("RGW secure Route %s has no admitted host", rgwRoute.Name)
+		return nil, fmt.Errorf("RGW secure Route %s has no admitted host", rgwRoute.Name)
 	}
 
 	spokeSecretName := consumerConfig.GetRGWCredentialsSecretName()
@@ -2984,7 +3018,7 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 	classList []T,
 	classDisplayName string,
 	genClassKubeObjFn func(string) (client.Object, error),
-) []kubeObjectWithOpRecord {
+) ([]kubeObjectWithOpRecord, error) {
 	classNameMapping := map[string]string{}
 	for i := len(classList) - 1; i >= 0; i-- {
 		src := classList[i].GetName()
@@ -3005,12 +3039,15 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 		if srcKubeObj = srcClassCache[srcName]; srcKubeObj == nil {
 			var err error
 			srcKubeObj, err = genClassKubeObjFn(srcName)
-			if kerrors.IsNotFound(err) {
+
+			if meta.IsNoMatchError(err) {
+				logger.Info("Resource with the type doesn't exist on the server", "Resource", classDisplayName, "Name", srcName)
+			} else if kerrors.IsNotFound(err) {
 				logger.Info("Resource with name doesn't exist in the cluster", "Resource", classDisplayName, "Name", srcName)
-			} else if errors.Is(err, util.ErrUnsupportedProvisioner) {
-				logger.Info("Encountered unsupported provisioner", "Resource", classDisplayName, "Name", srcName)
 			} else if errors.Is(err, util.ErrUnsupportedDriver) {
-				logger.Info("Encountered unsupported driver", "Resource", classDisplayName, "Name", srcName)
+				logger.Info("Encountered unsupported driver/provisioner", "Resource", classDisplayName, "Name", srcName)
+			} else if err != nil {
+				return nil, err
 			} else if srcKubeObj == nil || reflect.ValueOf(srcKubeObj).IsNil() {
 				logger.Info("Resource name does not points to a builtin or an existing object, skipping", "Resource", classDisplayName, "Name", srcName)
 			} else if srcKubeObj.GetLabels()[util.ExternalClassLabelKey] == "true" {
@@ -3028,7 +3065,7 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 			})
 		}
 	}
-	return records
+	return records, nil
 }
 
 func checkClientPreConditions(consumer *ocsv1alpha1.StorageConsumer, ocsOpVersion string, logger logr.Logger) bool {

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -105,12 +105,15 @@ func TestGetKubeResourcesForClass(t *testing.T) {
 		return srcSc, nil
 	}
 
-	objs := getKubeResourcesForClass(
+	objs, err := getKubeResourcesForClass(
 		klog.Background(),
 		consumer.Spec.StorageClasses,
 		"StorageClass",
 		genClassFn,
 	)
+	if err != nil {
+		t.Fatalf("getKubeResourcesForClass failed: %v", err)
+	}
 
 	// class-a, class-1 and class-2
 	wantObjs := 3


### PR DESCRIPTION
when a custom *Class is removed by user, due to caching that resource is reachable and it's get recreated. we disable cache as all the custom *Classes are only going to be handful and we only do get on them.

error from k8s api is properly surfaced to make the missing classes not to be silently deleted on the client-op end.