### PR TITLE
Clear stale target_size_ratio on existing built-in data pools

### DIFF
--- a/internal/controller/storagecluster/cephblockpools_test.go
+++ b/internal/controller/storagecluster/cephblockpools_test.go
@@ -68,7 +68,10 @@ func assertCephBlockPools(t *testing.T, reconciler *StorageClusterReconciler, cr
 				EnableCrushUpdates: ptr.To(true),
 				FailureDomain:      getFailureDomain(cr),
 				Replicated:         generateCephReplicatedSpec(cr, poolTypeData),
-				EnableRBDStats:     true,
+				Parameters: map[string]string{
+					"target_size_ratio": "0",
+				},
+				EnableRBDStats: true,
 			},
 		},
 	}

--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -1607,6 +1607,12 @@ func setDefaultDataPoolSpec(poolSpec *rookCephv1.PoolSpec, sc *ocsv1.StorageClus
 			poolSpec.Replicated.ReplicasPerFailureDomain = defaultReplicatedSpec.ReplicasPerFailureDomain
 		}
 	}
+	if _, ok := poolSpec.Parameters["target_size_ratio"]; !ok && poolSpec.Replicated.TargetSizeRatio == 0 {
+		if poolSpec.Parameters == nil {
+			poolSpec.Parameters = make(map[string]string)
+		}
+		poolSpec.Parameters["target_size_ratio"] = "0"
+	}
 }
 
 func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string) rookCephv1.ReplicatedSpec {

--- a/internal/controller/storagecluster/cephcluster_test.go
+++ b/internal/controller/storagecluster/cephcluster_test.go
@@ -2623,6 +2623,43 @@ func TestSetDefaultDataPoolSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "target_size_ratio already set",
+			pool: rookCephv1.PoolSpec{
+				Parameters: map[string]string{
+					"target_size_ratio": "0.5",
+				},
+			},
+			sc: baseSC.DeepCopy(),
+			expects: rookCephv1.PoolSpec{
+				EnableCrushUpdates: ptr.To(true),
+				DeviceClass:        "ssd",
+				FailureDomain:      "host",
+				Replicated:         generateCephReplicatedSpec(baseSC, "data"),
+				Parameters: map[string]string{
+					"target_size_ratio": "0.5",
+				},
+			},
+		},
+		{
+			name: "Replicated targetSizeRatio set",
+			pool: rookCephv1.PoolSpec{
+				Replicated: rookCephv1.ReplicatedSpec{
+					TargetSizeRatio: 0.2,
+				},
+			},
+			sc: baseSC.DeepCopy(),
+			expects: rookCephv1.PoolSpec{
+				EnableCrushUpdates: ptr.To(true),
+				DeviceClass:        "ssd",
+				FailureDomain:      "host",
+				Replicated: rookCephv1.ReplicatedSpec{
+					Size:                     generateCephReplicatedSpec(baseSC, "data").Size,
+					ReplicasPerFailureDomain: generateCephReplicatedSpec(baseSC, "data").ReplicasPerFailureDomain,
+					TargetSizeRatio:          0.2,
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -2640,6 +2677,13 @@ func TestSetDefaultDataPoolSpec(t *testing.T) {
 			assert.Equal(t, pool.FailureDomain, c.expects.FailureDomain)
 			assert.DeepEqual(t, pool.Replicated, c.expects.Replicated)
 			assert.DeepEqual(t, pool.ErasureCoded, c.expects.ErasureCoded)
+			if c.expects.Parameters != nil {
+				assert.DeepEqual(t, c.expects.Parameters, pool.Parameters)
+			} else if c.expects.Replicated.TargetSizeRatio != 0 {
+				assert.Equal(t, 0, len(pool.Parameters))
+			} else {
+				assert.DeepEqual(t, map[string]string{"target_size_ratio": "0"}, pool.Parameters)
+			}
 		})
 	}
 }

--- a/internal/controller/storagecluster/cephfilesystem_test.go
+++ b/internal/controller/storagecluster/cephfilesystem_test.go
@@ -99,6 +99,9 @@ func TestCephFileSystemDataPools(t *testing.T) {
 		DeviceClass:        mocksc.Status.DefaultCephDeviceClass,
 		FailureDomain:      getFailureDomain(mocksc),
 		Replicated:         generateCephReplicatedSpec(mocksc, poolTypeData),
+		Parameters: map[string]string{
+			"target_size_ratio": "0",
+		},
 	}
 
 	var cases = []struct {
@@ -222,6 +225,7 @@ func TestCephFileSystemDataPools(t *testing.T) {
 						EnableCrushUpdates: ptr.To(true),
 						Replicated:         defaultPoolSpec.Replicated,
 						FailureDomain:      defaultPoolSpec.FailureDomain,
+						Parameters:         defaultPoolSpec.Parameters,
 					},
 				},
 				{
@@ -231,6 +235,7 @@ func TestCephFileSystemDataPools(t *testing.T) {
 						EnableCrushUpdates: ptr.To(true),
 						Replicated:         defaultPoolSpec.Replicated,
 						FailureDomain:      defaultPoolSpec.FailureDomain,
+						Parameters:         defaultPoolSpec.Parameters,
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- Set `parameters.target_size_ratio` to `"0"` on OCS-managed built-in data pools when neither `Parameters` nor `Replicated.TargetSizeRatio` is already configured
- Clears stale `target_size_ratio` values on upgraded clusters where Rook retains the property after ocs-operator stopped setting it in 4.21
- Preserves explicit user overrides via `Parameters` 

## Context
Since ODF 4.21, ocs-operator no longer sets `target_size_ratio` on newly created built-in data pools ([DFBUGS-2665](https://redhat.atlassian.net/browse/DFBUGS-2665)). That fixes PG autoscaler behavior on fresh installs, but Rook does not remove the property from existing pools when it is omitted from the pool CR. This change explicitly clears it on reconcile for upgraded clusters 
Fixes: [DFBUGS-5871](https://redhat.atlassian.net/browse/DFBUGS-5871)

## Test plan
- [x] `go test ./internal/controller/storagecluster/ -run 'TestSetDefaultDataPoolSpec|TestCephBlockPools|TestCephFileSystemDataPools'`
- [ ] Upgrade a cluster from 4.20 to current and verify built-in data pools have `parameters.target_size_ratio: "0"` in their CRs
- [ ] Confirm `ceph osd pool get <pool> target_size_ratio` returns `0` on upgraded pools after reconcile