### PR TITLE
metrics: update owners and reviewers

### DIFF
--- a/metrics/OWNERS
+++ b/metrics/OWNERS
@@ -1,7 +1,12 @@
 approvers:
-  - weirdwiz
+  - yati1998
+  - Madhu-1
+  - bipuladh
+  - SanjalKatiyar
 reviewers:
-  - weirdwiz
   - aruniiird
   - yati1998
+  - Madhu-1
+  - bipuladh
+  - SanjalKatiyar
 component: ocs-metrics-exporter


### PR DESCRIPTION
this commit updates the owners and reviewers
for ocs-metrics-exporter as the earlier owner
has left