### PR TITLE
Ensure StorageAutoScaler Invalid state clears

### DIFF
--- a/internal/controller/storageautoscaler/storageautoscaler_controller.go
+++ b/internal/controller/storageautoscaler/storageautoscaler_controller.go
@@ -39,13 +39,101 @@ type StorageAutoscalerReconciler struct {
 
 // SetupWithManager sets up the reconciler with the manager
 func (r *StorageAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// get the eventCh from the storage autoscaler scraper
+	generationChanged := builder.WithPredicates(predicate.GenerationChangedPredicate{})
+
+	// Updates enqueue only when spec.resourceProfile changes.
+	resourceProfileChanged := predicate.Funcs{
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSC, oldOk := e.ObjectOld.(*ocsv1.StorageCluster)
+			newSC, newOk := e.ObjectNew.(*ocsv1.StorageCluster)
+			if !oldOk || !newOk {
+				return false
+			}
+			return oldSC.Spec.ResourceProfile != newSC.Spec.ResourceProfile
+		},
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&ocsv1.StorageAutoScaler{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&ocsv1.StorageAutoScaler{}, generationChanged).
+		// Reconcile autoscalers when StorageCluster.spec.resourceProfile
+		// changes (for example lean -> balanced).
+		Watches(
+			&ocsv1.StorageCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.mapStorageClusterToAutoScalers),
+			builder.WithPredicates(resourceProfileChanged),
+		).
+		// Reconcile sibling autoscalers when one is created or deleted so a
+		// previously Invalid CR can recover after a duplicate is removed.
+		Watches(
+			&ocsv1.StorageAutoScaler{},
+			handler.EnqueueRequestsFromMapFunc(r.mapStorageAutoScalerToSiblings),
+			generationChanged,
+		).
+		// get the eventCh from the storage autoscaler scraper
 		// watch for generic events to trigger the reconcile
 		WatchesRawSource(source.Channel(r.EventCh,
 			&handler.EnqueueRequestForObject{},
 		)).Complete(r)
+}
+
+// mapStorageClusterToAutoScalers enqueues StorageAutoScalers that reference the StorageCluster.
+func (r *StorageAutoscalerReconciler) mapStorageClusterToAutoScalers(ctx context.Context, obj client.Object) []reconcile.Request {
+	storageAutoScalerList := &ocsv1.StorageAutoScalerList{}
+	if err := r.List(ctx, storageAutoScalerList, client.InNamespace(obj.GetNamespace())); err != nil {
+		r.Log.Error(err, "failed to list storage autoscalers for storagecluster watch", "storageCluster", obj.GetName())
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for i := range storageAutoScalerList.Items {
+		storageAutoScaler := &storageAutoScalerList.Items[i]
+		if storageAutoScaler.Spec.StorageCluster.Name != obj.GetName() {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      storageAutoScaler.Name,
+				Namespace: storageAutoScaler.Namespace,
+			},
+		})
+	}
+	return requests
+}
+
+// mapStorageAutoScalerToSiblings enqueues other StorageAutoScalers that share the
+// same storage cluster and device class. The object that triggered the event is
+// already enqueued by For(), so it is skipped here.
+func (r *StorageAutoscalerReconciler) mapStorageAutoScalerToSiblings(ctx context.Context, obj client.Object) []reconcile.Request {
+	storageAutoScaler, ok := obj.(*ocsv1.StorageAutoScaler)
+	if !ok {
+		return nil
+	}
+
+	storageAutoScalerList := &ocsv1.StorageAutoScalerList{}
+	if err := r.List(ctx, storageAutoScalerList, client.InNamespace(storageAutoScaler.Namespace)); err != nil {
+		r.Log.Error(err, "failed to list storage autoscalers for sibling watch", "storageAutoScaler", storageAutoScaler.Name)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for i := range storageAutoScalerList.Items {
+		sibling := &storageAutoScalerList.Items[i]
+		if sibling.Name == storageAutoScaler.Name {
+			continue
+		}
+		if sibling.Spec.StorageCluster.Name == storageAutoScaler.Spec.StorageCluster.Name && sibling.Spec.DeviceClass == storageAutoScaler.Spec.DeviceClass {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sibling.Name,
+					Namespace: sibling.Namespace,
+				},
+			})
+		}
+	}
+	return requests
 }
 
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/api,resourceNames=k8s,verbs=get
@@ -264,7 +352,7 @@ func (r *StorageAutoscalerReconciler) detectInvalidState(ctx context.Context, st
 		return true, nil
 	}
 
-	r.Log.Info("storage autoscaler is in invalid state", "namespace", storageAutoScaler.Namespace, "name", storageAutoScaler.Name)
+	r.Log.Info("storage autoscaler is in valid state", "namespace", storageAutoScaler.Namespace, "name", storageAutoScaler.Name)
 	return false, nil
 }
 

--- a/internal/controller/storageautoscaler/storageautoscaler_controller_test.go
+++ b/internal/controller/storageautoscaler/storageautoscaler_controller_test.go
@@ -11,7 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestCalculateExpectedOsdSizeAndCount(t *testing.T) {
@@ -530,4 +533,108 @@ func TestDetectInvalidState(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, invalid)
 	})
+}
+
+func TestRecoverFromInvalidState(t *testing.T) {
+	t.Run("duplicate autoscaler deleted", func(t *testing.T) {
+		storageautoscaler := newTestStorageAutoScaler("autoscaler", "ssd")
+		storageautoscaler2 := newTestStorageAutoScaler("autoscaler2", "ssd")
+		storagecluster := newTestStorageCluster()
+		r := newTestReconciler(t, storageautoscaler, storageautoscaler2, storagecluster)
+
+		invalid, err := r.detectInvalidState(context.TODO(), storageautoscaler2, storagecluster, "namespace")
+		assert.NoError(t, err)
+		assert.True(t, invalid)
+		assert.Equal(t, ocsv1.StorageAutoScalerPhaseInvalid, storageautoscaler2.Status.Phase)
+
+		assert.NoError(t, r.Delete(context.TODO(), storageautoscaler))
+
+		invalid, err = r.detectInvalidState(context.TODO(), storageautoscaler2, storagecluster, "namespace")
+		assert.NoError(t, err)
+		assert.False(t, invalid)
+
+		assertPhaseNotStarted(t, r, storageautoscaler2.Name)
+	})
+
+	t.Run("resource profile changed from lean to balanced", func(t *testing.T) {
+		storageautoscaler := newTestStorageAutoScaler("autoscaler", "ssd")
+		storagecluster := newTestStorageCluster()
+		storagecluster.Spec.ResourceProfile = "lean"
+		r := newTestReconciler(t, storageautoscaler, storagecluster)
+
+		invalid, err := r.detectInvalidState(context.TODO(), storageautoscaler, storagecluster, "namespace")
+		assert.NoError(t, err)
+		assert.True(t, invalid)
+		assert.Equal(t, ocsv1.StorageAutoScalerPhaseInvalid, storageautoscaler.Status.Phase)
+
+		storagecluster.Spec.ResourceProfile = "balanced"
+		assert.NoError(t, r.Update(context.TODO(), storagecluster))
+
+		invalid, err = r.detectInvalidState(context.TODO(), storageautoscaler, storagecluster, "namespace")
+		assert.NoError(t, err)
+		assert.False(t, invalid)
+
+		assertPhaseNotStarted(t, r, storageautoscaler.Name)
+	})
+}
+
+func assertPhaseNotStarted(t *testing.T, r *StorageAutoscalerReconciler, name string) {
+	t.Helper()
+	_, _ = r.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: "namespace"},
+	})
+
+	updated := &ocsv1.StorageAutoScaler{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: "namespace"}, updated))
+	assert.Equal(t, ocsv1.StorageAutoScalerPhaseNotStarted, updated.Status.Phase)
+	assert.Nil(t, updated.Status.Error)
+}
+
+func newTestStorageAutoScaler(name, deviceClass string) *ocsv1.StorageAutoScaler {
+	return &ocsv1.StorageAutoScaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "namespace",
+		},
+		Spec: ocsv1.StorageAutoScalerSpec{
+			DeviceClass: deviceClass,
+			StorageCluster: v1.LocalObjectReference{
+				Name: "storagecluster",
+			},
+		},
+	}
+}
+
+func newTestStorageCluster() *ocsv1.StorageCluster {
+	return &ocsv1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "storagecluster",
+			Namespace: "namespace",
+		},
+		Spec: ocsv1.StorageClusterSpec{},
+	}
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) *StorageAutoscalerReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, ocsv1.AddToScheme(scheme))
+	assert.NoError(t, storagev1.AddToScheme(scheme))
+
+	runtimeObjs := make([]runtime.Object, len(objs))
+	for i, obj := range objs {
+		runtimeObjs[i] = obj
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(runtimeObjs...)
+	for _, obj := range objs {
+		if _, ok := obj.(*ocsv1.StorageAutoScaler); ok {
+			builder = builder.WithStatusSubresource(&ocsv1.StorageAutoScaler{})
+			break
+		}
+	}
+
+	return &StorageAutoscalerReconciler{
+		Client: builder.Build(),
+	}
 }


### PR DESCRIPTION
[DFBUGS-2732](https://redhat.atlassian.net/browse/DFBUGS-2732)
StorageAutoScaler remained in the Invalid phase after the invalidating condition had already been cleared. The Invalid-to-NotStarted transition was already implemented in Reconcile, but Reconcile was not invoked. The controller reconciled a StorageAutoScaler only on a generation change of that object (spec updates), and on scraper-driven events when OSD utilization already exceeded the scaling threshold. It did not observe StorageCluster spec updates (resource profile transition: lean/balanced) or create/delete events on other StorageAutoScaler objects.

Two watches were added:

StorageCluster — if its spec changes (lean → balanced), enqueue every StorageAutoScaler that points at that cluster.

Sibling StorageAutoScalers — if one is created or deleted, enqueue others with the same StorageCluster + device class.

Those events requeue the affected CR. Reconcile runs detectInvalidState again; when it returns false, the existing logic sets phase to NotStarted.